### PR TITLE
Cinnamon Maximus (Fork by Odyseus) (0dyseus@CinnamonMaximusFork) update

### DIFF
--- a/0dyseus@CinnamonMaximusFork/README.md
+++ b/0dyseus@CinnamonMaximusFork/README.md
@@ -27,6 +27,6 @@ This extension is a fork of the [Cinnamon Maximus](https://cinnamon-spices.linux
 
 **Note:** Both commands are already available on Linux Mint. They are installed by the **x11-utils** package.
 
-[Contributors/Mentions](https://github.com/Odyseus/CinnamonTools/blob/master/extensions/0dyseus%40CinnamonMaximusFork/CONTRIBUTORS.md)
-
-[Full change log](https://github.com/Odyseus/CinnamonTools/blob/master/extensions/0dyseus%40CinnamonMaximusFork/CHANGELOG.md)
+#### [Localized help](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@CinnamonMaximusFork.html)
+#### [Contributors/Mentions](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@CinnamonMaximusFork.html#xlet-contributors)
+#### [Full change log](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@CinnamonMaximusFork.html#xlet-changelog)

--- a/0dyseus@CinnamonMaximusFork/files/0dyseus@CinnamonMaximusFork/HELP.html
+++ b/0dyseus@CinnamonMaximusFork/files/0dyseus@CinnamonMaximusFork/HELP.html
@@ -12,6 +12,102 @@ exported toggleLocalizationVisibility
 
 /* jshint varstmt: false */
 
+// Source: https://github.com/julienetie/smooth-scroll
+(function(window, document) {
+    var prefixes = ['moz', 'webkit', 'o'],
+        animationFrame;
+
+    // Modern rAF prefixing without setTimeout
+    function requestAnimationFrameNative() {
+        prefixes.map(function(prefix) {
+            if (!window.requestAnimationFrame) {
+                animationFrame = window[prefix + 'RequestAnimationFrame'];
+            } else {
+                animationFrame = requestAnimationFrame;
+            }
+        });
+    }
+    requestAnimationFrameNative();
+
+    function getOffsetTop(el) {
+        if (!el) {
+            return 0;
+        }
+
+        var yOffset = el.offsetTop,
+            parent = el.offsetParent;
+
+        yOffset += getOffsetTop(parent);
+
+        return yOffset;
+    }
+
+    function getScrollTop(scrollable) {
+        return scrollable.scrollTop || document.body.scrollTop || document.documentElement.scrollTop;
+    }
+
+    function scrollTo(scrollable, coords, millisecondsToTake) {
+        var currentY = getScrollTop(scrollable),
+            diffY = coords.y - currentY,
+            startTimestamp = null;
+
+        if (coords.y === currentY || typeof scrollable.scrollTo !== 'function') {
+            return;
+        }
+
+        function doScroll(currentTimestamp) {
+            if (startTimestamp === null) {
+                startTimestamp = currentTimestamp;
+            }
+
+            var progress = currentTimestamp - startTimestamp,
+                fractionDone = (progress / millisecondsToTake),
+                pointOnSineWave = Math.sin(fractionDone * Math.PI / 2);
+            scrollable.scrollTo(0, currentY + (diffY * pointOnSineWave));
+
+            if (progress < millisecondsToTake) {
+                animationFrame(doScroll);
+            } else {
+                // Ensure we're at our destination
+                scrollable.scrollTo(coords.x, coords.y);
+            }
+        }
+
+        animationFrame(doScroll);
+    }
+
+    // Declaire scroll duration, (before script)
+    var speed = window.smoothScrollSpeed || 750;
+
+    function smoothScroll(e) { // no smooth scroll class to ignore links
+        if (e.target.className === 'no-ss') {
+            return;
+        }
+
+        var source = e.target,
+            targetHref = source.hash,
+            target = null;
+
+        if (!source || !targetHref) {
+            return;
+        }
+
+        targetHref = targetHref.substring(1);
+        target = document.getElementById(targetHref);
+        if (!target) {
+            return;
+        }
+
+        scrollTo(window, {
+            x: 0,
+            y: getOffsetTop(target)
+        }, speed);
+    }
+
+    // Uses target's hash for scroll
+    document.addEventListener('click', smoothScroll, false);
+}(window, document));
+
 if (!window.localStorage) {
     /*
     Storage objects are a recent addition to the standard. As such they may not be present
@@ -449,7 +545,7 @@ body {
 <noscript>
 <div class="alert alert-warning">
 <p><strong>Oh snap! This page needs JavaScript enabled to display correctly.</strong></p>
-<p><strong>This page uses JavaScript only to switch between the available languages.</strong></p>
+<p><strong>This page uses JavaScript only to switch between the available languages and/or display images.</strong></p>
 <p><strong>There are no tracking services of any kind and never will be (at least, not from my side).</strong></p>
 </div> <!-- .alert.alert-warning -->
 </noscript>
@@ -458,9 +554,9 @@ body {
     <div class="container-fluid">
     <div class="navbar-header">
         <ul class="nav navbar-nav">
-            <li><a id="nav-xlet-help" class="navbar-brand" href="#xlet-help"></a></li>
-            <li><a id="nav-xlet-contributors" class="navbar-brand" href="#xlet-contributors"></a></li>
-            <li><a id="nav-xlet-changelog" class="navbar-brand" href="#xlet-changelog"></a></li>
+            <li><a id="nav-xlet-help" class="js_smoothScroll navbar-brand" href="#xlet-help"></a></li>
+            <li><a id="nav-xlet-contributors" class="js_smoothScroll navbar-brand" href="#xlet-contributors"></a></li>
+            <li><a id="nav-xlet-changelog" class="js_smoothScroll navbar-brand" href="#xlet-changelog"></a></li>
         </ul>
     </div>
     <form class="navbar-form navbar-collapse collapse navbar-right">
@@ -477,7 +573,7 @@ body {
     </form>
     </div>
 </nav>
-<span id="xlet-help">
+<span id="xlet-help" style="padding-top:70px;">
 <div class="container boxed">
 
 <div id="da" class="localization-content hidden">
@@ -502,6 +598,7 @@ body {
 <li>Hvis der ikke er nogen oversættelse til denne udvidelse tilgængelig på dit sprog, kan du oprette en ved at følge de efterfølgende instruktioner. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">The following two sections are available only in English.</div>
 </div> <!-- .localization-content -->
 
 
@@ -527,6 +624,7 @@ body {
 <li>如果该xlet没有您的语言的本地化，您可以按照以下说明进行创建。 <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">以下两个部分仅使用英语。</div>
 </div> <!-- .localization-content -->
 
 
@@ -552,6 +650,7 @@ body {
 <li>Si este xlet no está disponible en su idioma, la localización puede ser creada siguiendo las siguientes instrucciones. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Las siguientes dos secciones están disponibles sólo en Inglés.</div>
 </div> <!-- .localization-content -->
 
 
@@ -577,6 +676,7 @@ body {
 <li>Om ditt språk saknas i denna xlet, kan du översätta den med hjälp av följande instruktioner. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Följande två sektioner är endast tillgängliga på Engelska.</div>
 </div> <!-- .localization-content -->
 
 
@@ -602,11 +702,11 @@ body {
 <li>If this xlet has no locale available for your language, you could create it by following the following instructions. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">The following two sections are available only in English.</div>
 </div> <!-- .localization-content -->
 
 </div> <!-- .container.boxed -->
-<div style="font-weight:bold;" class="container alert alert-info">The following two sections are available only in English.</div>
-<span id="xlet-contributors">
+<span id="xlet-contributors" style="padding-top:140px;">
 <div class="container boxed">
 <h2>Contributors/Mentions</h2>
 <ul>
@@ -618,10 +718,26 @@ body {
 
 </div> <!-- .container.boxed -->
 
-<span id="xlet-changelog">
+<span id="xlet-changelog" style="padding-top:70px;">
 <div class="container boxed">
 <h2>Cinnamon Maximus (Fork by Odyseus) changelog</h2>
 <h4>This change log is only valid for the version of the xlet hosted on <a href="https://github.com/Odyseus/CinnamonTools">its original repository</a></h4>
+<hr>
+<ul>
+<li><strong>Date:</strong> Tue, 6 Jun 2017 22:31:44 -0300</li>
+<li><strong>Commit:</strong> <a href="https://github.com/Odyseus/CinnamonTools/commit/e15e0c7">e15e0c7</a></li>
+<li><strong>Author:</strong> Odyseus</li>
+</ul>
+<pre><code>Cinnamon Maximus (Fork by Odyseus) extension
+- Better handling of **Settings.BindingDirection**. Just to avoid surprises when that constant is
+removed on future versions of Cinnamon.
+- Added option to handle invisible windows problem. On the original Maximus extension (by fmete) I
+changed one of the _MOTIF_WM_HINTS flags from 0x2 to 0x0 to avoid having a border at the top of a
+maximized window with its title bar removed. This was working perfectly fine until Cinnamon 3.4. On
+Cinnamon 3.4, setting that flag to 0x0 would result on windows that started maximized and with their
+title bars removed to become invisible. I simply added an option for people using Cinnamon 3.4 or
+greater to change that flag.
+</code></pre>
 <hr>
 <ul>
 <li><strong>Date:</strong> Sun, 4 Jun 2017 19:45:45 +0800</li>
@@ -932,6 +1048,8 @@ hr.po     14
 </div> <!-- .container.boxed -->
 
 </div> <!-- #mainarea -->
-<script type="text/javascript">toggleLocalizationVisibility(null);</script>
+<script type="text/javascript">toggleLocalizationVisibility(null);
+
+</script>
 </body>
 </html>

--- a/0dyseus@CinnamonMaximusFork/files/0dyseus@CinnamonMaximusFork/metadata.json
+++ b/0dyseus@CinnamonMaximusFork/files/0dyseus@CinnamonMaximusFork/metadata.json
@@ -16,7 +16,7 @@
     ],
     "url": "https://github.com/Odyseus/CinnamonTools",
     "uuid": "0dyseus@CinnamonMaximusFork",
-    "version": "0.3.6",
+    "version": "0.3.7",
     "contributors": "See this xlet help file.",
     "name": "Cinnamon Maximus (Fork by Odyseus)"
 }

--- a/0dyseus@CinnamonMaximusFork/files/0dyseus@CinnamonMaximusFork/po/0dyseus@CinnamonMaximusFork.pot
+++ b/0dyseus@CinnamonMaximusFork/files/0dyseus@CinnamonMaximusFork/po/0dyseus@CinnamonMaximusFork.pot
@@ -5,8 +5,8 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 0dyseus@CinnamonMaximusFork 0.3.6\n"
-"POT-Creation-Date: 2017-06-02 17:05-0300\n"
+"Project-Id-Version: 0dyseus@CinnamonMaximusFork 0.3.7\n"
+"POT-Creation-Date: 2017-06-12 22:20-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -15,32 +15,36 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Generated-By: make-xlet-pot.py 1.0.32\n"
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->head1->description
-msgid "Cinnamon Maximus (Fork by Odyseus) Settings"
+#. 0dyseus@CinnamonMaximusFork->metadata.json->name
+msgid "Cinnamon Maximus (Fork by Odyseus)"
 msgstr ""
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_whitelist->tooltip
-msgid ""
-"If enabled, only the applications specified bellow will have their titlebar removed when maximized.\n"
-"If disabled, all maximized windows will have their titlebar removed."
+#. 0dyseus@CinnamonMaximusFork->metadata.json->contributors
+msgid "See this xlet help file."
 msgstr ""
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_whitelist->description
-msgid "Use Whitelist"
+#. 0dyseus@CinnamonMaximusFork->metadata.json->description
+msgid "Remove windows decorations from maximized windows."
 msgstr ""
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->head2->description
-msgid "Troubleshooting"
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_undecorate_when_tiled->description
+msgid "Undecorate when tiled"
 msgstr ""
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_whitelisted_apps->description
-msgid "List of applications: "
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_undecorate_all->description
+msgid "Undecorate All Windows (Experimental, please close and re-open all windows)"
 msgstr ""
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_whitelisted_apps->tooltip
-msgid ""
-"\"Use Whitelist\" option must be checked.\n"
-"Use a \",\" (comma) to seperate applications."
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_logging_enabled->description
+msgid "Enable logging"
+msgstr ""
+
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_logging_enabled->tooltip
+msgid "If enabled, it will log to the Cinnamon log (~/.cinnamon/glass.log) information that could be used to debug the extension."
+msgstr ""
+
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_restart_cinnamon->description
+msgid "Check or uncheck to restart Cinnamon"
 msgstr ""
 
 #. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_restart_cinnamon->tooltip
@@ -49,96 +53,100 @@ msgid ""
 "Note: I couldn't make a proper button to work in this settings window, so I had to improvise and I had to use a checkbox. It doesn't really matter if it's checked or unchecked."
 msgstr ""
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_restart_cinnamon->description
-msgid "Check or uncheck to restart Cinnamon"
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_whitelisted_apps->tooltip
+msgid ""
+"\"Use Whitelist\" option must be checked.\n"
+"Use a \",\" (comma) to seperate applications."
 msgstr ""
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_logging_enabled->tooltip
-msgid "If enabled, it will log to the Cinnamon log (~/.cinnamon/glass.log) information that could be used to debug the extension."
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_whitelisted_apps->description
+msgid "List of applications: "
 msgstr ""
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_logging_enabled->description
-msgid "Enable logging"
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->head2->description
+msgid "Troubleshooting"
 msgstr ""
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_undecorate_all->description
-msgid "Undecorate All Windows (Experimental, please close and re-open all windows)"
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_whitelist->description
+msgid "Use Whitelist"
 msgstr ""
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_undecorate_when_tiled->description
-msgid "Undecorate when tiled"
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_whitelist->tooltip
+msgid ""
+"If enabled, only the applications specified bellow will have their titlebar removed when maximized.\n"
+"If disabled, all maximized windows will have their titlebar removed."
 msgstr ""
 
-#. 0dyseus@CinnamonMaximusFork->metadata.json->description
-msgid "Remove windows decorations from maximized windows."
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->head1->description
+msgid "Cinnamon Maximus (Fork by Odyseus) Settings"
 msgstr ""
 
-#. 0dyseus@CinnamonMaximusFork->metadata.json->contributors
-msgid "See this xlet help file."
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_invisible_windows_hack->description
+msgid "Enable hack for invisible windows"
 msgstr ""
 
-#. 0dyseus@CinnamonMaximusFork->metadata.json->name
-msgid "Cinnamon Maximus (Fork by Odyseus)"
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_invisible_windows_hack->tooltip
+msgid "On Cinnamon 3.4 or greater, the windows of the applications configured so that their decorations are removed when maximized, may become invisible. Enabling this option might prevent that, but it might also add a border of about 1 pixel in place of the title bar (it might depend on the metacity theme (Window borders) used)."
 msgstr ""
 
-#: ../../create_localized_help.py:90
+#: ../../create_localized_help.py:90 ../../create_localized_help.py:96 ../../create_localized_help.py:125
 msgid "The following two sections are available only in English."
 msgstr ""
 
 #. TO TRANSLATORS: This is a placeholder.
 #. Here goes your language name in your own language (a.k.a. endonym).
-#: ../../create_localized_help.py:115 ../../create_localized_help.py:187
+#: ../../create_localized_help.py:115 ../../create_localized_help.py:119 ../../create_localized_help.py:121 ../../create_localized_help.py:187 ../../create_localized_help.py:194 ../../create_localized_help.py:195
 msgid "language-name"
 msgstr ""
 
-#: ../../create_localized_help.py:190
+#: ../../create_localized_help.py:190 ../../create_localized_help.py:197 ../../create_localized_help.py:198
 msgid "Help"
 msgstr ""
 
-#: ../../create_localized_help.py:191
+#: ../../create_localized_help.py:191 ../../create_localized_help.py:198 ../../create_localized_help.py:199
 msgid "Contributors"
 msgstr ""
 
-#: ../../create_localized_help.py:192
+#: ../../create_localized_help.py:192 ../../create_localized_help.py:199 ../../create_localized_help.py:200
 msgid "Changelog"
 msgstr ""
 
-#: ../../create_localized_help.py:193
+#: ../../create_localized_help.py:193 ../../create_localized_help.py:200 ../../create_localized_help.py:201
 msgid "Choose language"
 msgstr ""
 
 #. TO TRANSLATORS: Full sentence:
 #. "Help for <xlet_name>"
-#: ../../create_localized_help.py:194 ../../create_localized_help.py:201
+#: ../../create_localized_help.py:194 ../../create_localized_help.py:201 ../../create_localized_help.py:202 ../../create_localized_help.py:208 ../../create_localized_help.py:209
 #, python-format
 msgid "Help for %s"
 msgstr ""
 
-#: ../../create_localized_help.py:202
+#: ../../create_localized_help.py:202 ../../create_localized_help.py:209 ../../create_localized_help.py:210
 msgid "IMPORTANT!!!"
 msgstr ""
 
-#: ../../create_localized_help.py:203
+#: ../../create_localized_help.py:203 ../../create_localized_help.py:210 ../../create_localized_help.py:211
 msgid "Never delete any of the files found inside this xlet folder. It might break this xlet functionality."
 msgstr ""
 
-#: ../../create_localized_help.py:204
+#: ../../create_localized_help.py:204 ../../create_localized_help.py:211 ../../create_localized_help.py:212
 msgid "Bug reports, feature requests and contributions should be done on this xlet's repository linked next."
 msgstr ""
 
-#: ../../create_localized_help.py:210
+#: ../../create_localized_help.py:210 ../../create_localized_help.py:217 ../../create_localized_help.py:218
 msgid "Applets/Desklets/Extensions (a.k.a. xlets) localization"
 msgstr ""
 
-#: ../../create_localized_help.py:211
+#: ../../create_localized_help.py:211 ../../create_localized_help.py:218 ../../create_localized_help.py:219
 msgid "If this xlet was installed from Cinnamon Settings, all of this xlet's localizations were automatically installed."
 msgstr ""
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:213
+#: ../../create_localized_help.py:213 ../../create_localized_help.py:220 ../../create_localized_help.py:221
 msgid "If this xlet was installed manually and not trough Cinnamon Settings, localizations can be installed by executing the script called **localizations.sh** from a terminal opened inside the xlet's folder."
 msgstr ""
 
-#: ../../create_localized_help.py:214
+#: ../../create_localized_help.py:214 ../../create_localized_help.py:221 ../../create_localized_help.py:222
 msgid "If this xlet has no locale available for your language, you could create it by following the following instructions."
 msgstr ""

--- a/0dyseus@CinnamonMaximusFork/files/0dyseus@CinnamonMaximusFork/po/es.po
+++ b/0dyseus@CinnamonMaximusFork/files/0dyseus@CinnamonMaximusFork/po/es.po
@@ -7,8 +7,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: 0.3.4\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-02 17:08-0300\n"
-"PO-Revision-Date: 2017-06-02 17:08-0300\n"
+"POT-Creation-Date: 2017-06-06 22:14-0300\n"
+"PO-Revision-Date: 2017-06-06 22:14-0300\n"
 "Last-Translator: Odyseus\n"
 "Language-Team: \n"
 "Language: es\n"
@@ -18,40 +18,45 @@ msgstr ""
 "X-Generator: Poedit 1.8.7.1\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->head1->description
-msgid "Cinnamon Maximus (Fork by Odyseus) Settings"
-msgstr "Opciones de Cinnamon Maximus (Fork by Odyseus)"
+#. 0dyseus@CinnamonMaximusFork->metadata.json->name
+msgid "Cinnamon Maximus (Fork by Odyseus)"
+msgstr "Cinnamon Maximus (Fork by Odyseus)"
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_whitelist->tooltip
+#. 0dyseus@CinnamonMaximusFork->metadata.json->contributors
+msgid "See this xlet help file."
+msgstr "Ver el archivo de ayuda de este xlet."
+
+#. 0dyseus@CinnamonMaximusFork->metadata.json->description
+msgid "Remove windows decorations from maximized windows."
+msgstr "Eliminar decoraciones de ventanas maximizadas."
+
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_undecorate_when_tiled->description
+msgid "Undecorate when tiled"
+msgstr "Eliminar decoraciones de ventanas ancladas."
+
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_undecorate_all->description
 msgid ""
-"If enabled, only the applications specified bellow will have their titlebar "
-"removed when maximized.\n"
-"If disabled, all maximized windows will have their titlebar removed."
+"Undecorate All Windows (Experimental, please close and re-open all windows)"
 msgstr ""
-"Con esta opción activada, sólo las aplicaciones especificadas en el cuadro "
-"de abajo tendrán sus decoraciones eliminadas al estar maximizadas.\n"
-"Si está desactivada, todas las ventanas maximizadas tendrán sus decoraciones "
-"eliminadas."
+"Remover decoraciones de todas las ventanas (Experimental. Por favor, cerrar "
+"y re-abrir todas las ventanas)"
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_whitelist->description
-msgid "Use Whitelist"
-msgstr "Usar lista blanca"
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_logging_enabled->description
+msgid "Enable logging"
+msgstr "Habilitar el registro de sucesos"
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->head2->description
-msgid "Troubleshooting"
-msgstr "Solución de problemas"
-
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_whitelisted_apps->description
-msgid "List of applications: "
-msgstr "Lista de aplicaciones: "
-
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_whitelisted_apps->tooltip
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_logging_enabled->tooltip
 msgid ""
-"\"Use Whitelist\" option must be checked.\n"
-"Use a \",\" (comma) to seperate applications."
+"If enabled, it will log to the Cinnamon log (~/.cinnamon/glass.log) "
+"information that could be used to debug the extension."
 msgstr ""
-"La opción \"Usar lista blanca\" debe estar activada.\n"
-"Usar una \",\" (coma) para separar aplicaciones."
+"Con esta opción activada, se registrará en el registro de Cinnamon (~/."
+"cinnamon/glass.log) información que se podría utilizar para depurar la "
+"extensión."
+
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_restart_cinnamon->description
+msgid "Check or uncheck to restart Cinnamon"
+msgstr "Activar o desactivar para reiniciar Cinnamon"
 
 #. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_restart_cinnamon->tooltip
 msgid ""
@@ -65,45 +70,40 @@ msgstr ""
 "que tuve que improvisar y tuve que utilizar una casilla de verificación. "
 "Realmente no importa si está activada o desactivada."
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_restart_cinnamon->description
-msgid "Check or uncheck to restart Cinnamon"
-msgstr "Activar o desactivar para reiniciar Cinnamon"
-
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_logging_enabled->tooltip
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_whitelisted_apps->tooltip
 msgid ""
-"If enabled, it will log to the Cinnamon log (~/.cinnamon/glass.log) "
-"information that could be used to debug the extension."
+"\"Use Whitelist\" option must be checked.\n"
+"Use a \",\" (comma) to seperate applications."
 msgstr ""
-"Con esta opción activada, se registrará en el registro de Cinnamon (~/."
-"cinnamon/glass.log) información que se podría utilizar para depurar la "
-"extensión."
+"La opción \"Usar lista blanca\" debe estar activada.\n"
+"Usar una \",\" (coma) para separar aplicaciones."
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_logging_enabled->description
-msgid "Enable logging"
-msgstr "Habilitar el registro de sucesos"
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_whitelisted_apps->description
+msgid "List of applications: "
+msgstr "Lista de aplicaciones: "
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_undecorate_all->description
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->head2->description
+msgid "Troubleshooting"
+msgstr "Solución de problemas"
+
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_whitelist->description
+msgid "Use Whitelist"
+msgstr "Usar lista blanca"
+
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_whitelist->tooltip
 msgid ""
-"Undecorate All Windows (Experimental, please close and re-open all windows)"
+"If enabled, only the applications specified bellow will have their titlebar "
+"removed when maximized.\n"
+"If disabled, all maximized windows will have their titlebar removed."
 msgstr ""
-"Remover decoraciones de todas las ventanas (Experimental. Por favor, cerrar "
-"y re-abrir todas las ventanas)"
+"Con esta opción activada, sólo las aplicaciones especificadas en el cuadro "
+"de abajo tendrán sus decoraciones eliminadas al estar maximizadas.\n"
+"Si está desactivada, todas las ventanas maximizadas tendrán sus decoraciones "
+"eliminadas."
 
-#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_undecorate_when_tiled->description
-msgid "Undecorate when tiled"
-msgstr "Eliminar decoraciones de ventanas ancladas."
-
-#. 0dyseus@CinnamonMaximusFork->metadata.json->description
-msgid "Remove windows decorations from maximized windows."
-msgstr "Eliminar decoraciones de ventanas maximizadas."
-
-#. 0dyseus@CinnamonMaximusFork->metadata.json->contributors
-msgid "See this xlet help file."
-msgstr "Ver el archivo de ayuda de este xlet."
-
-#. 0dyseus@CinnamonMaximusFork->metadata.json->name
-msgid "Cinnamon Maximus (Fork by Odyseus)"
-msgstr "Cinnamon Maximus (Fork by Odyseus)"
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->head1->description
+msgid "Cinnamon Maximus (Fork by Odyseus) Settings"
+msgstr "Opciones de Cinnamon Maximus (Fork by Odyseus)"
 
 #: ../../create_localized_help.py:90
 msgid "The following two sections are available only in English."
@@ -190,6 +190,25 @@ msgid ""
 msgstr ""
 "Si este xlet no está disponible en su idioma, la localización puede ser "
 "creada siguiendo las siguientes instrucciones."
+
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_invisible_windows_hack->description
+msgid "Enable hack for invisible windows"
+msgstr "Habilitar hack para ventanas invisibles"
+
+#. 0dyseus@CinnamonMaximusFork->settings-schema.json->pref_invisible_windows_hack->tooltip
+msgid ""
+"On Cinnamon 3.4 or greater, the windows of the applications configured so "
+"that their decorations are removed when maximized, may become invisible. "
+"Enabling this option might prevent that, but it might also add a border of "
+"about 1 pixel in place of the title bar (it might depend on the metacity "
+"theme (Window borders) used)."
+msgstr ""
+"En Cinnamon 3.4 o superior, las ventanas de las aplicaciones configuradas "
+"para que sus decoraciones sean removidas al ser maximizadas, puede que se "
+"vuelvan invisibles. La habilitación de esta opción puede evitarlo, pero "
+"también puede agregar un borde de aproximadamente 1 píxel en lugar de la "
+"barra de título (puede depender del tema de metacity (bordes de ventana) "
+"utilizado)."
 
 #~ msgid "Read CONTRIBUTORS.md file inside this xlet folder."
 #~ msgstr "Leer el archivo CONTRIBUTORS.md dentro de la carpeta de este xlet."

--- a/0dyseus@CinnamonMaximusFork/files/0dyseus@CinnamonMaximusFork/settings-schema.json
+++ b/0dyseus@CinnamonMaximusFork/files/0dyseus@CinnamonMaximusFork/settings-schema.json
@@ -1,46 +1,52 @@
 {
-	"head1": {
-		"type": "header",
-		"description": "Cinnamon Maximus (Fork by Odyseus) Settings"
-	},
-	"pref_undecorate_when_tiled": {
-		"type": "checkbox",
-		"default": false,
-		"description": "Undecorate when tiled"
-	},
-	"pref_undecorate_all": {
-		"type": "checkbox",
-		"default": false,
-		"description": "Undecorate All Windows (Experimental, please close and re-open all windows)"
-	},
-	"pref_whitelist": {
-		"type": "checkbox",
-		"default": false,
-		"description": "Use Whitelist",
-		"tooltip": "If enabled, only the applications specified bellow will have their titlebar removed when maximized.\nIf disabled, all maximized windows will have their titlebar removed."
-	},
-	"pref_whitelisted_apps": {
-		"type": "entry",
-		"indent": true,
-		"description": "List of applications: ",
-		"dependency": "pref_whitelist",
-		"tooltip": "\"Use Whitelist\" option must be checked.\nUse a \",\" (comma) to seperate applications.",
-		"default": "chromium,firefox"
-	},
-	"head2": {
-		"type": "header",
-		"description": "Troubleshooting"
-	},
-	"pref_logging_enabled": {
-		"type": "checkbox",
-		"default": false,
-		"description": "Enable logging",
-		"tooltip": "If enabled, it will log to the Cinnamon log (~/.cinnamon/glass.log) information that could be used to debug the extension."
-	},
-	"pref_restart_cinnamon": {
-		"type": "checkbox",
-		"default": false,
-		"description": "Check or uncheck to restart Cinnamon",
-		"tooltip": "Check or uncheck this options to restart Cinnamon.\nNote: I couldn't make a proper button to work in this settings window, so I had to improvise and I had to use a checkbox. It doesn't really matter if it's checked or unchecked."
-	}
+    "head1": {
+        "type": "header",
+        "description": "Cinnamon Maximus (Fork by Odyseus) Settings"
+    },
+    "pref_undecorate_when_tiled": {
+        "type": "checkbox",
+        "default": false,
+        "description": "Undecorate when tiled"
+    },
+    "pref_undecorate_all": {
+        "type": "checkbox",
+        "default": false,
+        "description": "Undecorate All Windows (Experimental, please close and re-open all windows)"
+    },
+    "pref_whitelist": {
+        "type": "checkbox",
+        "default": false,
+        "description": "Use Whitelist",
+        "tooltip": "If enabled, only the applications specified bellow will have their titlebar removed when maximized.\nIf disabled, all maximized windows will have their titlebar removed."
+    },
+    "pref_whitelisted_apps": {
+        "type": "entry",
+        "indent": true,
+        "description": "List of applications: ",
+        "dependency": "pref_whitelist",
+        "tooltip": "\"Use Whitelist\" option must be checked.\nUse a \",\" (comma) to seperate applications.",
+        "default": "chromium,firefox"
+    },
+    "head2": {
+        "type": "header",
+        "description": "Troubleshooting"
+    },
+    "pref_logging_enabled": {
+        "type": "checkbox",
+        "default": false,
+        "description": "Enable logging",
+        "tooltip": "If enabled, it will log to the Cinnamon log (~/.cinnamon/glass.log) information that could be used to debug the extension."
+    },
+    "pref_invisible_windows_hack": {
+        "type": "checkbox",
+        "default": false,
+        "description": "Enable hack for invisible windows",
+        "tooltip": "On Cinnamon 3.4 or greater, the windows of the applications configured so that their decorations are removed when maximized, may become invisible. Enabling this option might prevent that, but it might also add a border of about 1 pixel in place of the title bar (it might depend on the metacity theme (Window borders) used)."
+    },
+    "pref_restart_cinnamon": {
+        "type": "checkbox",
+        "default": false,
+        "description": "Check or uncheck to restart Cinnamon",
+        "tooltip": "Check or uncheck this options to restart Cinnamon.\nNote: I couldn't make a proper button to work in this settings window, so I had to improvise and I had to use a checkbox. It doesn't really matter if it's checked or unchecked."
+    }
 }


### PR DESCRIPTION
- Better handling of **Settings.BindingDirection**. Just to avoid surprises when that constant is removed on future versions of Cinnamon.
- Added option to handle invisible windows problem. On the original Maximus extension (by fmete) I changed one of the _MOTIF_WM_HINTS flags from 0x2 to 0x0 to avoid having a border at the top of a maximized window with its title bar removed. This was working perfectly fine until Cinnamon 3.4. On Cinnamon 3.4, setting that flag to 0x0 would result on windows that started maximized and with their title bars removed to become invisible. I simply added an option for people using Cinnamon 3.4 or greater to change that flag.
- Redesigned the creation of the help file to be "on-line friendly".
- Finally fixed the annoyance of having titles on the help files hidden behind the top navigation bar when clicking the navigation links (Help/Contributors/Changelog).
- Fixed the display of a translated sentence on the help files that was being displayed untranslated.
- Added smooth scrolling for the links on the navigation bar of the help files.
- Updated localization template, localizations and help file due to changes to the *help file creator* script.
- Added to the xlet README file links to the localized help file.