### PR TITLE
Multi Translator (0dyseus@MultiTranslatorExtension) update

### DIFF
--- a/0dyseus@MultiTranslatorExtension/README.md
+++ b/0dyseus@MultiTranslatorExtension/README.md
@@ -46,6 +46,6 @@ Once installed and enabled, the following shortcuts will be available.
 
 ![MultiTranslatorExtension-options](https://odyseus.github.io/CinnamonTools/lib/img/MultiTranslatorExtension-options.gif)
 
-[Contributors/Mentions](https://github.com/Odyseus/CinnamonTools/blob/master/extensions/0dyseus%40MultiTranslatorExtension/CONTRIBUTORS.md)
-
-[Full change log](https://github.com/Odyseus/CinnamonTools/blob/master/extensions/0dyseus%40MultiTranslatorExtension/CHANGELOG.md)
+#### [Localized help](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@MultiTranslatorExtension.html)
+#### [Contributors/Mentions](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@MultiTranslatorExtension.html#xlet-contributors)
+#### [Full change log](https://odyseus.github.io/CinnamonTools/help_files/0dyseus@MultiTranslatorExtension.html#xlet-changelog)

--- a/0dyseus@MultiTranslatorExtension/files/0dyseus@MultiTranslatorExtension/HELP.html
+++ b/0dyseus@MultiTranslatorExtension/files/0dyseus@MultiTranslatorExtension/HELP.html
@@ -12,6 +12,102 @@ exported toggleLocalizationVisibility
 
 /* jshint varstmt: false */
 
+// Source: https://github.com/julienetie/smooth-scroll
+(function(window, document) {
+    var prefixes = ['moz', 'webkit', 'o'],
+        animationFrame;
+
+    // Modern rAF prefixing without setTimeout
+    function requestAnimationFrameNative() {
+        prefixes.map(function(prefix) {
+            if (!window.requestAnimationFrame) {
+                animationFrame = window[prefix + 'RequestAnimationFrame'];
+            } else {
+                animationFrame = requestAnimationFrame;
+            }
+        });
+    }
+    requestAnimationFrameNative();
+
+    function getOffsetTop(el) {
+        if (!el) {
+            return 0;
+        }
+
+        var yOffset = el.offsetTop,
+            parent = el.offsetParent;
+
+        yOffset += getOffsetTop(parent);
+
+        return yOffset;
+    }
+
+    function getScrollTop(scrollable) {
+        return scrollable.scrollTop || document.body.scrollTop || document.documentElement.scrollTop;
+    }
+
+    function scrollTo(scrollable, coords, millisecondsToTake) {
+        var currentY = getScrollTop(scrollable),
+            diffY = coords.y - currentY,
+            startTimestamp = null;
+
+        if (coords.y === currentY || typeof scrollable.scrollTo !== 'function') {
+            return;
+        }
+
+        function doScroll(currentTimestamp) {
+            if (startTimestamp === null) {
+                startTimestamp = currentTimestamp;
+            }
+
+            var progress = currentTimestamp - startTimestamp,
+                fractionDone = (progress / millisecondsToTake),
+                pointOnSineWave = Math.sin(fractionDone * Math.PI / 2);
+            scrollable.scrollTo(0, currentY + (diffY * pointOnSineWave));
+
+            if (progress < millisecondsToTake) {
+                animationFrame(doScroll);
+            } else {
+                // Ensure we're at our destination
+                scrollable.scrollTo(coords.x, coords.y);
+            }
+        }
+
+        animationFrame(doScroll);
+    }
+
+    // Declaire scroll duration, (before script)
+    var speed = window.smoothScrollSpeed || 750;
+
+    function smoothScroll(e) { // no smooth scroll class to ignore links
+        if (e.target.className === 'no-ss') {
+            return;
+        }
+
+        var source = e.target,
+            targetHref = source.hash,
+            target = null;
+
+        if (!source || !targetHref) {
+            return;
+        }
+
+        targetHref = targetHref.substring(1);
+        target = document.getElementById(targetHref);
+        if (!target) {
+            return;
+        }
+
+        scrollTo(window, {
+            x: 0,
+            y: getOffsetTop(target)
+        }, speed);
+    }
+
+    // Uses target's hash for scroll
+    document.addEventListener('click', smoothScroll, false);
+}(window, document));
+
 if (!window.localStorage) {
     /*
     Storage objects are a recent addition to the standard. As such they may not be present
@@ -449,7 +545,7 @@ body {
 <noscript>
 <div class="alert alert-warning">
 <p><strong>Oh snap! This page needs JavaScript enabled to display correctly.</strong></p>
-<p><strong>This page uses JavaScript only to switch between the available languages.</strong></p>
+<p><strong>This page uses JavaScript only to switch between the available languages and/or display images.</strong></p>
 <p><strong>There are no tracking services of any kind and never will be (at least, not from my side).</strong></p>
 </div> <!-- .alert.alert-warning -->
 </noscript>
@@ -458,16 +554,18 @@ body {
     <div class="container-fluid">
     <div class="navbar-header">
         <ul class="nav navbar-nav">
-            <li><a id="nav-xlet-help" class="navbar-brand" href="#xlet-help"></a></li>
-            <li><a id="nav-xlet-contributors" class="navbar-brand" href="#xlet-contributors"></a></li>
-            <li><a id="nav-xlet-changelog" class="navbar-brand" href="#xlet-changelog"></a></li>
+            <li><a id="nav-xlet-help" class="js_smoothScroll navbar-brand" href="#xlet-help"></a></li>
+            <li><a id="nav-xlet-contributors" class="js_smoothScroll navbar-brand" href="#xlet-contributors"></a></li>
+            <li><a id="nav-xlet-changelog" class="js_smoothScroll navbar-brand" href="#xlet-changelog"></a></li>
         </ul>
     </div>
     <form class="navbar-form navbar-collapse collapse navbar-right">
         <div class="form-group">
             <label id="localization-chooser-label" class="control-label" for="localization-switch"></label>
             <select class="form-control input-sm" id="localization-switch" onchange="self.toggleLocalizationVisibility(value, this);">
-                <!-- English --><option selected data-title="Help for Multi Translator" data-language-chooser-label="Choose language" data-xlet-help="Help" data-xlet-contributors="Contributors" data-xlet-changelog="Changelog" value="en">English</option>
+                <!-- Česky --><option data-title="Nápověda pro Multi Translator" data-language-chooser-label="Zvolte jazyk" data-xlet-help="Nápověda" data-xlet-contributors="Přispěvatelé" data-xlet-changelog="Changelog" value="cs">Česky</option>
+<!-- Dansk --><option data-title="Hjælp til Multi Translator" data-language-chooser-label="Vælg sprog" data-xlet-help="Hjælp" data-xlet-contributors="Bidragydere" data-xlet-changelog="Ændringslog" value="da">Dansk</option>
+<!-- English --><option selected data-title="Help for Multi Translator" data-language-chooser-label="Choose language" data-xlet-help="Help" data-xlet-contributors="Contributors" data-xlet-changelog="Changelog" value="en">English</option>
 <!-- Español --><option data-title="Ayuda para Multi Translator" data-language-chooser-label="Elegir idioma" data-xlet-help="Ayuda" data-xlet-contributors="Colaboradores" data-xlet-changelog="Registro de cambios" value="es">Español</option>
 <!-- Svenska --><option data-title="Hjälp för Multi Translator" data-language-chooser-label="Välj språk" data-xlet-help="Hjälp" data-xlet-contributors="Medhjälpare" data-xlet-changelog="Ändringslogg" value="sv">Svenska</option>
 <!-- 简体中文 --><option data-title="Multi Translator的帮助" data-language-chooser-label="选择语言" data-xlet-help="帮助" data-xlet-contributors="贡献者" data-xlet-changelog="变更日志" value="zh_CN">简体中文</option>
@@ -476,8 +574,90 @@ body {
     </form>
     </div>
 </nav>
-<span id="xlet-help">
+<span id="xlet-help" style="padding-top:70px;">
 <div class="container boxed">
+
+<div id="da" class="localization-content hidden">
+
+<h1>Hjælp til Multi Translator</h1>
+
+<div style="font-weight:bold;" class="alert alert-warning">
+<h2>VIGTIGT!!!</h2>
+
+<p>Slet aldrig nogen af filerne i denne udvidelses mappe. Det kan ødelægge udvidelsens funktionalitet.</p>
+
+<p>Fejlrapporter, forslag til nye funktioner og bidrag bør ske i denne udvidelses arkiv, som der er linket til efterfølgende. <a href="https://github.com/Odyseus/CinnamonTools">GitHub</a></p>
+
+</div>
+<hr>
+
+<h2>Afhængigheder</h2>
+<p><strong>Hvis en eller flere af disse afhængigheder mangler i dit system, kan du ikke bruge denne udvidelse.</strong></p>
+<ul>
+<li>Kommandoen xsel: XSel er et kommandolinjeprogram til at hente og indstille indholdet af X-markeringen.</li>
+<li>Kommandoen trans: Kommando i pakken translate-shell. Det er en simpel kommandolinjegrænseflade til adskillige udbydere af oversættelser (Google Translate, Yandex Translate, Bing Translate og Apertium), som lader dig oversætte strenge i din terminal.<ul>
+<li>Tjek translate-shell <a href="https://github.com/soimort/translate-shell#dependencies">afhængigheder</a> og <a href="https://github.com/soimort/translate-shell#recommended-dependencies">anbefalede afhængigheder</a>.</li>
+</ul>
+</li>
+</ul>
+<p><strong>Bemærk:</strong> I Ubuntu 16.04.x's/Linux Mint 18.x's arkiver er pakken translate-shell forældet og i stykker. Pakken kan alligevel installeres og afhængighederne vil også blive installeret. Men der bør opdateres til nyeste version som beskrevet nedenfor.</p>
+<h2>Sådan installeres nyeste version af translate-shell</h2>
+<h3>Mulighed 1. Direkte download</h3>
+<p>Denne metode vil kun installere trans-skriptet i de angivne placeringer.</p>
+<p>Kun for den aktuelle bruger. <strong>~/.local/bin</strong> skal være i din PATH.</p>
+<pre><code class="lang-shell">$ wget -O ~/.local/bin/trans git.io/trans &amp;&amp; chmod ugo+rx ~/.local/bin/trans
+</code></pre>
+<p>For alle brugere uden at overskrive den installerede version.</p>
+<pre><code class="lang-shell">$ sudo wget -O /usr/local/bin/trans git.io/trans &amp;&amp; sudo chmod ugo+rx /usr/local/bin/trans
+</code></pre>
+<h3>Mulighed 2. Fra Git <a href="https://github.com/soimort/translate-shell/blob/develop/README.md#option-3-from-git-recommended-for-seasoned-hackers">Flere detaljer</a></h3>
+<p>Denne metode vil ikke kun installere trans-skriptet, men også man-siderne. Se linket ovenfor for flere detaljer om installation.</p>
+<pre><code class="lang-shell">$ git clone https://github.com/soimort/translate-shell
+$ cd translate-shell
+$ make
+$ sudo make install
+</code></pre>
+<hr>
+<h2>Brug af udvidelsen</h2>
+<p>Når installeret og aktiveret vil følgende genveje være tilgængelige.</p>
+<h3>Globale genveje (kan konfigureres fra udvidelsens indstillinger)</h3>
+<ul>
+<li><strong><kbd>Super</kbd> + <kbd>T</kbd>:</strong> Åbn oversættelsesvinduet.</li>
+<li><strong><kbd>Super</kbd> + <kbd>Shift</kbd> + <kbd>T</kbd>:</strong> Åbn oversættelsesvinduet og oversæt teksten i udklipsholderen.</li>
+<li><strong><kbd>Super</kbd> + <kbd>Alt</kbd> + <kbd>T</kbd>:</strong> Åbn oversættelsesvinduet og oversæt indholdet i den primære markering.</li>
+</ul>
+<h3>Genveje tilgængelige i oversættelsesvinduet</h3>
+<ul>
+<li><strong><kbd>Ctrl</kbd> + <kbd>Enter</kbd>:</strong> Oversæt tekst.</li>
+<li><strong><kbd>Shift</kbd> + <kbd>Enter</kbd>:</strong> Gennemtving oversættelse af tekst. Ignorerer oversættelseshistorik.</li>
+<li><strong><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>:</strong> Kopiér oversat tekst til udklipsholderen.</li>
+<li><strong><kbd>Ctrl</kbd> + <kbd>S</kbd>:</strong> Ombyt sprog.</li>
+<li><strong><kbd>Ctrl</kbd> + <kbd>D</kbd>:</strong> Nulstil sprog til standard.</li>
+<li><strong><kbd>Escape</kbd>:</strong> Luk vindue.</li>
+</ul>
+<hr>
+<h2>Udvidelsens indstillingsvindue</h2>
+<p>Fra udvidelsens indstillingsvindue kan alle indstillinger importeres, eksporteres eller nulstilles til standardværdierne.</p>
+<ul>
+<li>For at kunne udføre disse handlinger skal indstillingsskemaet installeres i systemet. Dette sker automatisk, hvis udvidelsen installeres gennem Cinnamons modul til håndtering af udvidelser. Blev udvidelsen installeret manuelt, skal indstillingsskemaet også installeres manuelt. Dette gøres ved at gå til udvidelsens mappe og køre følgende kommando:<ul>
+<li>Kommando til at installere indstillingsskemaet: <code>./settings.py install-schema</code></li>
+<li>Kommando til at afinstallere indstillingsskemaet: <code>./settings.py remove-schema</code></li>
+</ul>
+</li>
+<li>For at importere/eksportere indstillinger skal kommandoen <strong>dconf</strong> findes i systemet.</li>
+</ul>
+<hr>
+
+<h2>Oversættelser af panelprogrammer, skrivebordsprogrammer og udvidelser</h2>
+<ul>
+<li>Hvis denne udvidelse blev installeret gennem Cinnamons indstillinger, blev alle oversættelser automatisk installeret.</li>
+<li>Hvis denne udvidelse blev installeret manuelt og ikke gennem Cinnamons indstillinger, kan alle oversættelser installeres ved at køre skriptet <strong>localizations.sh</strong> i en terminal åbnet i udvidelsens mappe.</li>
+<li>Hvis der ikke er nogen oversættelse til denne udvidelse tilgængelig på dit sprog, kan du oprette en ved at følge de efterfølgende instruktioner. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
+</ul>
+
+<div style="font-weight:bold;" class="alert alert-info">De næste to afsnit er kun tilgængelig på engelsk.</div>
+</div> <!-- .localization-content -->
+
 
 <div id="zh_CN" class="localization-content hidden">
 
@@ -557,6 +737,7 @@ $ sudo make install
 <li>如果该xlet没有您的语言的本地化，您可以按照以下说明进行创建。 <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">以下两个部分仅使用英语。</div>
 </div> <!-- .localization-content -->
 
 
@@ -638,6 +819,89 @@ $ sudo make install
 <li>Si este xlet no está disponible en su idioma, la localización puede ser creada siguiendo las siguientes instrucciones. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Las siguientes dos secciones están disponibles sólo en Inglés.</div>
+</div> <!-- .localization-content -->
+
+
+<div id="cs" class="localization-content hidden">
+
+<h1>Nápověda pro Multi Translator</h1>
+
+<div style="font-weight:bold;" class="alert alert-warning">
+<h2>DŮLEŽITÉ!!!</h2>
+
+<p>Nikdy neodstraňujte soubory ze složky tohoto xletu. Mohlo by to narušit funkčnost xletu.</p>
+
+<p>Zprávy o chybách, požadavky na funkce a příspěvky by měly být prováděny v repozitáři tohoto xletu, na který je odkaz dále. <a href="https://github.com/Odyseus/CinnamonTools">GitHub</a></p>
+
+</div>
+<hr>
+
+<h2>Závislosti</h2>
+<p><strong>Pokud v systému chybí jedna nebo více těchto závislostí, nebudete moci toto rozšíření používat.</strong></p>
+<ul>
+<li>xsel příkaz: XSel je program příkazového řádku pro získání a nastavení obsahu výběru X.</li>
+<li>trans příkaz: Příkaz poskytovaný balíkem translate-shell. Jde o jednoduché rozhraní příkazového řádku pro několik poskytovatelů překladů (Google Translate, Yandex Translate, Bing Translate a Apertium), které umožní přeložit řetězce ve vaše terminálu. <ul>
+<li>Zkontrolujte translate-shell <a href="https://github.com/soimort/translate-shell#dependencies">závislosti</a> a <a href="https://github.com/soimort/translate-shell#recommended-pendencies">doporučené závislosti</a>.</li>
+</ul>
+</li>
+</ul>
+<p><strong>Poznámka:</strong> Balík translate-shell dostupný v repozitářích Ubuntu 16.04.x ​​/ Linux Mint 18.x je zastaralý a porušený. Přesto může být instalován tak, že bude také instalovat jeho závislosti. Aktualizace na nejnovější verzi by měla být provedena způsobem popsaným níže.</p>
+<h2>Jak nainstalovat nejnovější verzi translate-shell</h2>
+<h3>Možnost 1. Přímé stažení</h3>
+<p>Tato metoda pouze nainstaluje skript trans do určených umístění.</p>
+<p>Pouze pro aktuálního uživatele. <strong>~/.local/bin</strong> musí být ve vaší cestě.</p>
+<pre><code class="lang-shell">$ wget -O ~/.local/bin/trans git.io/trans &amp;&amp; chmod ugo+rx ~/.local/bin/trans
+</code></pre>
+<p>Pro všechny uživatele bez přepsání nainstalované verze.</p>
+<pre><code class="lang-shell">$ sudo wget -O /usr/local/bin/trans git.io/trans &amp;&amp; sudo chmod ugo+rx /usr/local/bin/trans
+</code></pre>
+<h3>Možnost 2. Z Git - <a href="https://github.com/soimort/translate-shell/blob/develop/README.md#option-3-from-git-recommended-for-seasoned-hackers">Podrobnosti</a></h3>
+<p>Tato metoda nebude pouze instalovat trans skript, ale i jeho man pages. Více podrobností o instalaci naleznete na výše uvedeném odkazu.</p>
+<pre><code class="lang-shell">$ git clone https://github.com/soimort/translate-shell
+$ cd translate-shell
+$ make
+$ sudo make install
+</code></pre>
+<hr>
+<h2>Používání rozšíření</h2>
+<p>Po instalaci a aktivaci rozšíření budou k dispozici následující klávesové zkratky.</p>
+<h3>Globální klávesové zkratky (konfigurovatelné z nastavení rozšíření)</h3>
+<ul>
+<li><strong><kbd>Super</kbd> + <kbd>T</kbd>:</strong> Otevřít dialog překladače.</li>
+<li><strong><kbd>Super</kbd> + <kbd>Shift</kbd> + <kbd>T</kbd>:</strong> Otevřít dialog překladače a přeložit text ze schránky.</li>
+<li><strong><kbd>Super</kbd> + <kbd>Alt</kbd> + <kbd>T</kbd>:</strong> Otevřít dialog překladače a přeložit vybraný text.</li>
+</ul>
+<h3>Klávesové zkratky dostupné v dialogovém okně překladu</h3>
+<ul>
+<li><strong><kbd>Ctrl</kbd> + <kbd>Enter</kbd>:</strong> Přeložit text.</li>
+<li><strong><kbd>Shift</kbd> + <kbd>Enter</kbd>:</strong> Vynutit překlad textu. Ignoruje historii překladů.</li>
+<li><strong><kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>C</kbd>:</strong> Kopírovat přeložený text do schránky.</li>
+<li><strong><kbd>Ctrl</kbd> + <kbd>S</kbd>:</strong> Prohodit jazyky.</li>
+<li><strong><kbd>Ctrl</kbd> + <kbd>D</kbd>:</strong> Resetovat jazyky do výchozího stavu.</li>
+<li><strong><kbd>Escape</kbd>:</strong> Zavřít dialog.</li>
+</ul>
+<hr>
+<h2>Okno nastavení rozšíření</h2>
+<p>Z tohoto okna nastavení rozšíření lze všechny volby importovat, exportovat a/nebo je resetovat na výchozí hodnoty.</p>
+<ul>
+<li>Chcete-li provést některé z těchto akcí, musí být v systému nainstalováno schéma nastavení. To se provede automaticky, když je rozšíření nainstalováno ze správce rozšíření Cinnamonu. Ale pokud bylo rozšíření nainstalováno ručně, schéma nastavení musí být také nainstalováno ručně. Toho lze dosáhnout pouhým přechodem do složky rozšíření a spuštěním následujícího příkazu: <ul>
+<li>Příkaz pro instalaci schématu nastavení: <code>./settings.py install-schema</code></li>
+<li>Příkaz k odinstalování schématu nastavení: <code>./settings.py remove-schema</code></li>
+</ul>
+</li>
+<li>Chcete-li importovat/exportovat nastavení, musí být v systému k dispozici příkaz <strong>dconf</strong>.</li>
+</ul>
+<hr>
+
+<h2>Lokalizace apletů/deskletů/rozšíření (a.k.a. xlety)</h2>
+<ul>
+<li>Pokud byl tento xlet nainstalován z nastavení systému v Cinnamonu, byly všechny tyto lokalizace xletu automaticky nainstalovány.</li>
+<li>Pokud byl tento xlet nainstalován ručně a nikoliv pomocí nastavení systému v Cinnamonu, mohou být lokalizace instalovány spuštěním skriptu nazvaného <strong> localizations.sh </strong> z terminálu otevřeného uvnitř složky xletu.</li>
+<li>Pokud tento xlet nemá k dispozici překlad pro váš jazyk, můžete jej vytvořit podle následujících pokynů. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
+</ul>
+
+<div style="font-weight:bold;" class="alert alert-info">Následující dvě části jsou k dispozici pouze v angličtině.</div>
 </div> <!-- .localization-content -->
 
 
@@ -719,6 +983,7 @@ $ sudo make install
 <li>Om ditt språk saknas i denna xlet, kan du översätta den med hjälp av följande instruktioner. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">Följande två sektioner är endast tillgängliga på Engelska.</div>
 </div> <!-- .localization-content -->
 
 
@@ -800,11 +1065,11 @@ $ sudo make install
 <li>If this xlet has no locale available for your language, you could create it by following the following instructions. <a href="https://github.com/Odyseus/CinnamonTools/wiki/Xlet-localization">Wiki</a></li>
 </ul>
 
+<div style="font-weight:bold;" class="alert alert-info">The following two sections are available only in English.</div>
 </div> <!-- .localization-content -->
 
 </div> <!-- .container.boxed -->
-<div style="font-weight:bold;" class="container alert alert-info">The following two sections are available only in English.</div>
-<span id="xlet-contributors">
+<span id="xlet-contributors" style="padding-top:140px;">
 <div class="container boxed">
 <h2>Contributors/Mentions</h2>
 <ul>
@@ -816,14 +1081,41 @@ $ sudo make install
 <li><strong><a href="https://github.com/Radek71">Radek71</a>:</strong> Czech localization and author of Thunderbolt theme.</li>
 <li><strong><a href="https://github.com/NikoKrause">NikoKrause</a>:</strong> German localization.</li>
 <li><strong><a href="https://github.com/eson57">eson57</a>:</strong> Swedish localization.</li>
+<li><strong><a href="https://github.com/Alan01">Alan01</a>:</strong> Danish localization.</li>
 </ul>
 
 </div> <!-- .container.boxed -->
 
-<span id="xlet-changelog">
+<span id="xlet-changelog" style="padding-top:70px;">
 <div class="container boxed">
 <h2>Multi Translator changelog</h2>
 <h4>This change log is only valid for the version of the xlet hosted on <a href="https://github.com/Odyseus/CinnamonTools">its original repository</a></h4>
+<hr>
+<ul>
+<li><strong>Date:</strong> Thu, 8 Jun 2017 18:56:10 -0300</li>
+<li><strong>Commit:</strong> <a href="https://github.com/Odyseus/CinnamonTools/commit/727b583">727b583</a></li>
+<li><strong>Author:</strong> Odyseus</li>
+</ul>
+<pre><code>Multi Translator extension
+- Added Danish localization.
+</code></pre>
+<hr>
+<ul>
+<li><strong>Date:</strong> Thu, 8 Jun 2017 19:08:01 +0200</li>
+<li><strong>Commit:</strong> <a href="https://github.com/Odyseus/CinnamonTools/commit/eb0ff14">eb0ff14</a></li>
+<li><strong>Author:</strong> Alan01</li>
+</ul>
+<pre><code>Create da.po
+</code></pre>
+<hr>
+<ul>
+<li><strong>Date:</strong> Thu, 8 Jun 2017 02:02:08 -0300</li>
+<li><strong>Commit:</strong> <a href="https://github.com/Odyseus/CinnamonTools/commit/e47ca02">e47ca02</a></li>
+<li><strong>Author:</strong> Odyseus</li>
+</ul>
+<pre><code>Multi Translator extension
+- Updated Czech localization.
+</code></pre>
 <hr>
 <ul>
 <li><strong>Date:</strong> Sun, 4 Jun 2017 19:49:32 +0800</li>
@@ -1344,6 +1636,8 @@ certain settings without adding to much clutter
 </div> <!-- .container.boxed -->
 
 </div> <!-- #mainarea -->
-<script type="text/javascript">toggleLocalizationVisibility(null);</script>
+<script type="text/javascript">toggleLocalizationVisibility(null);
+
+</script>
 </body>
 </html>

--- a/0dyseus@MultiTranslatorExtension/files/0dyseus@MultiTranslatorExtension/metadata.json
+++ b/0dyseus@MultiTranslatorExtension/files/0dyseus@MultiTranslatorExtension/metadata.json
@@ -12,7 +12,7 @@
         "3.2",
         "3.4"
     ],
-    "version": "1.04",
+    "version": "1.05",
     "schema-file": "schemas/org.cinnamon.extensions.0dyseus@MultiTranslatorExtension.gschema.xml",
     "name": "Multi Translator"
 }

--- a/0dyseus@MultiTranslatorExtension/files/0dyseus@MultiTranslatorExtension/po/0dyseus@MultiTranslatorExtension.pot
+++ b/0dyseus@MultiTranslatorExtension/files/0dyseus@MultiTranslatorExtension/po/0dyseus@MultiTranslatorExtension.pot
@@ -5,8 +5,8 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 0dyseus@MultiTranslatorExtension 1.04\n"
-"POT-Creation-Date: 2017-06-02 17:05-0300\n"
+"Project-Id-Version: 0dyseus@MultiTranslatorExtension 1.05\n"
+"POT-Creation-Date: 2017-06-12 22:20-0300\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -170,65 +170,65 @@ msgstr ""
 msgid "To import/export settings, the **dconf** command needs to be available on the system."
 msgstr ""
 
-#: ../../create_localized_help.py:164
-msgid "The following two sections are available only in English."
-msgstr ""
-
 #. TO TRANSLATORS: This is a placeholder.
 #. Here goes your language name in your own language (a.k.a. endonym).
-#: ../../create_localized_help.py:189 ../../create_localized_help.py:261
+#: ../../create_localized_help.py:193 ../../create_localized_help.py:269
 msgid "language-name"
 msgstr ""
 
-#: ../../create_localized_help.py:264 settings.py:1385 __init__.js:3456
+#: ../../create_localized_help.py:199
+msgid "The following two sections are available only in English."
+msgstr ""
+
+#: ../../create_localized_help.py:272 settings.py:1385 __init__.js:3456
 msgid "Help"
 msgstr ""
 
-#: ../../create_localized_help.py:265
+#: ../../create_localized_help.py:273
 msgid "Contributors"
 msgstr ""
 
-#: ../../create_localized_help.py:266
+#: ../../create_localized_help.py:274
 msgid "Changelog"
 msgstr ""
 
-#: ../../create_localized_help.py:267
+#: ../../create_localized_help.py:275
 msgid "Choose language"
 msgstr ""
 
 #. TO TRANSLATORS: Full sentence:
 #. "Help for <xlet_name>"
-#: ../../create_localized_help.py:268 ../../create_localized_help.py:275
+#: ../../create_localized_help.py:276 ../../create_localized_help.py:283
 #, python-format
 msgid "Help for %s"
 msgstr ""
 
-#: ../../create_localized_help.py:276
+#: ../../create_localized_help.py:284
 msgid "IMPORTANT!!!"
 msgstr ""
 
-#: ../../create_localized_help.py:277
+#: ../../create_localized_help.py:285
 msgid "Never delete any of the files found inside this xlet folder. It might break this xlet functionality."
 msgstr ""
 
-#: ../../create_localized_help.py:278
+#: ../../create_localized_help.py:286
 msgid "Bug reports, feature requests and contributions should be done on this xlet's repository linked next."
 msgstr ""
 
-#: ../../create_localized_help.py:284
+#: ../../create_localized_help.py:292
 msgid "Applets/Desklets/Extensions (a.k.a. xlets) localization"
 msgstr ""
 
-#: ../../create_localized_help.py:285
+#: ../../create_localized_help.py:293
 msgid "If this xlet was installed from Cinnamon Settings, all of this xlet's localizations were automatically installed."
 msgstr ""
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
-#: ../../create_localized_help.py:287
+#: ../../create_localized_help.py:295
 msgid "If this xlet was installed manually and not trough Cinnamon Settings, localizations can be installed by executing the script called **localizations.sh** from a terminal opened inside the xlet's folder."
 msgstr ""
 
-#: ../../create_localized_help.py:288
+#: ../../create_localized_help.py:296
 msgid "If this xlet has no locale available for your language, you could create it by following the following instructions."
 msgstr ""
 

--- a/0dyseus@MultiTranslatorExtension/files/0dyseus@MultiTranslatorExtension/po/da.po
+++ b/0dyseus@MultiTranslatorExtension/files/0dyseus@MultiTranslatorExtension/po/da.po
@@ -1,49 +1,50 @@
-# This is a template file for translating the Cinnamon extension called Multi Translator.
-# Copyright (C) 2017
-# This file is distributed under the same license as the Multi Translator extension.
-# Odyseus <EMAIL@ADDRESS>, 2017.
+# This is a template file for translating the 0dyseus@MultiTranslatorExtension package.
+# Copyright (C) 2016-2017
+# This file is distributed under the same license as the 0dyseus@MultiTranslatorExtension package.
+# Odyseus <EMAIL@ADDRESS>, 2016-2017.
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: 1.04\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2017-06-08 06:27+0200\n"
-"PO-Revision-Date: 2017-06-08 06:49+0200\n"
-"Last-Translator: Radek Otáhal <radek.otahal@email.cz>\n"
+"Project-Id-Version: 0dyseus@MultiTranslatorExtension 1.04\n"
+"POT-Creation-Date: 2017-06-03 20:29+0200\n"
+"PO-Revision-Date: 2017-06-08 19:06+0200\n"
 "Language-Team: \n"
-"Language: cs\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+"Generated-By: make-xlet-pot.py 1.0.32\n"
 "X-Generator: Poedit 1.8.7.1\n"
-"Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
+"Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"Language: da\n"
 
 #: ../../create_localized_help.py:64
 msgid "Dependencies"
-msgstr "Závislosti"
+msgstr "Afhængigheder"
 
 #: ../../create_localized_help.py:65
 msgid ""
 "If one or more of these dependencies are missing in your system, you will "
 "not be able to use this extension."
 msgstr ""
-"Pokud v systému chybí jedna nebo více těchto závislostí, nebudete moci toto "
-"rozšíření používat."
+"Hvis en eller flere af disse afhængigheder mangler i dit system, kan du ikke "
+"bruge denne udvidelse."
 
 #: ../../create_localized_help.py:66
 msgid "xsel command:"
-msgstr "xsel příkaz:"
+msgstr "Kommandoen xsel:"
 
 #: ../../create_localized_help.py:67
 msgid ""
 "XSel is a command-line program for getting and setting the contents of the X "
 "selection."
 msgstr ""
-"XSel je program příkazového řádku pro získání a nastavení obsahu výběru X."
+"XSel er et kommandolinjeprogram til at hente og indstille indholdet af X-"
+"markeringen."
 
 #: ../../create_localized_help.py:68
 msgid "trans command:"
-msgstr "trans příkaz:"
+msgstr "Kommandoen trans:"
 
 #: ../../create_localized_help.py:69
 msgid ""
@@ -52,10 +53,10 @@ msgid ""
 "Translate, Bing Translate and Apertium) which allows you to translate "
 "strings in your terminal."
 msgstr ""
-"Příkaz poskytovaný balíkem translate-shell. Jde o jednoduché rozhraní "
-"příkazového řádku pro několik poskytovatelů překladů (Google Translate, "
-"Yandex Translate, Bing Translate a Apertium), které umožní přeložit řetězce "
-"ve vaše terminálu. "
+"Kommando i pakken translate-shell. Det er en simpel kommandolinjegrænseflade "
+"til adskillige udbydere af oversættelser (Google Translate, Yandex "
+"Translate, Bing Translate og Apertium), som lader dig oversætte strenge i "
+"din terminal."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
 #: ../../create_localized_help.py:71
@@ -64,13 +65,13 @@ msgid ""
 "shell#dependencies) and [recommended dependencies](https://github.com/"
 "soimort/translate-shell#recommended-dependencies)."
 msgstr ""
-"Zkontrolujte translate-shell [závislosti](https://github.com/soimort/"
-"translate-shell#dependencies) a [doporučené závislosti](https://github.com/"
-"soimort/translate-shell#recommended-pendencies)."
+"Tjek translate-shell [afhængigheder](https://github.com/soimort/translate-"
+"shell#dependencies) og [anbefalede afhængigheder](https://github.com/soimort/"
+"translate-shell#recommended-dependencies)."
 
 #: ../../create_localized_help.py:73
 msgid "Note:"
-msgstr "Poznámka:"
+msgstr "Bemærk:"
 
 #: ../../create_localized_help.py:73
 msgid ""
@@ -79,33 +80,33 @@ msgid ""
 "also install its dependencies. But updating to the latest version should be "
 "done as described bellow."
 msgstr ""
-"Balík translate-shell dostupný v repozitářích Ubuntu 16.04.x ​​/ Linux Mint 18."
-"x je zastaralý a porušený. Přesto může být instalován tak, že bude také "
-"instalovat jeho závislosti. Aktualizace na nejnovější verzi by měla být "
-"provedena způsobem popsaným níže. "
+"I Ubuntu 16.04.x's/Linux Mint 18.x's arkiver er pakken translate-shell "
+"forældet og i stykker. Pakken kan alligevel installeres og afhængighederne "
+"vil også blive installeret. Men der bør opdateres til nyeste version som "
+"beskrevet nedenfor."
 
 #: ../../create_localized_help.py:75
 msgid "How to install latest version of translate-shell"
-msgstr "Jak nainstalovat nejnovější verzi translate-shell"
+msgstr "Sådan installeres nyeste version af translate-shell"
 
 #: ../../create_localized_help.py:76
 msgid "Option 1. Direct Download"
-msgstr "Možnost 1. Přímé stažení"
+msgstr "Mulighed 1. Direkte download"
 
 #: ../../create_localized_help.py:77
 msgid ""
 "This method will only install the trans script into the specified locations."
-msgstr "Tato metoda pouze nainstaluje skript trans do určených umístění."
+msgstr ""
+"Denne metode vil kun installere trans-skriptet i de angivne placeringer."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
 #: ../../create_localized_help.py:80
 msgid "For the current user only. **~/.local/bin** needs to be in your PATH."
-msgstr ""
-"Pouze pro aktuálního uživatele. **~/.local/bin** musí být ve vaší cestě. "
+msgstr "Kun for den aktuelle bruger. **~/.local/bin** skal være i din PATH."
 
 #: ../../create_localized_help.py:86
 msgid "For all users without overwriting the installed version."
-msgstr "Pro všechny uživatele bez přepsání nainstalované verze."
+msgstr "For alle brugere uden at overskrive den installerede version."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
 #: ../../create_localized_help.py:94
@@ -114,35 +115,34 @@ msgid ""
 "shell/blob/develop/README.md#option-3-from-git-recommended-for-seasoned-"
 "hackers)"
 msgstr ""
-"Možnost 2. Z Git - [Podrobnosti](https://github.com/soimort/translate-shell/"
-"blob/develop/README.md#option-3-from-git-recommended-for-seasoned-hackers)"
+"Mulighed 2. Fra Git [Flere detaljer](https://github.com/soimort/translate-"
+"shell/blob/develop/README.md#option-3-from-git-recommended-for-seasoned-"
+"hackers)"
 
 #: ../../create_localized_help.py:95
 msgid ""
 "This method will not just install the trans script but also its man pages. "
 "Refer to the link above for more installation details."
 msgstr ""
-"Tato metoda nebude pouze instalovat trans skript, ale i jeho man pages. Více "
-"podrobností o instalaci naleznete na výše uvedeném odkazu. "
+"Denne metode vil ikke kun installere trans-skriptet, men også man-siderne. "
+"Se linket ovenfor for flere detaljer om installation."
 
 #: ../../create_localized_help.py:105
 msgid "Extension usage"
-msgstr "Používání rozšíření"
+msgstr "Brug af udvidelsen"
 
 #: ../../create_localized_help.py:106
 msgid "Once installed and enabled, the following shortcuts will be available."
-msgstr ""
-"Po instalaci a aktivaci rozšíření budou k dispozici následující klávesové "
-"zkratky."
+msgstr "Når installeret og aktiveret vil følgende genveje være tilgængelige."
 
 #: ../../create_localized_help.py:107
 msgid "Global shortcuts (configurable from the extension settings)"
-msgstr "Globální klávesové zkratky (konfigurovatelné z nastavení rozšíření)"
+msgstr "Globale genveje (kan konfigureres fra udvidelsens indstillinger)"
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
 #: ../../create_localized_help.py:109
 msgid "**[[Super]] + [[T]]:** Open translator dialog."
-msgstr "**[[Super]] + [[T]]:** Otevřít dialog překladače."
+msgstr "**[[Super]] + [[T]]:** Åbn oversættelsesvinduet."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
 #: ../../create_localized_help.py:111
@@ -150,8 +150,8 @@ msgid ""
 "**[[Super]] + [[Shift]] + [[T]]:** Open translator dialog and translate text "
 "from clipboard."
 msgstr ""
-"**[[Super]] + [[Shift]] + [[T]]:** Otevřít dialog překladače a přeložit text "
-"ze schránky."
+"**[[Super]] + [[Shift]] + [[T]]:** Åbn oversættelsesvinduet og oversæt "
+"teksten i udklipsholderen."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
 #: ../../create_localized_help.py:113
@@ -159,17 +159,17 @@ msgid ""
 "**[[Super]] + [[Alt]] + [[T]]:** Open translator dialog and translate from "
 "primary selection."
 msgstr ""
-"**[[Super]] + [[Alt]] + [[T]]:** Otevřít dialog překladače a přeložit "
-"vybraný text."
+"**[[Super]] + [[Alt]] + [[T]]:** Åbn oversættelsesvinduet og oversæt "
+"indholdet i den primære markering."
 
 #: ../../create_localized_help.py:115
 msgid "Shortcuts available on the translation dialog"
-msgstr "Klávesové zkratky dostupné v dialogovém okně překladu"
+msgstr "Genveje tilgængelige i oversættelsesvinduet"
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
 #: ../../create_localized_help.py:117
 msgid "**[[Ctrl]] + [[Enter]]:** Translate text."
-msgstr "**[[Ctrl]] + [[Enter]]:** Přeložit text."
+msgstr "**[[Ctrl]] + [[Enter]]:** Oversæt tekst."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
 #: ../../create_localized_help.py:119
@@ -177,40 +177,41 @@ msgid ""
 "**[[Shift]] + [[Enter]]:** Force text translation. Ignores translation "
 "history."
 msgstr ""
-"**[[Shift]] + [[Enter]]:** Vynutit překlad textu. Ignoruje historii překladů."
+"**[[Shift]] + [[Enter]]:** Gennemtving oversættelse af tekst. Ignorerer "
+"oversættelseshistorik."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
 #: ../../create_localized_help.py:121
 msgid "**[[Ctrl]] + [[Shift]] + [[C]]:** Copy translated text to clipboard."
 msgstr ""
-"**[[Ctrl]] + [[Shift]] + [[C]]:** Kopírovat přeložený text do schránky."
+"**[[Ctrl]] + [[Shift]] + [[C]]:** Kopiér oversat tekst til udklipsholderen."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
 #: ../../create_localized_help.py:123
 msgid "**[[Ctrl]] + [[S]]:** Swap languages."
-msgstr "**[[Ctrl]] + [[S]]:** Prohodit jazyky."
+msgstr "**[[Ctrl]] + [[S]]:** Ombyt sprog."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
 #: ../../create_localized_help.py:125
 msgid "**[[Ctrl]] + [[D]]:** Reset languages to default."
-msgstr "**[[Ctrl]] + [[D]]:** Resetovat jazyky do výchozího stavu."
+msgstr "**[[Ctrl]] + [[D]]:** Nulstil sprog til standard."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
 #: ../../create_localized_help.py:127
 msgid "**[[Escape]]:** Close dialog."
-msgstr "**[[Escape]]:** Zavřít dialog."
+msgstr "**[[Escape]]:** Luk vindue."
 
 #: ../../create_localized_help.py:130
 msgid "Extension's settings window"
-msgstr "Okno nastavení rozšíření"
+msgstr "Udvidelsens indstillingsvindue"
 
 #: ../../create_localized_help.py:131
 msgid ""
 "From this extension settings window, all options can be imported, exported "
 "and/or reseted to their defaults."
 msgstr ""
-"Z tohoto okna nastavení rozšíření lze všechny volby importovat, exportovat a/"
-"nebo je resetovat na výchozí hodnoty."
+"Fra udvidelsens indstillingsvindue kan alle indstillinger importeres, "
+"eksporteres eller nulstilles til standardværdierne."
 
 #: ../../create_localized_help.py:133
 msgid ""
@@ -221,22 +222,21 @@ msgid ""
 "This is achieved by simply going to the extension folder and launch the "
 "following command:"
 msgstr ""
-"Chcete-li provést některé z těchto akcí, musí být v systému nainstalováno "
-"schéma nastavení. To se provede automaticky, když je rozšíření nainstalováno "
-"ze správce rozšíření Cinnamonu. Ale pokud bylo rozšíření nainstalováno "
-"ručně, schéma nastavení musí být také nainstalováno ručně. Toho lze "
-"dosáhnout pouhým přechodem do složky rozšíření a spuštěním následujícího "
-"příkazu: "
+"For at kunne udføre disse handlinger skal indstillingsskemaet installeres i "
+"systemet. Dette sker automatisk, hvis udvidelsen installeres gennem "
+"Cinnamons modul til håndtering af udvidelser. Blev udvidelsen installeret "
+"manuelt, skal indstillingsskemaet også installeres manuelt. Dette gøres ved "
+"at gå til udvidelsens mappe og køre følgende kommando:"
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
 #: ../../create_localized_help.py:135
 msgid "Command to install the settings schema:"
-msgstr "Příkaz pro instalaci schématu nastavení:"
+msgstr "Kommando til at installere indstillingsskemaet:"
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
 #: ../../create_localized_help.py:138
 msgid "Command to uninstall the settings schema:"
-msgstr "Příkaz k odinstalování schématu nastavení:"
+msgstr "Kommando til at afinstallere indstillingsskemaet:"
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
 #: ../../create_localized_help.py:141
@@ -244,73 +244,73 @@ msgid ""
 "To import/export settings, the **dconf** command needs to be available on "
 "the system."
 msgstr ""
-"Chcete-li importovat/exportovat nastavení, musí být v systému k dispozici "
-"příkaz **dconf**."
+"For at importere/eksportere indstillinger skal kommandoen **dconf** findes i "
+"systemet."
 
 #: ../../create_localized_help.py:164
 msgid "The following two sections are available only in English."
-msgstr "Následující dvě části jsou k dispozici pouze v angličtině."
+msgstr "De næste to afsnit er kun tilgængelig på engelsk."
 
 #. TO TRANSLATORS: This is a placeholder.
 #. Here goes your language name in your own language (a.k.a. endonym).
 #: ../../create_localized_help.py:189 ../../create_localized_help.py:261
 msgid "language-name"
-msgstr "Česky"
+msgstr "Dansk"
 
 #: ../../create_localized_help.py:264 settings.py:1385 __init__.js:3456
 msgid "Help"
-msgstr "Nápověda"
+msgstr "Hjælp"
 
 #: ../../create_localized_help.py:265
 msgid "Contributors"
-msgstr "Přispěvatelé"
+msgstr "Bidragydere"
 
 #: ../../create_localized_help.py:266
 msgid "Changelog"
-msgstr "Changelog"
+msgstr "Ændringslog"
 
 #: ../../create_localized_help.py:267
 msgid "Choose language"
-msgstr "Zvolte jazyk"
+msgstr "Vælg sprog"
 
 #. TO TRANSLATORS: Full sentence:
 #. "Help for <xlet_name>"
 #: ../../create_localized_help.py:268 ../../create_localized_help.py:275
 #, python-format
 msgid "Help for %s"
-msgstr "Nápověda pro %s"
+msgstr "Hjælp til %s"
 
 #: ../../create_localized_help.py:276
 msgid "IMPORTANT!!!"
-msgstr "DŮLEŽITÉ!!!"
+msgstr "VIGTIGT!!!"
 
 #: ../../create_localized_help.py:277
 msgid ""
 "Never delete any of the files found inside this xlet folder. It might break "
 "this xlet functionality."
 msgstr ""
-"Nikdy neodstraňujte soubory ze složky tohoto xletu. Mohlo by to narušit "
-"funkčnost xletu. "
+"Slet aldrig nogen af filerne i denne udvidelses mappe. Det kan ødelægge "
+"udvidelsens funktionalitet."
 
 #: ../../create_localized_help.py:278
 msgid ""
 "Bug reports, feature requests and contributions should be done on this "
 "xlet's repository linked next."
 msgstr ""
-"Zprávy o chybách, požadavky na funkce a příspěvky by měly být prováděny v "
-"repozitáři tohoto xletu, na který je odkaz dále."
+"Fejlrapporter, forslag til nye funktioner og bidrag bør ske i denne "
+"udvidelses arkiv, som der er linket til efterfølgende."
 
 #: ../../create_localized_help.py:284
 msgid "Applets/Desklets/Extensions (a.k.a. xlets) localization"
-msgstr "Lokalizace apletů/deskletů/rozšíření (a.k.a. xlety)"
+msgstr "Oversættelser af panelprogrammer, skrivebordsprogrammer og udvidelser"
 
 #: ../../create_localized_help.py:285
 msgid ""
 "If this xlet was installed from Cinnamon Settings, all of this xlet's "
 "localizations were automatically installed."
 msgstr ""
-"Pokud byl tento xlet nainstalován z nastavení systému v Cinnamonu, byly "
-"všechny tyto lokalizace xletu automaticky nainstalovány."
+"Hvis denne udvidelse blev installeret gennem Cinnamons indstillinger, blev "
+"alle oversættelser automatisk installeret."
 
 #. TO TRANSLATORS: MARKDOWN string. Respect formatting.
 #: ../../create_localized_help.py:287
@@ -319,651 +319,652 @@ msgid ""
 "localizations can be installed by executing the script called "
 "**localizations.sh** from a terminal opened inside the xlet's folder."
 msgstr ""
-"Pokud byl tento xlet nainstalován ručně a nikoliv pomocí nastavení systému v "
-"Cinnamonu, mohou být lokalizace instalovány spuštěním skriptu nazvaného ** "
-"localizations.sh ** z terminálu otevřeného uvnitř složky xletu."
+"Hvis denne udvidelse blev installeret manuelt og ikke gennem Cinnamons "
+"indstillinger, kan alle oversættelser installeres ved at køre skriptet "
+"**localizations.sh** i en terminal åbnet i udvidelsens mappe."
 
 #: ../../create_localized_help.py:288
 msgid ""
 "If this xlet has no locale available for your language, you could create it "
 "by following the following instructions."
 msgstr ""
-"Pokud tento xlet nemá k dispozici překlad pro váš jazyk, můžete jej vytvořit "
-"podle následujících pokynů."
+"Hvis der ikke er nogen oversættelse til denne udvidelse tilgængelig på dit "
+"sprog, kan du oprette en ved at følge de efterfølgende instruktioner."
 
 #: extensionHelper.py:271
 msgid "Multi Translator history"
-msgstr "Multi Translator historie"
+msgstr "Multioversætter-historik"
 
 #: extensionHelper.py:295
 msgid "Date"
-msgstr "Datum"
+msgstr "Dato"
 
 #: extensionHelper.py:303
 msgid "Source text"
-msgstr "Zdrojový text"
+msgstr "Indtastet tekst"
 
 #: extensionHelper.py:308
 msgid "Language pair"
-msgstr "Vybrané jazyky"
+msgstr "Sprogpar"
 
 #: extensionHelper.py:316
 msgid "Target text"
-msgstr "Cílový text"
+msgstr "Oversat tekst"
 
 #. TO TRANSLATORS: "xsel" is a command, do not translate.
 #: extensionHelper.py:430
 msgid "xsel command not found!!!"
-msgstr "xsel příkaz nebyl nalezen!!!"
+msgstr "Kommandoen xsel kunne ikke findes!!!"
 
 #. TO TRANSLATORS: "xdg-open" is a command, do not translate.
 #: extensionHelper.py:436
 msgid "xdg-open command not found!!!"
-msgstr "xdg-open příkaz nebyl nalezen!!!"
+msgstr "Kommandoen xdg-open kunne ikke findes!!!"
 
 #. TO TRANSLATORS: "trans" is a command and "PATH" is an
 #. environmental variable, do not translate.
 #: extensionHelper.py:443
 msgid "trans command not found or it isn't in your PATH!!!"
-msgstr "trans příkaz nebyl nalezen nebo není v PATH!!!"
+msgstr "Kommandoen trans kunne ikke findes eller er ikke i din PATH!!!"
 
 #. 0dyseus@MultiTranslatorExtension->metadata.json->name
 #: settings.py:64 translation_providers/yandex_translation_provider.js:332
 msgid "Multi Translator"
-msgstr "Multi Translator"
+msgstr "Multioversætter"
 
 #: settings.py:67 __init__.js:219
 msgid "Detect language"
-msgstr "Rozpoznat  jazyk"
+msgstr "Registrér sprog"
 
 #: settings.py:68 __init__.js:220
 msgid "Afrikaans"
-msgstr ""
+msgstr "Afrikaans"
 
 #: settings.py:69 __init__.js:221
 msgid "Amharic"
-msgstr ""
+msgstr "Amharisk"
 
 #: settings.py:70 __init__.js:222
 msgid "Arabic"
-msgstr ""
+msgstr "Arabisk"
 
 #: settings.py:71 __init__.js:223
 msgid "Azerbaijani"
-msgstr ""
+msgstr "Aserbajdsjansk"
 
 #: settings.py:72 __init__.js:224
 msgid "Belarusian"
-msgstr ""
+msgstr "Hviderussisk"
 
 #: settings.py:73 __init__.js:225
 msgid "Bulgarian"
-msgstr ""
+msgstr "Bulgarsk"
 
 #: settings.py:74 __init__.js:226
 msgid "Bengali"
-msgstr ""
+msgstr "Bengalsk"
 
 #: settings.py:75 __init__.js:227
 msgid "Bosnian (Y)"
-msgstr ""
+msgstr "Bosnisk (Y)"
 
 #: settings.py:76 __init__.js:228
 msgid "Catalan"
-msgstr ""
+msgstr "Catalansk"
 
 #: settings.py:77 __init__.js:229
 msgid "Chichewa"
-msgstr ""
+msgstr "Chichewa"
 
 #: settings.py:78 __init__.js:230
 msgid "Corsican"
-msgstr ""
+msgstr "Korsikansk"
 
 #: settings.py:79 __init__.js:231
 msgid "Czech"
-msgstr ""
+msgstr "Tjekkisk"
 
 #: settings.py:80 __init__.js:232
 msgid "Welsh"
-msgstr ""
+msgstr "Walesisk"
 
 #: settings.py:81 __init__.js:233
 msgid "Danish"
-msgstr ""
+msgstr "Dansk"
 
 #: settings.py:82 __init__.js:234
 msgid "German"
-msgstr ""
+msgstr "Tysk"
 
 #: settings.py:83 __init__.js:235
 msgid "Greek"
-msgstr ""
+msgstr "Græsk"
 
 #: settings.py:84 __init__.js:236
 msgid "English"
-msgstr ""
+msgstr "Engelsk"
 
 #: settings.py:85 __init__.js:237
 msgid "Esperanto"
-msgstr ""
+msgstr "Esperanto"
 
 #: settings.py:86 __init__.js:238
 msgid "Spanish"
-msgstr ""
+msgstr "Spansk"
 
 #: settings.py:87 __init__.js:239
 msgid "Estonian"
-msgstr ""
+msgstr "Estisk"
 
 #: settings.py:88 __init__.js:240
 msgid "Basque"
-msgstr ""
+msgstr "Baskisk"
 
 #: settings.py:89 __init__.js:241
 msgid "Persian"
-msgstr ""
+msgstr "Persisk"
 
 #: settings.py:90 __init__.js:242
 msgid "Finnish"
-msgstr ""
+msgstr "Finsk"
 
 #: settings.py:91 __init__.js:243
 msgid "French"
-msgstr ""
+msgstr "Fransk"
 
 #: settings.py:92 __init__.js:244
 msgid "Frisian"
-msgstr ""
+msgstr "Frisisk"
 
 #: settings.py:93 __init__.js:245
 msgid "Irish"
-msgstr ""
+msgstr "Irsk"
 
 #: settings.py:94 __init__.js:246
 msgid "Scots Gaelic"
-msgstr ""
+msgstr "Skotsk gælisk"
 
 #: settings.py:95 __init__.js:247
 msgid "Galician"
-msgstr ""
+msgstr "Galisisk"
 
 #: settings.py:96 __init__.js:248
 msgid "Gujarati"
-msgstr ""
+msgstr "Gujarati"
 
 #: settings.py:97 __init__.js:249
 msgid "Hausa"
-msgstr ""
+msgstr "Hausa"
 
 #: settings.py:98 __init__.js:250
 msgid "Hawaiian"
-msgstr ""
+msgstr "Hawaiiansk"
 
 #: settings.py:99 __init__.js:251
 msgid "Hebrew (Y)"
-msgstr ""
+msgstr "Hebraisk (Y)"
 
 #: settings.py:100 __init__.js:252
 msgid "Hindi"
-msgstr ""
+msgstr "Hindi"
 
 #: settings.py:101 __init__.js:253
 msgid "Hmong"
-msgstr ""
+msgstr "Hmong"
 
 #: settings.py:102 __init__.js:254
 msgid "Croatian"
-msgstr ""
+msgstr "Kroatisk"
 
 #: settings.py:103 __init__.js:255
 msgid "Haitian Creole"
-msgstr ""
+msgstr "Haitiansk kreolsprog"
 
 #: settings.py:104 __init__.js:256
 msgid "Hungarian"
-msgstr ""
+msgstr "Ungarsk"
 
 #: settings.py:105 __init__.js:257
 msgid "Armenian"
-msgstr ""
+msgstr "Armensk"
 
 #: settings.py:106 __init__.js:258
 msgid "Indonesian"
-msgstr ""
+msgstr "Indonesisk"
 
 #: settings.py:107 __init__.js:259
 msgid "Igbo"
-msgstr ""
+msgstr "Igbo"
 
 #: settings.py:108 __init__.js:260
 msgid "Icelandic"
-msgstr ""
+msgstr "Islandsk"
 
 #: settings.py:109 __init__.js:261
 msgid "Italian"
-msgstr ""
+msgstr "Italiensk"
 
 #: settings.py:110 __init__.js:262
 msgid "Hebrew"
-msgstr ""
+msgstr "Hebraisk"
 
 #: settings.py:111 __init__.js:263
 msgid "Japanese"
-msgstr ""
+msgstr "Japansk"
 
 #: settings.py:112 __init__.js:264
 msgid "Javanese"
-msgstr ""
+msgstr "Javanesisk"
 
 #: settings.py:113 __init__.js:265
 msgid "Georgian"
-msgstr ""
+msgstr "Georgisk"
 
 #: settings.py:114 __init__.js:266
 msgid "Kazakh"
-msgstr ""
+msgstr "Kasakhisk"
 
 #: settings.py:115 __init__.js:267
 msgid "Khmer"
-msgstr ""
+msgstr "Khmer"
 
 #: settings.py:116 __init__.js:268
 msgid "Kannada"
-msgstr ""
+msgstr "Kannada"
 
 #: settings.py:117 __init__.js:269
 msgid "Korean"
-msgstr ""
+msgstr "Koreansk"
 
 #: settings.py:118 __init__.js:270
 msgid "Kurdish (Kurmanji)"
-msgstr ""
+msgstr "Kurdisk (Kurmanji)"
 
 #: settings.py:119 __init__.js:271
 msgid "Kyrgyz"
-msgstr ""
+msgstr "Kirgisisk"
 
 #: settings.py:120 __init__.js:272
 msgid "Latin"
-msgstr ""
+msgstr "Latinsk"
 
 #: settings.py:121 __init__.js:273
 msgid "Luxembourgish"
-msgstr ""
+msgstr "Luxembourgsk"
 
 #: settings.py:122 __init__.js:274
 msgid "Lao"
-msgstr ""
+msgstr "Lao"
 
 #: settings.py:123 __init__.js:275
 msgid "Lithuanian"
-msgstr ""
+msgstr "Litauisk"
 
 #: settings.py:124 __init__.js:276
 msgid "Latvian"
-msgstr ""
+msgstr "Lettisk"
 
 #: settings.py:125 __init__.js:277
 msgid "Malagasy"
-msgstr ""
+msgstr "Malagassisk"
 
 #: settings.py:126 __init__.js:278
 msgid "Maori"
-msgstr ""
+msgstr "Maori"
 
 #: settings.py:127 __init__.js:279
 msgid "Macedonian"
-msgstr ""
+msgstr "Makedonsk"
 
 #: settings.py:128 __init__.js:280
 msgid "Malayalam"
-msgstr ""
+msgstr "Malayalam"
 
 #: settings.py:129 __init__.js:281
 msgid "Mongolian"
-msgstr ""
+msgstr "Mongolsk"
 
 #: settings.py:130 __init__.js:282
 msgid "Marathi"
-msgstr ""
+msgstr "Marathi"
 
 #: settings.py:131 __init__.js:283
 msgid "Malay"
-msgstr ""
+msgstr "Malaysisk"
 
 #: settings.py:132 __init__.js:284
 msgid "Maltese"
-msgstr ""
+msgstr "Maltesisk"
 
 #: settings.py:133 __init__.js:285
 msgid "Myanmar (Burmese)"
-msgstr ""
+msgstr "Burmesisk"
 
 #: settings.py:134 __init__.js:286
 msgid "Nepali"
-msgstr ""
+msgstr "Nepalesisk"
 
 #: settings.py:135 __init__.js:287
 msgid "Dutch"
-msgstr ""
+msgstr "Hollandsk"
 
 #: settings.py:136 __init__.js:288
 msgid "Norwegian"
-msgstr ""
+msgstr "Norsk"
 
 #: settings.py:137 __init__.js:289
 msgid "Cebuano"
-msgstr ""
+msgstr "Cebuano"
 
 #: settings.py:138 __init__.js:290
 msgid "Punjabi"
-msgstr ""
+msgstr "Punjabi"
 
 #: settings.py:139 __init__.js:291
 msgid "Polish"
-msgstr ""
+msgstr "Polsk"
 
 #: settings.py:140 __init__.js:292
 msgid "Pashto"
-msgstr ""
+msgstr "Pashto"
 
 #: settings.py:141 __init__.js:293
 msgid "Portuguese"
-msgstr ""
+msgstr "Portugisisk"
 
 #: settings.py:142 __init__.js:294
 msgid "Romanian"
-msgstr ""
+msgstr "Rumænsk"
 
 #: settings.py:143 __init__.js:295
 msgid "Russian"
-msgstr ""
+msgstr "Russisk"
 
 #: settings.py:144 __init__.js:296
 msgid "Sindhi"
-msgstr ""
+msgstr "Sindhi"
 
 #: settings.py:145 __init__.js:297
 msgid "Sinhala"
-msgstr ""
+msgstr "Sinhala"
 
 #: settings.py:146 __init__.js:298
 msgid "Slovak"
-msgstr ""
+msgstr "Slovakisk"
 
 #: settings.py:147 __init__.js:299
 msgid "Slovenian"
-msgstr ""
+msgstr "Slovensk"
 
 #: settings.py:148 __init__.js:300
 msgid "Samoan"
-msgstr ""
+msgstr "Samoansk"
 
 #: settings.py:149 __init__.js:301
 msgid "Shona"
-msgstr ""
+msgstr "Shona"
 
 #: settings.py:150 __init__.js:302
 msgid "Somali"
-msgstr ""
+msgstr "Somalisk"
 
 #: settings.py:151 __init__.js:303
 msgid "Albanian"
-msgstr ""
+msgstr "Albansk"
 
 #: settings.py:152 __init__.js:304
 msgid "Serbian"
-msgstr ""
+msgstr "Serbisk"
 
 #: settings.py:153 __init__.js:305
 msgid "Sesotho"
-msgstr ""
+msgstr "Sesotho"
 
 #: settings.py:154 __init__.js:306
 msgid "Sundanese"
-msgstr ""
+msgstr "Sundanesisk"
 
 #: settings.py:155 __init__.js:307
 msgid "Swedish"
-msgstr ""
+msgstr "Svensk"
 
 #: settings.py:156 __init__.js:308
 msgid "Swahili"
-msgstr ""
+msgstr "Swahili"
 
 #: settings.py:157 __init__.js:309
 msgid "Tamil"
-msgstr ""
+msgstr "Tamilsk"
 
 #: settings.py:158 __init__.js:310
 msgid "Telugu"
-msgstr ""
+msgstr "Telugu"
 
 #: settings.py:159 __init__.js:311
 msgid "Tajik"
-msgstr ""
+msgstr "Tadsjikisk"
 
 #: settings.py:160 __init__.js:312
 msgid "Thai"
-msgstr ""
+msgstr "Thai"
 
 #: settings.py:161 __init__.js:313
 msgid "Filipino"
-msgstr ""
+msgstr "Filipinsk"
 
 #: settings.py:162 __init__.js:314
 msgid "Turkish"
-msgstr ""
+msgstr "Tyrkisk"
 
 #: settings.py:163 __init__.js:315
 msgid "Ukrainian"
-msgstr ""
+msgstr "Ukrainsk"
 
 #: settings.py:164 __init__.js:316
 msgid "Urdu"
-msgstr ""
+msgstr "Urdu"
 
 #: settings.py:165 __init__.js:317
 msgid "Uzbek"
-msgstr ""
+msgstr "Usbekisk"
 
 #: settings.py:166 __init__.js:318
 msgid "Vietnamese"
-msgstr ""
+msgstr "Vietnamesisk"
 
 #: settings.py:167 __init__.js:319
 msgid "Xhosa"
-msgstr ""
+msgstr "Xhosa"
 
 #: settings.py:168 __init__.js:320
 msgid "Yiddish"
-msgstr ""
+msgstr "Jiddisch"
 
 #: settings.py:169 __init__.js:321
 msgid "Yoruba"
-msgstr ""
+msgstr "Yoruba"
 
 #: settings.py:170 __init__.js:322
 msgid "Chinese (Y)"
-msgstr ""
+msgstr "Kinesisk (Y)"
 
 #: settings.py:171 __init__.js:323
 msgid "Chinese Simplified"
-msgstr ""
+msgstr "Kinesisk forenklet"
 
 #: settings.py:172 __init__.js:324
 msgid "Chinese Traditional"
-msgstr ""
+msgstr "Kinesisk traditionel"
 
 #: settings.py:173 __init__.js:325
 msgid "Zulu"
-msgstr ""
+msgstr "Zulu"
 
 #: settings.py:183
 msgid "Global"
-msgstr "Globální"
+msgstr "Global"
 
 #: settings.py:185
 msgid "Global extension options"
-msgstr "Globální volby rozšíření"
+msgstr "Globale indstillinger"
 
 #: settings.py:190
 msgid "Default translation provider"
-msgstr "Výchozí poskytovatel služby překladu."
+msgstr "Standardudbyder af oversættelser"
 
 #: settings.py:191
 msgid "Select the default translation provider."
-msgstr "Zvolit výchozího poskytovatele služby překladu."
+msgstr "Vælg standardudbyderen af oversættelser."
 
 #: settings.py:192
 msgid "Providers marked with (*) require translate-shell package to work."
-msgstr ""
-"Poskytovatelé označení (*) vyžadují pro funkčnost balíček translate-shell."
+msgstr "Udbydere markeret med (*) kræver pakken translate-shell for at virke."
 
 #: settings.py:193 __init__.js:3553
 msgid "See the extended help of this extension for more information."
-msgstr "V podrobné nápovědě tohoto rozšíření naleznete další informace."
+msgstr "Se den udvidede hjælp til denne udvidelse for mere information."
 
 #: settings.py:207
 msgid "Remember last translator"
-msgstr "Pamatovat si poslední překladač"
+msgstr "Husk sidste oversætter"
 
 #: settings.py:208
 msgid "Remember last used translation provider."
-msgstr "Pamatovat si posledního poskytovatele služby překladu."
+msgstr "Husk den sidst brugte udbyder af oversættelser."
 
 #: settings.py:214
 msgid "Keep source entry text selected"
-msgstr "Zachovat zdrojový text vybraný"
+msgstr "Lad indtastet tekst være markeret"
 
 #: settings.py:215
 msgid ""
 "Keep source entry text selected whenever the translation dialog is opened "
 "and the source entry box contains text."
 msgstr ""
-"Zachovat zdrojový text vybraný vždy, když je dialogové okno překladu "
-"otevřené a box pro zdrojový text obsahuje text."
+"Lad den indtastede tekst være markeret, når oversættelsesvinduet er åbent, "
+"og tekstfeltet indeholder tekst."
 
 #: settings.py:221
 msgid "Show most used languages"
-msgstr "Zobrazit nejpoužívanější jazyky"
+msgstr "Vis hyppigst anvendte sprog"
 
 #: settings.py:222
 msgid "Display a list of most used languages."
-msgstr "Zobrazit seznam s nejpoužívanějšími jazyky."
+msgstr "Vis en liste over de hyppigst anvendte sprog."
 
 #: settings.py:228
 msgid "Synchronize scroll entries"
-msgstr "Synchronizovat posun položek"
+msgstr "Synkronisér rulning"
 
 #: settings.py:229
 msgid "Make the source and target entries scroll synchronously."
-msgstr "Umožnit synchronizovaný posun zdrojových a cílových položek."
+msgstr "Lad de to tekstfelter rulle synkront."
 
 #: settings.py:235
 msgid "Enable shortcuts"
-msgstr "Povolit klávesové zkratky"
+msgstr "Aktivér genveje"
 
 #: settings.py:236
 msgid "Enable/Disable the use of keyboard shortcuts."
-msgstr "Povolit/zakázat použití klávesových zkratek."
+msgstr "Aktivér/deaktivér brugen af tastaturgenveje."
 
 #: settings.py:243
 msgid "Open translator dialog"
-msgstr "Otevřít dialog překladače"
+msgstr "Åbn oversættelsesvinduet"
 
 #: settings.py:244
 msgid "Translate text from clipboard"
-msgstr "Přeložit text ze schránky"
+msgstr "Oversæt tekst fra udklipsholderen"
 
 #: settings.py:245
 msgid "Translate from primary selection"
-msgstr "Přeložit vybraný text"
+msgstr "Oversæt fra den primære markering"
 
 #: settings.py:253
 msgid "Translators"
-msgstr "Překladače"
+msgstr "Oversættere"
 
 #: settings.py:255
 msgid "Set default settings for each available translation service"
-msgstr "Výchozí nastavení pro každou dostupnou službu překladu"
+msgstr "Angiv standardindstillinger for hver oversættelsestjeneste"
 
 #: settings.py:266
 msgid "Appearance"
-msgstr "Vzhled"
+msgstr "Udseende"
 
 #: settings.py:268
 msgid "Translation dialog appearance"
-msgstr "Vzhled dialogového okna překladu"
+msgstr "Oversættelsesvinduets udseende"
 
 #: settings.py:273
 msgid "Dialog theme"
-msgstr "Motiv dialogu"
+msgstr "Vinduestema"
 
 #: settings.py:274
 msgid "Select a theme for the translation dialog."
-msgstr "Vybrat motiv pro dialogové okno překladu."
+msgstr "Vælg et tema til oversættelsesvinduet."
 
 #: settings.py:276 settings.py:349
 msgid "Custom"
-msgstr "Vlastní"
+msgstr "Brugerdefineret"
 
 #: settings.py:277
 msgid "Default"
-msgstr "Výchozí"
+msgstr "Standard"
 
 #: settings.py:298
 msgid "Custom theme"
-msgstr "Vlastní motiv"
+msgstr "Brugerdefineret tema"
 
 #: settings.py:299
 msgid "Select a custom theme for the translation dialog."
-msgstr "Vybrat vlastní motiv pro dialogové okno překladu."
+msgstr "Vælg et brugerdefineret tema til oversættelsesvinduet."
 
 #: settings.py:305
 msgid "Font size"
-msgstr "Velikost písma"
+msgstr "Skriftstørrelse"
 
 #: settings.py:306
 msgid "Select a font size for the source text and target text entries."
-msgstr "Vybrat velikost písma pro zdrojový a cílový text."
+msgstr "Vælg en skriftstørrelse til tekstfelterne i oversættelsesvinduet."
 
 #: settings.py:310 settings.py:371 settings.py:381 settings.py:392
 msgid "pixels"
-msgstr "pixelů"
+msgstr "pixler"
 
 #: settings.py:316
 msgid "Percentage of screen width"
-msgstr "Procento šířky obrazovky"
+msgstr "Procent af skærmbredden"
 
 #: settings.py:317
 msgid "What percentage of screen width should the translation dialog fill."
-msgstr "Nastavit kolik procent šířky obrazovky vyplní dialogové okno překladu."
+msgstr ""
+"Hvor stor en procentdel af skærmbredden skal oversættelsesvinduet fylde."
 
 #: settings.py:321 settings.py:332
 msgid "percentage"
-msgstr "procenta"
+msgstr "procent"
 
 #: settings.py:327
 msgid "Percentage of screen height"
-msgstr "Procento výšky obrazovky"
+msgstr "Procent af skærmhøjden"
 
 #: settings.py:328
 msgid "What percentage of screen height should the translation dialog fill."
-msgstr "Nastavit kolik procent výšky obrazovky vyplní dialogové okno překladu."
+msgstr ""
+"Hvor stor en procentdel af skærmhøjden skal oversættelsesvinduet fylde."
 
 #: settings.py:339 __init__.js:2713 extension.js:1096 extension.js:1099
 msgid "History"
-msgstr "Historie"
+msgstr "Historik"
 
 #: settings.py:341
 msgid "Translation history settings"
-msgstr "Nastavení historie překladu"
+msgstr "Indstillinger for oversættelseshistorik"
 
 #: settings.py:346
 msgid "Timestamp for history entries"
-msgstr "Časové razítko pro záznamy v historii překladů"
+msgstr "Tidsstempel for historikelementer"
 
 #: settings.py:347
 msgid ""
@@ -972,18 +973,18 @@ msgid ""
 "history will be saved with the new timestamp format. Old entries will still "
 "have the previous timestamp format."
 msgstr ""
-"Formát časového razítka pro záznamy v historii překladů \\ n\n"
-"Poznámka: Po změně tohoto nastavení budou uloženy pouze nové záznamy v "
-"historii překladu s novým formátem časového razítka. Staré záznamy budou mít "
-"i nadále předchozí formát časového razítka. "
+"Tidsstempelformat for elementer i oversættelseshistorikken.\n"
+"Bemærk: Efter at have ændret indstillinger vil kun nye elementer i "
+"oversættelseshistorikken blive gemt med det nye tidsstempelformat. Gamle "
+"elementer vil stadig have det tidligere tidsstempelformat."
 
 #: settings.py:351
 msgid "European"
-msgstr "Evropské"
+msgstr "Europæisk"
 
 #: settings.py:358
 msgid "Custom timestamp"
-msgstr "Uživatelské časové razítko"
+msgstr "Brugerdefineret tidsstempelformat"
 
 #. TO TRANSLATORS: The following strings shouldn't be translated:
 #. YYYY, MM, DD, hh, mm and ss.
@@ -997,45 +998,46 @@ msgid ""
 "mm: minutes\n"
 "ss: seconds"
 msgstr ""
-"Zvolte vlastní časové razítko pro záznamy v historii překladů.\n"
-"YYYY: rok\n"
-"MM: měsíc\n"
-"DD: den\n"
-"hh: hodiny\n"
-"mm: minuty\n"
-"ss: sekundy"
+"Vælg et brugerdefineret tidsstempel til elementer i "
+"oversættelseshistorikken.\n"
+"YYYY: år\n"
+"MM: måned\n"
+"DD: dag\n"
+"hh: timer\n"
+"mm: minutter\n"
+"ss: sekunder"
 
 #: settings.py:367
 msgid "History window initial width"
-msgstr "Výchozí šířka okna historie"
+msgstr "Historikvinduets bredde når det åbnes."
 
 #: settings.py:377
 msgid "History window initial height"
-msgstr "Výchozí výška okna historie"
+msgstr "Historikvinduets højde når det åbnes."
 
 #: settings.py:387
 msgid "Width to trigger word wrap"
-msgstr "Šířka pro zalomení řádků"
+msgstr "Bredde som udløser tekstombrydning"
 
 #: settings.py:388
 msgid ""
 "The \"Source text\" and \"Target text\" columns on the history window will "
 "wrap its text at the width defined by this setting."
 msgstr ""
-"Text ve sloupcích \"Zdrojový text\" a \"Cílový text\" v okně historie bude "
-"zalomen na šířku definovanou tímto nastavením."
+"Teksten i kolonnerne \"Indtastet tekst\" og \"Oversat tekst\" i "
+"historikvinduet vil blive ombrudt ved bredden angivet ved denne indstilling."
 
 #: settings.py:399
 msgid "Advanced"
-msgstr "Pokročilé"
+msgstr "Avanceret"
 
 #: settings.py:401
 msgid "Various advanced options"
-msgstr "Pokročilé volby"
+msgstr "Forskellige avancerede indstillinger"
 
 #: settings.py:407
 msgid "Yandex API keys"
-msgstr "Yandex API klíče"
+msgstr "API-nøgler til Yandex"
 
 #: settings.py:408
 msgid ""
@@ -1043,150 +1045,151 @@ msgid ""
 "Read the help file found inside this extension folder to know how to get "
 "free Yandex API keys."
 msgstr ""
-"Zadejte jeden API klíč na každém řádku.\n"
-"Přečtěte si soubor s nápovědou ve složce tohoto rozšíření pro získání "
-"informací, jak se získat zdarma Yandex API klíče."
+"Indtast en API-nøgle pr. linje.\n"
+"Læs hjælpfilen i denne udvidelses mappe for at finde ud af, hvordan man får "
+"gratis API-nøgler til Yandex."
 
 #: settings.py:413
 msgid "This options are only useful for the extension developer."
-msgstr "Tyto volby jsou užitečné pouze pro vývojáře rozšíření."
+msgstr "Disse indstillinger er kun nyttige for udvikleren af udvidelsen."
 
 #: settings.py:421
 msgid "Enable logging"
-msgstr "Povolit protokolování"
+msgstr "Aktivér logning"
 
 #: settings.py:422
 msgid ""
 "It enables the ability to log the output of several functions used by the "
 "extension."
 msgstr ""
-"Povoluje možnost logovat výstup z několika funkcí používaných rozšířením."
+"Tillader logning af outputtet fra adskillelige funktioner, som anvendes af "
+"udvidelsen."
 
 #: settings.py:428
 msgid "Indent translation history data"
-msgstr "Odsadit data historie překladu"
+msgstr "Indryk data i oversættelseshistorikken"
 
 #: settings.py:429
 msgid "It allows to save the translation history data with indentation."
-msgstr "Umožňuje ukládat data o historii překladu s odsazením."
+msgstr "Tillader at data i oversættelseshistorikken gemmes med indrykning."
 
 #: settings.py:874
 msgid "Select a directory to use"
-msgstr "Vybrat adresář pro použití"
+msgstr "Vælg en mappe, der skal bruges"
 
 #: settings.py:877
 msgid "Select a file"
-msgstr "Vybrat soubor"
+msgstr "Vælg en fil"
 
 #. TO TRANSLATORS: Could be left blank.
 #: settings.py:882 settings.py:1466 settings.py:1472
 msgid "_Cancel"
-msgstr "_Zrušit"
+msgstr "_Annullér"
 
 #. TO TRANSLATORS: Could be left blank.
 #: settings.py:884 settings.py:1474
 msgid "_Open"
-msgstr "_Otevřít"
+msgstr "_Åbn"
 
 #: settings.py:887
 msgid "Directories"
-msgstr "Adresáře"
+msgstr "Mapper"
 
 #: settings.py:947
 msgid "Shortcut action"
-msgstr "Akce pro klávesovou zkratku"
+msgstr "Genvejshandling"
 
 #: settings.py:961
 msgid "Shortcut"
-msgstr "Klávesová zkratka"
+msgstr "Genvej"
 
 #: settings.py:977
 msgid "Click to set a new hotkey."
-msgstr "Klepněte k nastavení nové klávesové zkratky."
+msgstr "Klik for at angive en ny genvejstast."
 
 #: settings.py:1038
 msgid "Default source language:"
-msgstr "Výchozí zdrojový jazyk:"
+msgstr "Standardsprog for indtastet tekst:"
 
 #: settings.py:1050
 msgid "Default target language:"
-msgstr "Výchozí cílový jazyk:"
+msgstr "Standardsprog for oversat tekst:"
 
 #: settings.py:1061
 msgid "Remember the last used languages:"
-msgstr "Pamatovat si poslední použité jazyky:"
+msgstr "Husk de sidst brugte sprog:"
 
 #: settings.py:1246
 msgid "Contributors/Mentions:"
-msgstr "Přispěvatelé/uznání:"
+msgstr "Bidragydere:"
 
 #. TO TRANSLATORS:
 #. Here goes the name/s of the author/s of the translations.
 #. Only e-mail addresses and links to GitHub accounts are allowed. NOTHING MORE.
 #: settings.py:1254
 msgid "translator-credits"
-msgstr "překladatelé-zásluhy"
+msgstr "Alan01 https://github.com/Alan01"
 
 #. TO TRANSLATORS: Full sentence:
 #. ExtensionName extension preferences
 #: settings.py:1324
 #, python-format
 msgid "%s extension preferences"
-msgstr "%s předvolby rozšíření"
+msgstr "Indstillinger for udvidelsen %s"
 
 #: settings.py:1370
 msgid "Reset settings to defaults"
-msgstr "Obnovit výchozí hodnoty"
+msgstr "Nulstil indstillingerne"
 
 #: settings.py:1372
 msgid "Import settings from a file"
-msgstr "Importovat nastavení ze souboru"
+msgstr "Importér indstillinger fra en fil"
 
 #: settings.py:1374
 msgid "Export settings to a file"
-msgstr "Exportovat nastavení do souboru"
+msgstr "Eksportér indstillinger til en fil"
 
 #: settings.py:1379
 msgid "Remember window size"
-msgstr "Pamatovat si velikost okna"
+msgstr "Husk vinduesstørrelse"
 
 #: settings.py:1387
 msgid "About"
-msgstr "O aplikaci"
+msgstr "Om"
 
 #: settings.py:1395
 msgid "Manage settings"
-msgstr "Spravovat nastavení"
+msgstr "Håndtér indstillinger"
 
 #. TO TRANSLATORS: Full sentence:
 #. Warning: Trying to reset all ExtensionName settings!!!
 #: settings.py:1447
 #, python-format
 msgid "Warning: Trying to reset all %s settings!!!"
-msgstr "Upozornění: Probíhá reset všech %s nastavení!!!"
+msgstr "Advarsel: Prøver at nulstille alle indstillinger for %s!!!"
 
 #. TO TRANSLATORS: Full sentence:
 #. Reset all ExtensionName settings to default?
 #: settings.py:1451
 #, python-format
 msgid "Reset all %s settings to default?"
-msgstr "Resetovat všechna %s nastavení na jejich výchozí hodnoty?"
+msgstr "Nulstil alle indstillinger for %s til deres standardværdier?"
 
 #: settings.py:1464
 msgid "Select or enter file to export to"
-msgstr "Vyberte nebo zadejte soubor, do něhož se bude exportovat"
+msgstr "Vælg eller indtast fil, der skal eksporteres til"
 
 #: settings.py:1467
 msgid "_Save"
-msgstr "_Uložit"
+msgstr "_Gem"
 
 #: settings.py:1470
 msgid "Select a file to import"
-msgstr "Vyberte soubor pro import"
+msgstr "Vælg en fil, der skal importeres"
 
 #: settings.py:1486
 msgid "DCONF files"
-msgstr "DCONF soubory"
+msgstr "DCONF-filer"
 
 #. TO TRANSLATORS: Could be left blank.
 #: settings.py:1534
@@ -1194,7 +1197,8 @@ msgstr "DCONF soubory"
 msgid ""
 "Please enter your password to install the required settings schema for %s"
 msgstr ""
-"Prosím zadejte své heslo k instalaci vyžadovaných nastavení schémat pro %s"
+"Indtast din adgangskode for at installere det krævede indstillingsskema til "
+"%s"
 
 #. TO TRANSLATORS: Could be left blank.
 #: settings.py:1545
@@ -1203,14 +1207,14 @@ msgid ""
 "Could not install the settings schema for %s.  You will have to perform this "
 "step yourself."
 msgstr ""
-"Nelze nainstalovat nastavení schémat pro %s. Tyto kroky musíte provést "
-"osobně."
+"Kunne ikke installere indstillingsskemaet til %s. Du må selv udføre dette "
+"trin."
 
 #. TO TRANSLATORS: Could be left blank.
 #: settings.py:1551
 #, python-format
 msgid "Please enter your password to remove the settings schema for %s"
-msgstr "Vložte prosím své heslo k odebrání nastavení schémat pro %s"
+msgstr "Indtast din adgangskode for at fjerne indstillingsskemaet til %s"
 
 #. TO TRANSLATORS: Could be left blank.
 #: settings.py:1562
@@ -1219,325 +1223,295 @@ msgid ""
 "Could not remove the settings schema for %s.  You will have to perform this "
 "step yourself.  This is not a critical error."
 msgstr ""
-"Nelze odebrat nastavení schémat pro %s. Tento krok budete muset provést "
-"osobně. Nejedná se o závažnou chybu."
+"Kunne ikke fjerne indstillingsskemaet til %s. Du må selv udføre dette trin. "
+"Dette er ikke en kritisk fejl."
 
 #: __init__.js:457
 #, javascript-format
 msgid "Schema %s could not be found for extension %s."
-msgstr "Schéma %s nemůže být nalezeno pro rozšíření %s."
+msgstr "Skemaet %s til udvidelsen %s kunne ikke findes."
 
 #: __init__.js:458
 msgid "Please check your installation."
-msgstr "Zkontrolujte prosím instalaci."
+msgstr "Tjek venligst din installation."
 
 #: __init__.js:857
 msgid "Icon and label are both false."
-msgstr "Ikona a popisek jsou chybné."
+msgstr "Ikon og etiket er begge forkert."
 
 #: __init__.js:1261
 msgid "Shortcuts"
-msgstr "Zkratky"
+msgstr "Genveje"
 
 #: __init__.js:1263
 msgid "Open translator dialog."
-msgstr "Otevřít dialog překladače."
+msgstr "Åbn oversættelsesvinduet."
 
 #: __init__.js:1265
 msgid "Open translator dialog and translate text from clipboard."
-msgstr "Otevřete dialog překladače a přeložit text ze schránky."
+msgstr "Åbn oversættelsesvinduet og oversæt teksten i udklipsholderen."
 
 #: __init__.js:1267
 msgid "Open translator dialog and translate from primary selection."
-msgstr "Otevřít dialog překladače a přeložit vybraný text."
+msgstr "Åbn oversættelsesvinduet og oversæt indholdet i den primære markering."
 
 #: __init__.js:1269
 msgid "Translate text."
-msgstr "Přeložit text."
+msgstr "Oversæt tekst."
 
 #: __init__.js:1271
 msgid "Force text translation. Ignores translation history."
-msgstr "Vynuťte překlad textu. Ignoruje historii překladů."
+msgstr "Gennemtving oversættelse af tekst. Ignorerer oversættelseshistorik."
 
 #: __init__.js:1273
 msgid "Copy translated text to clipboard."
-msgstr "Kopírovat přeložený text do schránky."
+msgstr "Kopiér oversat tekst til udklipsholderen."
 
 #: __init__.js:1275
 msgid "Swap languages."
-msgstr "Prohodit jazyky."
+msgstr "Ombyt sprog."
 
 #: __init__.js:1277
 msgid "Reset languages to default."
-msgstr "Resetovat jazyky do výchozího stavu."
+msgstr "Nulstil sprog til standard."
 
 #: __init__.js:1279
 msgid "Close dialog."
-msgstr "Zavřít dialog."
+msgstr "Luk vindue."
 
 #: __init__.js:1426
 msgid "Type to search..."
-msgstr "Vyhledávejte psaním..."
+msgstr "Skriv for at søge …"
 
 #: __init__.js:1639
 msgid "Most used languages​​."
-msgstr "Nejčastěji používané jazyky."
+msgstr "Hyppigst anvendte sprog."
 
 #: __init__.js:2117
 #, javascript-format
 msgid "Can't load preferences for %s"
-msgstr "Nelze načíst nastavení pro %s"
+msgstr "Kan ikke indlæse indstillinger for %s"
 
 #: __init__.js:2239 translation_providers/google_translation_provider.js:76
 #: translation_providers/transltr_translation_provider.js:66
 #: translation_providers/yandex_translation_provider.js:272
 msgid "Error"
-msgstr "Chyba"
+msgstr "Fejl"
 
 #. jshint ignore:line
 #: __init__.js:2297 __init__.js:2301
 msgid "Not implemented"
-msgstr "Není implementováno"
+msgstr "Ikke implementeret"
 
 #: __init__.js:3244
 msgid "Error executing translate-shell"
-msgstr "Vyskytla se chyba při spuštění translate-shell"
+msgstr "Fejl under kørsel af translate-shell"
 
 #: __init__.js:3433 __init__.js:3450
 msgid "Unmet dependencies found!!!"
-msgstr "Nalezeny nesplněné závislosti!!!"
+msgstr "Uopfyldte afhængigheder fundet!!!"
 
 #: __init__.js:3435 __init__.js:3452
 #: translation_providers/yandex_translation_provider.js:334
 msgid "Check this extension help file for instructions."
-msgstr ""
-"Zkontrolujte soubor s nápovědou tohoto rozšíření pro získání instrukcí."
+msgstr "Tjek denne udvidelses hjælpfil for instruktioner."
 
 #: __init__.js:3436
 msgid "It can be accessed from the translation dialog main menu."
-msgstr "Je přístupná z hlavní nabídky dialogového okna překladu."
+msgstr "Den kan tilgås fra oversættelsesvinduets hovedmenu."
 
 #: __init__.js:3441
 msgid "All dependencies seem to be met."
-msgstr "Všechny závislosti jsou splněny."
+msgstr "Alle afhængigheder ser ud til at være opfyldt."
 
 #: __init__.js:3453
 msgid ""
 "This information has also been logged into the ~/.cinnamon/glass.log file."
-msgstr "Tato informace byla zaznamenána také do ~/.cinnamon/glass.log souboru."
+msgstr "Denne information er også blevet logget i ~/.cinnamon/glass.log-filen."
 
 #. Just in case.
 #: __init__.js:3457 extension.js:589
 msgid "Extended help"
-msgstr "Rozšířená nápověda"
+msgstr "Udvidet hjælp"
 
 #: __init__.js:3497
 msgid "Press <Esc> to close"
-msgstr "Stiskněte <Esc> pro zavření"
+msgstr "Tryk <Esc> for at lukke"
 
 #: __init__.js:3549
 msgid "This translation provider doesn't require translate-shell to work."
-msgstr ""
-"Tento zprostředkovatel překladu nevyžaduje pro svou funkčnost translate-"
-"shell."
+msgstr "Denne oversættelsesudbyder kræver ikke translate-shell for at virke."
 
 #: __init__.js:3552
 msgid "This translation provider requires translate-shell to work."
-msgstr ""
-"Tento zprostředkovatel překladu vyžaduje pro svou funkčnost translate-shell."
+msgstr "Denne oversættelsesudbyder kræver translate-shell for at virke."
 
 #: extension.js:148 extension.js:406
 msgid "Choose source language"
-msgstr "Zvolit zdrojový jazyk"
+msgstr "Vælg sprog for indtastet tekst"
 
 #: extension.js:155 extension.js:436
 msgid "Choose target language"
-msgstr "Zvolit cílový jazyk"
+msgstr "Vælg sprog for oversat tekst"
 
 #: extension.js:200
 msgid "There is nothing to copy."
-msgstr "Není nic ke zkopírování."
+msgstr "Der er ikke noget at kopiere."
 
 #: extension.js:209
 msgid "Translated text copied to clipboard."
-msgstr "Přeložený text byl zkopírován do schránky."
+msgstr "Oversat tekst kopieret til udklipsholderen."
 
 #: extension.js:259
 #, javascript-format
 msgid "Go to %s's website"
-msgstr "Přejít na %s web"
+msgstr "Gå til webstedet for %s"
 
 #: extension.js:261
 #, javascript-format
 msgid "Service provided by %s"
-msgstr "Poskytovatel služby %s"
+msgstr "Tjeneste udbudt af %s"
 
 #. TO TRANSLATORS: Full sentence:
 #. "»From« source language to target language with service provider."
 #: extension.js:377 extension.js:401
 msgid "From"
-msgstr "Z"
+msgstr "Fra"
 
 #. TO TRANSLATORS: Full sentence:
 #. "From source language »to« target language with service provider."
 #: extension.js:386 extension.js:431
 msgid "to"
-msgstr "do"
+msgstr "til"
 
 #: extension.js:461
 msgid "Swap languages"
-msgstr "Prohodit jazyky"
+msgstr "Ombyt sprog"
 
 #: extension.js:485
 msgid "Choose translation provider"
-msgstr "Zvolit poskytovatele služby překladu."
+msgstr "Vælg udbyder af oversættelse"
 
 #: extension.js:533
 msgid "Go!"
-msgstr "Přeložit!"
+msgstr "Oversæt!"
 
 #: extension.js:534
 msgid "Translate text (<Ctrl> + <Enter>)"
-msgstr "Přeložit text (<Ctrl> + <Enter>)"
+msgstr "Oversæt tekst (<Ctrl> + <Enter>)"
 
 #: extension.js:551
 msgid "Main menu"
-msgstr "Hlavní menu"
+msgstr "Hovedmenu"
 
 #: extension.js:565
 msgid "Preferences"
-msgstr "Předvolby"
+msgstr "Indstillinger"
 
 #: extension.js:573
 msgid "Translation history"
-msgstr "Historie překladu"
+msgstr "Oversættelseshistorik"
 
 #: extension.js:581
 msgid "Check dependencies"
-msgstr "Zkontrolovat závislosti"
+msgstr "Tjek afhængigheder"
 
 #: extension.js:625
 msgid "Quick help"
-msgstr "Rychlá nápověda"
+msgstr "Hurtighjælp"
 
 #: extension.js:640
 msgid "Quit"
-msgstr "Ukončit"
+msgstr "Afslut"
 
 #. TO TRANSLATORS: Full sentence:
 #. "From source language to target language »with« service provider."
 #: extension.js:669
 msgid "with"
-msgstr "s"
+msgstr "med"
 
 #: extension.js:735
 msgid "Translating..."
-msgstr "Probíhá překlad..."
+msgstr "Oversætter ..."
 
 #: extension.js:793
 msgid "Clipboard is empty."
-msgstr "Schránka je prázdná."
+msgstr "Udklipsholderen er tom."
 
 #: extension.js:982
 msgid "Error trying to get theme"
-msgstr "Chyba při získávání motivu"
+msgstr "Fejl ved forsøg på at hente tema"
 
 #: extension.js:989
 msgid "Stylesheet parse error"
-msgstr "Chyba parsování stylu"
+msgstr "Fejl under fortolkning af typografiark (stylesheet)"
 
 #: extension.js:998
 msgid "Error unloading stylesheet"
-msgstr "Chyba načítání stylu"
+msgstr "Fejl ved fjernelse af typografiark (stylesheet)"
 
 #: translation_providers/apertium_ts_translation_provider.js:87
 #: translation_providers/bing_ts_translation_provider.js:87
 #: translation_providers/google_ts_translation_provider.js:88
 msgid "Error while parsing data"
-msgstr "Chyba parsování dat"
+msgstr "Fejl ved fortolkning af data"
 
 #: translation_providers/apertium_ts_translation_provider.js:120
 #: translation_providers/bing_ts_translation_provider.js:121
 #: translation_providers/google_ts_translation_provider.js:122
 msgid "Error while translating, check your internet connection"
-msgstr "Chyba při převodu, zkontrolujte připojení k Internetu"
+msgstr "Fejl under oversættelsen. Tjek din internetforbindelse"
 
 #: translation_providers/google_translation_provider.js:81
 #: translation_providers/transltr_translation_provider.js:71
 #: translation_providers/yandex_translation_provider.js:277
 msgid "Can't translate text, please try later."
-msgstr "Nelze přeložit text, zkuste to prosím později."
+msgstr "Kan ikke oversætte tekst. Prøv igen senere."
 
 #: translation_providers/yandex_translation_provider.js:293
 msgid "API key is invalid"
-msgstr "API klíč je neplatný"
+msgstr "API-nøglen er ugyldig"
 
 #: translation_providers/yandex_translation_provider.js:296
 msgid "Blocked API key"
-msgstr "Blokovaný API klíč"
+msgstr "Blokeret API-nøgle"
 
 #: translation_providers/yandex_translation_provider.js:299
 msgid "Exceeded the daily limit on the amount of translated text"
-msgstr "Překročen denní limit množství přeloženého textu"
+msgstr "Overskred den daglige grænse for oversættelse"
 
 #: translation_providers/yandex_translation_provider.js:302
 msgid "Exceeded the maximum text size"
-msgstr "Překročena maximální délka textu"
+msgstr "Overskred den maksimale tekststørrelse"
 
 #: translation_providers/yandex_translation_provider.js:305
 msgid "The text cannot be translated"
-msgstr "Text nemůže být přeložen"
+msgstr "Teksten kan ikke oversættes"
 
 #: translation_providers/yandex_translation_provider.js:308
 msgid "The specified translation direction is not supported"
-msgstr "Vybraný směr překladu není podporován"
+msgstr "Den angivne oversættelsesretning understøttes ikke"
 
 #: translation_providers/yandex_translation_provider.js:333
 msgid "No Yandex API keys were found!!!"
-msgstr "Žádné Yandex API klíče nebyly nalezeny!!!"
+msgstr "Der blev ikke fundet nogen API-nøgler til Yandex!!!"
 
 #. 0dyseus@MultiTranslatorExtension->metadata.json->description
 msgid ""
 "Translation of text by different translation providers (currently Google, "
 "Yandex, Bing and Apertium)."
 msgstr ""
-"Překlad textu různými poskytovateli překladu (v současné době Google, "
-"Yandex, Bing a Apertium)."
+"Oversættelse af tekst med forskellige udbydere (aktuelt Google, Yandex, Bing "
+"og Apertium)."
 
 #. 0dyseus@MultiTranslatorExtension->metadata.json->contributors
 msgid "See this xlet help file."
-msgstr "Viz soubor s nápovědou tohoto xletu."
+msgstr "Se denne udvidelses hjælpfil."
 
 #. 0dyseus@MultiTranslatorExtension->metadata.json->comments
 msgid ""
 "Bug reports, feature requests and contributions should be done on this "
 "xlet's repository linked below."
 msgstr ""
-"Zprávy o chybách, požadavky na funkce a příspěvky by měly být prováděny v "
-"repozitáři tohoto xletu, na který je odkaz níže."
-
-#~ msgid "muzena: Croatian localization https://github.com/muzena."
-#~ msgstr "muzena: Chorvatská lokalizace https://github.com/muzena."
-
-#~ msgid "giwhub: Chinese localization https://github.com/giwhub."
-#~ msgstr "giwhub: Čínská lokalizace https://github.com/giwhub."
-
-#~ msgid ""
-#~ "Radek71: Czech localization and author of Thunderbolt theme https://"
-#~ "github.com/Radek71."
-#~ msgstr ""
-#~ "Radek71: Česká lokalizace a Thunderbolt motiv https://github.com/Radek71."
-
-#~ msgid "NikoKrause: German localization https://github.com/NikoKrause."
-#~ msgstr "NikoKrause: Německá lokalizace https://github.com/NikoKrause."
-
-#~ msgid "eson57: Swedish localization."
-#~ msgstr "eson57: Švédská lokalizace."
-
-#~ msgid "Cinnamon Tweaks"
-#~ msgstr "Vylepšení Cinnamonu"
-
-#~ msgid "Reset all Multi Translator settings to default?"
-#~ msgstr ""
-#~ "Resetovat všechna nastavení Multi Translator rozšíření na jejich výchozí "
-#~ "hodnoty?"
+"Fejlrapporter, forslag til nye funktioner og bidrag bør ske i denne "
+"udvidelses arkiv, som der er linket til efterfølgende."


### PR DESCRIPTION
- Added Danish localization. Thanks to [Alan01](https://github.com/Alan01).
- Redesigned the creation of the help file to be "on-line friendly".
- Finally fixed the annoyance of having titles on the help files hidden behind the top navigation bar when clicking the navigation links (Help/Contributors/Changelog).
- Fixed the display of a translated sentence on the help files that was being displayed untranslated.
- Added smooth scrolling for the links on the navigation bar of the help files.
- Updated localization template, localizations and help file due to changes to the *help file creator* script.
- Added to the xlet README file links to the localized help file.