### PR TITLE
8 extensions: set authors to none

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,25 +6,25 @@
 0dyseus@MultiTranslatorExtension/*                 @Odyseus
 0dyseus@WindowDemandsAttentionBehavior/*           @Odyseus
 CinnaDockP2@norbusan/*                             @norbusan
-DesktopCube@yare/*                                 @yare
-Flipper@connerdev/*                                @ConnerHansen
 ShadowParameters@mikhail-ekzi/*                    @mikhail-ekzi
-blur-overview@nailfarmer.nailfarmer.com/*          @nailfarmer
 center-center-panel@mohammad-sn/*                  @mohammad-sn
-cinnamon-maximus@fmete/*                           @fmete
-desktop-scroller@ccadeptic23/*                     @ccadeptic23
-gTile@shuairan/*                                   @shuairan
 gnome2alttab@savagetiger.org/*                     @SavageTiger
-opacify@anish.org/*                                @AnishN
 opacity-fix@mohammad-sn/*                          @mohammad-sn
 rnbdsh@negateWindow/*                              @rnbdsh
 slider@mohammad-sn/*                               @mohammad-sn
 smart-panel@mohammad-sn/*                          @mohammad-sn
 transparent-panels@germanfr/*                      @germanfr
-workspace-scroller@ori/*                           @ori
 
 # The following xlets have no author assigned to them.
 # CinnaDockPlus@entelechy
+# DesktopCube@yare
+# Flipper@connerdev
 # Win7AltTab@entelechy
+# blur-overview@nailfarmer.nailfarmer.com
+# cinnamon-maximus@fmete
+# desktop-scroller@ccadeptic23
+# gTile@shuairan
+# opacify@anish.org
 # wobbly-windows@mecheye.net
 # workspace-grid@daemonl
+# workspace-scroller@ori

--- a/DesktopCube@yare/info.json
+++ b/DesktopCube@yare/info.json
@@ -1,1 +1,4 @@
-{"author": "yare"}
+{
+    "author": "none",
+    "original_author": "yare"
+}

--- a/Flipper@connerdev/info.json
+++ b/Flipper@connerdev/info.json
@@ -1,1 +1,4 @@
-{"author": "ConnerHansen"}
+{
+    "author": "none",
+    "original_author": "ConnerHansen"
+}

--- a/blur-overview@nailfarmer.nailfarmer.com/info.json
+++ b/blur-overview@nailfarmer.nailfarmer.com/info.json
@@ -1,1 +1,4 @@
-{"author": "nailfarmer"}
+{
+    "author": "none",
+    "original_author": "nailfarmer"
+}

--- a/cinnamon-maximus@fmete/info.json
+++ b/cinnamon-maximus@fmete/info.json
@@ -1,1 +1,4 @@
-{"author": "fmete"}
+{
+    "author": "none",
+    "original_author": "fmete"
+}

--- a/desktop-scroller@ccadeptic23/info.json
+++ b/desktop-scroller@ccadeptic23/info.json
@@ -1,1 +1,4 @@
-{"author": "ccadeptic23"}
+{
+    "author": "none",
+    "original_author": "ccadeptic23"
+}

--- a/gTile@shuairan/info.json
+++ b/gTile@shuairan/info.json
@@ -1,1 +1,4 @@
-{"author": "shuairan"}
+{
+    "author": "none",
+    "original_author": "shuairan"
+}

--- a/opacify@anish.org/info.json
+++ b/opacify@anish.org/info.json
@@ -1,1 +1,4 @@
-{"author": "AnishN"}
+{
+    "author": "none",
+    "original_author": "AnishN"
+}

--- a/workspace-scroller@ori/info.json
+++ b/workspace-scroller@ori/info.json
@@ -1,1 +1,4 @@
-{"author": "ori"}
+{
+    "author": "none",
+    "original_author": "ori"
+}


### PR DESCRIPTION
@yare @ConnerHansen @fmete @ccadeptic23 @shuairan @AnishN @ori

Set authors of abandoned applets to `Update`

none CODEOWNERS

[DesktopCube@yare](https://cinnamon-spices.linuxmint.com/extensions/view/27)
[Flipper@connerdev](https://cinnamon-spices.linuxmint.com/extensions/view/36)
[blur-overview@nailfarmer.nailfarmer.com](https://cinnamon-spices.linuxmint.com/extensions/view/14)
[cinnamon-maximus@fmete](https://cinnamon-spices.linuxmint.com/extensions/view/29)
[desktop-scroller@ccadeptic23](https://cinnamon-spices.linuxmint.com/extensions/view/17)
[gTile@shuairan](https://cinnamon-spices.linuxmint.com/extensions/view/21)
[opacify@anish.org](https://cinnamon-spices.linuxmint.com/extensions/view/25)
[workspace-scroller@ori](https://cinnamon-spices.linuxmint.com/extensions/view/38)