### PR TITLE
Update Watermark v3.6 (watermark@germanfr)

### DIFF
--- a/watermark@germanfr/files/watermark@germanfr/extension.js
+++ b/watermark@germanfr/files/watermark@germanfr/extension.js
@@ -90,6 +90,7 @@ MyExtension.prototype = {
 
 	_detect_os: function() {
 		let cmd = [this.meta.path + '/os-detection.sh', this.meta.path + '/icons'];
+		Util.spawn(['chmod', 'u+x', cmd[0]]);
 		Util.spawn_async(cmd, os_name => {
 			if(os_name) {
 				this.path_name = os_name;


### PR DESCRIPTION
Changelog at: https://github.com/germanfr/watermark-cinnamon/commits/master

Sorry for PRing again. I didn't notice this until you merged the previous PR and I realized that the execution permission of files is not present after downloading from the spices. This is needed in order to detect the distribution to show it's logo by default.