### PR TITLE
gTile@shuairan: Reset tile mode before resizing window

### DIFF
--- a/gTile@shuairan/files/gTile@shuairan/extension.js
+++ b/gTile@shuairan/files/gTile@shuairan/extension.js
@@ -282,6 +282,7 @@ function reset_window(metaWindow) {
   metaWindow.unmaximize(Meta.MaximizeFlags.HORIZONTAL);
   metaWindow.unmaximize(Meta.MaximizeFlags.VERTICAL);
   metaWindow.unmaximize(Meta.MaximizeFlags.HORIZONTAL | Meta.MaximizeFlags.VERTICAL);
+  metaWindow.tile(Meta.WindowTileType.NONE, false);
 }
 
 function _getInvisibleBorderPadding(metaWindow) {


### PR DESCRIPTION
Windows that are tiled or snapped by the Muffin window manager can't be
resized or moved. Reset the tile mode before resizing the window.