### PR TITLE
cinnamon-maximus@fmete: remove some hacks

### DIFF
--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
@@ -113,7 +113,7 @@ let settings = null;
 
 let APP_LIST;
 let IS_BLACKLIST;
-let USE_SET_HIDE_TITLEBAR;
+let USE_SET_HIDE_TITLEBAR = false;
 
 
 function LOG(message) {

--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/metadata.json
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/metadata.json
@@ -1,11 +1,6 @@
 {
     "name": "Cinnamon Maximus",
     "cinnamon-version": [
-        "1.8",
-        "1.9",
-        "2.0",
-        "2.1",
-        "2.2",
         "2.4",
         "2.6",
         "2.8",
@@ -13,7 +8,9 @@
         "3.2",
         "3.4",
         "3.6",
-        "3.8"
+        "3.8",
+        "4.0",
+        "4.2"
     ],
     "url": "linuxmint.com",
     "description": "Undecorate windows its maximised.",

--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/metadata.json
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/metadata.json
@@ -14,6 +14,6 @@
     ],
     "url": "linuxmint.com",
     "description": "Undecorate windows its maximised.",
-    "last-edited": "1567173257",
+    "last-edited": "1567774600",
     "uuid": "cinnamon-maximus@fmete"
 }


### PR DESCRIPTION
Current version of the maximus uses the compex way to determine the identificator of XWindow, including calls of `spawn_command_line_sync()` function. From version 2.4 of the muffin there is a suitable `get_xwindow()` method. Now we can use it. It's more simple and safe. Also it removes the warning of usage of unsafe functions.

The `_GTK_HIDE_TITLEBAR_WHEN_MAXIMIZED` hint has been removed several months ago from the mutter, so better don't use it now to avoid unexpected behavior in future version.

Also there are code style improvements like usage of double quotes for strings, more clear variable names etc.

Last patch removes outdated comments.