### PR TITLE
gTile@shuairan: Add Cinnamon 4.2 to compatibility list

### DIFF
--- a/gTile@shuairan/files/gTile@shuairan/metadata.json
+++ b/gTile@shuairan/files/gTile@shuairan/metadata.json
@@ -1,5 +1,5 @@
 {
-    "cinnamon-version": ["3.6", "3.8", "4.0"],
+    "cinnamon-version": ["3.6", "3.8", "4.0", "4.2"],
     "uuid": "gTile@shuairan",
     "name": "gTile",
     "description": "Tile your windows as you like.",


### PR DESCRIPTION
Tested with Cinnamon 4.2.4 in Fedora 30. Can't reproduce the issues mentioned in #220.