### PR TITLE
gTile@shuairan: Add Cinnamon 4.4 to compatibility list

### DIFF
--- a/gTile@shuairan/files/gTile@shuairan/metadata.json
+++ b/gTile@shuairan/files/gTile@shuairan/metadata.json
@@ -1,5 +1,5 @@
 {
-    "cinnamon-version": ["3.6", "3.8", "4.0", "4.2"],
+    "cinnamon-version": ["3.6", "3.8", "4.0", "4.2", "4.4"],
     "uuid": "gTile@shuairan",
     "name": "gTile",
     "description": "Tile your windows as you like.",


### PR DESCRIPTION
Successfully tested with Cinnamon 4.4.2 in Fedora 30.