### PR TITLE
cinnamon-maximus@fmete: hotkey to toggle decoration of active window

### DIFF
--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/settings-schema.json
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/settings-schema.json
@@ -1,28 +1,41 @@
 {
- "head" : {
+  "head" : {
     "type" : "header",
     "description" : "Cinnamon-Maximus Settings"
- },
- "undecorateTile" : {
-      "type" : "checkbox",
-      "default" : false,
-      "description": "Undecorate when tile"
-   },
- "undecorateAll" : {
-      "type" : "checkbox",
-      "default" : false,
-      "description": "Undecorate All Windows (Experimental, please close and re-open all windows)"
- },
- "blacklist" : {
-      "type" : "checkbox",
-      "default" : false,
-      "description": "Use Blacklist"
-   },
+  },
+  "useHotkey" : {
+    "type" : "checkbox",
+    "default" : false,
+    "description": "Use Hotkey to toggle decoration of current window"
+  },
+  "hotkey": {
+    "type" : "keybinding",
+    "default" : "<Super>u",
+    "description" : "Global Hotkey to toggle decoration of current window (Experimental)"
+  },
+  "undecorateTile" : {
+    "type" : "checkbox",
+    "default" : false,
+    "description": "Undecorate when tile"
+  },
+  "undecorateAll" : {
+    "type" : "checkbox",
+    "default" : false,
+    "description": "Undecorate All Windows (Experimental, please close and re-open all windows)"
+  },
+  "blacklist" : {
+    "type" : "checkbox",
+    "default" : false,
+    "description": "Use Blacklist"
+  },
   "blacklist_apps": {
-        "type": "entry", 
-        "description": "Blacklist Apps (\"Recheck Blacklist Active\", please use \",\" for seperate apps)", 
-        "default": "chromium"
+    "type": "entry",
+    "description": "Blacklist Apps (\"Recheck Blacklist Active\", please use \",\" for seperate apps)",
+    "default": "chromium"
+  },
+  "enableLogs" : {
+    "type" : "checkbox",
+    "default" : false,
+    "description": "Logging (see Melange - Log)"
   }
-  
- 
 }


### PR DESCRIPTION
1. add toggle decoration hotkey settings (<super>+u by default)
2. add setting to enable the logging
3. improve indentations of the settings-schema.json
4. fix the typo in the comment
5. settings initialization in alphabet order