### PR TITLE
cinnamon-maximus@fmete: various improvements and fixes

### DIFF
--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
@@ -277,7 +277,7 @@ function shouldAffect(win) {
  *
  * Use with `shouldAffect` to get a full check..
  */
-function shouldBeUndecorated(win) {
+function isFullyMaximized(win) {
     let max = win.get_maximized();
     return ((max === Meta.MaximizeFlags.BOTH));
 }
@@ -293,7 +293,7 @@ function isHalfMaximized(win) {
 /** Checks if `win` is fully maximised, or half-maximised + undecorateHalfMaximised.
  * If so, undecorates the window. */
 function possiblyUndecorate(win) {
-    if (shouldBeUndecorated(win)) {
+    if (isFullyMaximized(win)) {
         if (!win.get_compositor_private()) {
             Mainloop.idle_add(function () {
                 undecorate(win);
@@ -308,7 +308,7 @@ function possiblyUndecorate(win) {
 /** Checks if `win` is fully maximised, or half-maximised + undecorateHalfMaximised.
  * If *NOT*, redecorates the window. */
 function possiblyRedecorate(win) {
-    if (!shouldBeUndecorated(win)) {
+    if (!isFullyMaximized(win)) {
         if (!win.get_compositor_private()) {
             Mainloop.idle_add(function () {
                 decorate(win);

--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
@@ -290,7 +290,7 @@ function isHalfMaximized(win) {
     return ((max === Meta.MaximizeFlags.VERTICAL) || (max === Meta.MaximizeFlags.HORIZONTAL));
 }
 
-/** Checks if `win` is fully maximized, or half-maximized + undecorateHalfMaximized.
+/** Checks if `win` is fully maximized.
  * If so, undecorates the window. */
 function possiblyUndecorate(win) {
     if (isFullyMaximized(win)) {
@@ -305,7 +305,7 @@ function possiblyUndecorate(win) {
     }
 }
 
-/** Checks if `win` is fully maximized, or half-maximized + undecorateHalfMaximized.
+/** Checks if `win` is fully maximized.
  * If *NOT*, redecorates the window. */
 function possiblyRedecorate(win) {
     if (!isFullyMaximized(win)) {

--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
@@ -312,6 +312,10 @@ function shouldAffect(win) {
         }
     }
 
+    if (isHalfMaximized(win)) {
+        verdict = false;
+    }
+
     return verdict;
 }
 
@@ -326,6 +330,11 @@ function shouldAffect(win) {
 function shouldBeUndecorated(win) {
     let max = win.get_maximized();
     return ((max === Meta.MaximizeFlags.BOTH));
+}
+
+function isHalfMaximized(win) {
+    let max = win.get_maximized();
+    return ((max === Meta.MaximizeFlags.VERTICAL) || (max === Meta.MaximizeFlags.HORIZONTAL));
 }
 
 /** Checks if `win` is fully maximised, or half-maximised + undecorateHalfMaximised.

--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
@@ -116,9 +116,10 @@ let blacklistEnabled;
 let useHideTitlebarHint = false;
 
 
-function logMessage(message, logEnable = false) {
-    if (logEnable)
-        global.log(message);
+function logMessage(message, alwaysLog = false) {
+    if (alwaysLog || settings.enableLogs) {
+        global.log("[maximus] " + message);
+    }
 }
 
 /** Guesses the X ID of a window.
@@ -135,7 +136,7 @@ function guessWindowXID(win) {
     } catch (err) {
     }
     // debugging for when people find bugs.. always logging this message.
-    logMessage("[maximus]: Could not find XID for window with title %s".format(win.title), settings.enableLogs);
+    logMessage("[maximus]: Could not find XID for window with title %s".format(win.title), true);
     return null;
 }
 
@@ -687,16 +688,16 @@ function toggleDecorActiveWindow() {
     let win = global.display.focus_window;
     if (win) {
         if (win._maximusUndecorated !== true) {
-            logMessage("undecorate: win " + win.get_title(), " _maximusDecoratedState: " + win._maximusUndecorated, settings.enableLogs);
+            logMessage("undecorate: win " + win.get_title() + " _maximusDecoratedState: " + win._maximusUndecorated);
             undecorate(win);
             win._maximusUndecorated = true;
         } else {
-            logMessage("decorate: win " + win.get_title(), " _maximusDecoratedState: " + win._maximusUndecorated, settings.enableLogs);
+            logMessage("decorate: win " + win.get_title() + " _maximusDecoratedState: " + win._maximusUndecorated);
             decorate(win);
             win._maximusUndecorated = false;
         }
     } else {
-        logMessage("active window not found!", settings.enableLogs);
+        logMessage("active window not found!");
     }
     return true;
 }

--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
@@ -1,15 +1,15 @@
-//Cinnamon Extension: Cinnamon-Maximus v0.3.1
-//Release Date: 22 Nov 2014
-//
-//Author: Fatih Mete
-//
-//          Email: fatihmete@live.com
-
-//This extension adopted for cinnamon, maximus-gnome-shell-extension
-//https://bitbucket.org/mathematicalcoffee/maximus-gnome-shell-extension/overview
-/*global global, log */ // <-- jshint
-/*jshint unused:true */
-/*
+/* Cinnamon Extension: Cinnamon-Maximus v0.4.0
+ * Release Date: 2020.07.17
+ *
+ * Author:
+ * - Fatih Mete <fatihmete@live.com>
+ *
+ * Other contributors:
+ * - Anton Danilov <littlesmilingcloud@gmail.com>
+ *
+ * This extension adopted for cinnamon, maximus-gnome-shell-extension
+ * https://bitbucket.org/mathematicalcoffee/maximus-gnome-shell-extension/overview
+ *
  * Maximus v2.1
  * Amy Chan <mathematical.coffee@gmail.com>
  * Other contributors:

--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
@@ -330,7 +330,7 @@ function possiblyRedecorate(win) {
  * It is expected to be maximized (in at least one direction) already - we will
  * not check before undecorating.
  */
-function onMaximise(shellwm, actor) {
+function onMaximize(shellwm, actor) {
     if (!actor) {
         return;
     }
@@ -339,7 +339,7 @@ function onMaximise(shellwm, actor) {
         return;
     }
     // note: window is maximized by this point.
-    logMessage("onMaximise: " + win.get_title() + " [" + win.get_wm_class() + "]");
+    logMessage("onMaximize: " + win.get_title() + " [" + win.get_wm_class() + "]");
     undecorate(win);
 }
 
@@ -351,7 +351,7 @@ function onMaximise(shellwm, actor) {
  * @param {Meta.WindowActor} actor - the window actor for the unmaximized window.
  * It is expected to be unmaximized - we will not check before decorating.
  */
-function onUnmaximise(shellwm, actor) {
+function onUnmaximize(shellwm, actor) {
 
     if (!actor) {
         return;
@@ -360,7 +360,7 @@ function onUnmaximise(shellwm, actor) {
     if (!shouldAffect(win)) {
         return;
     }
-    logMessage("onUnmaximise: " + win.get_title());
+    logMessage("onUnmaximize: " + win.get_title());
     // if the user is unmaximizing by dragging, we wait to decorate until they
     // have dropped the window, so that we don't force the user to drop
     // the window prematurely with the redecorate (which stops the grab).
@@ -468,10 +468,10 @@ function startUndecorating() {
     changeNWorkspacesEventID = global.screen.connect("notify::n-workspaces", onChangeNWorkspaces);
 
     // we must listen to maximize and unmaximize events.
-    maximizeEventID = global.window_manager.connect("maximize", onMaximise);
-    minimizeEventID = global.window_manager.connect("unmaximize", onUnmaximise);
+    maximizeEventID = global.window_manager.connect("maximize", onMaximize);
+    minimizeEventID = global.window_manager.connect("unmaximize", onUnmaximize);
     if (settings.undecorateTile == true) {
-        tileEventID = global.window_manager.connect("tile", onMaximise);
+        tileEventID = global.window_manager.connect("tile", onMaximize);
     }
     /* this is needed to prevent Metacity from interpreting an attempted drag
      * of an undecorated window as a fullscreen request. Otherwise thunderbird
@@ -491,10 +491,10 @@ function startUndecorating() {
      * This needs a delay as the window list is not yet loaded
      *  when the extension is loaded.
      * Also, connect up the 'window-added' event.
-     * Note that we do not connect this before the onMaximise loop
+     * Note that we do not connect this before the onMaximize loop
      *  because when one restarts the gnome-shell, window-added gets
      *  fired for every currently-existing window, and then
-     *  these windows will have onMaximise called twice on them.
+     *  these windows will have onMaximize called twice on them.
      */
     idleTimerID = Mainloop.idle_add(function () {
         let winList = global.get_window_actors().map(function (w) { return w.meta_window; }),

--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
@@ -19,7 +19,7 @@
  * This extension attempts to emulate the Maximus package[1] that
  * Ubuntu Netbook Remix had, back when people still used that.
  *
- * Basically whenever a window is maximised, its window decorations (title
+ * Basically whenever a window is maximized, its window decorations (title
  * bar, etc) are hidden so as to space a bit of vertical screen real-estate.
  *
  * This may sound petty, but believe me, on a 10" netbook it's fantastic!
@@ -27,19 +27,19 @@
  * you already have the current application's name in the top bar and can
  * even get the window's title with the StatusTitleBar extension[2].
  *
- * Note that since the title bar for the window is gone when it's maximised,
- * you might find it difficult to unmaximise the window.
+ * Note that since the title bar for the window is gone when it's maximized,
+ * you might find it difficult to unmaximize the window.
  * In this case, I recommend either the Window Options shell extension[3] which
- * adds the minimise/restore/maximise/etc window menu to your title bar (NOTE:
+ * adds the minimize/restore/maximize/etc window menu to your title bar (NOTE:
  * I wrote that, so it's a shameless plug),  OR
- * refresh your memory on your system's keyboard shortcut for unmaximising a window
- * (for me it's Ctrl + Super + Down to unmaximise, Ctrl + Super + Up to maximise).
+ * refresh your memory on your system's keyboard shortcut for unmaximizing a window
+ * (for me it's Ctrl + Super + Down to unmaximize, Ctrl + Super + Up to maximize).
  *
  * Small idiosyncracies:
  * Note - these are simple enough for me to implement so if enough people let
  * me know that they want this behaviour, I'll do it.
  *
- * * the original Maximus also maximised all windows on startup.
+ * * the original Maximus also maximized all windows on startup.
  *   This doesn't (it was annoying).
  *
  * Help! It didn't work/I found a bug!
@@ -65,7 +65,7 @@
  *
  *
  * Note:
- * It's actually possible to get the undecorate-on-maximise behaviour without
+ * It's actually possible to get the undecorate-on-maximize behaviour without
  * needing this extension. See the link [5] and in particular, the bit on editing
  * your metacity theme metacity-theme-3.xml. ("Method 2: editing the theme").
  *
@@ -270,7 +270,7 @@ function shouldAffect(win) {
     return verdict;
 }
 
-/** Checks if `win` should be undecorated, based *purely* off its maximised
+/** Checks if `win` should be undecorated, based *purely* off its maximized
  * state (doesn't incorporate blacklist).
  *
  * If it's fully-maximized this returns true.
@@ -290,7 +290,7 @@ function isHalfMaximized(win) {
     return ((max === Meta.MaximizeFlags.VERTICAL) || (max === Meta.MaximizeFlags.HORIZONTAL));
 }
 
-/** Checks if `win` is fully maximised, or half-maximised + undecorateHalfMaximised.
+/** Checks if `win` is fully maximized, or half-maximized + undecorateHalfMaximized.
  * If so, undecorates the window. */
 function possiblyUndecorate(win) {
     if (isFullyMaximized(win)) {
@@ -305,7 +305,7 @@ function possiblyUndecorate(win) {
     }
 }
 
-/** Checks if `win` is fully maximised, or half-maximised + undecorateHalfMaximised.
+/** Checks if `win` is fully maximized, or half-maximized + undecorateHalfMaximized.
  * If *NOT*, redecorates the window. */
 function possiblyRedecorate(win) {
     if (!isFullyMaximized(win)) {
@@ -487,7 +487,7 @@ function startUndecorating() {
     Meta.prefs_set_force_fullscreen(false);
 
 
-    /* Go through already-maximised windows & undecorate.
+    /* Go through already-maximized windows & undecorate.
      * This needs a delay as the window list is not yet loaded
      *  when the extension is loaded.
      * Also, connect up the 'window-added' event.

--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
@@ -114,6 +114,12 @@ let settings = null;
 let blacklistApps;
 let blacklistEnabled;
 
+/** Logging helper function
+ *
+ * Writes the log message with additional prefix depends on settings.
+ * If the log message should be write unconditionally, just pass `true`
+ * in the second parameter.
+ */
 function logMessage(message, alwaysLog = false) {
     if (alwaysLog || settings.enableLogs) {
         global.log("[maximus] " + message);
@@ -267,8 +273,7 @@ function shouldAffect(win) {
 /** Checks if `win` should be undecorated, based *purely* off its maximised
  * state (doesn't incorporate blacklist).
  *
- * If it's fully-maximized or half-maximised and undecorateHalfMaximised is true,
- * this returns true.
+ * If it's fully-maximized this returns true.
  *
  * Use with `shouldAffect` to get a full check..
  */
@@ -277,6 +282,9 @@ function shouldBeUndecorated(win) {
     return ((max === Meta.MaximizeFlags.BOTH));
 }
 
+/** Checks if `win` is half-maximized (only vertically or horizontally)
+ *
+ */
 function isHalfMaximized(win) {
     let max = win.get_maximized();
     return ((max === Meta.MaximizeFlags.VERTICAL) || (max === Meta.MaximizeFlags.HORIZONTAL));

--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
@@ -331,14 +331,7 @@ function onMaximise(shellwm, actor) {
         return;
     }
     // note: window is maximized by this point.
-    let max = win.get_maximized();
     logMessage("onMaximise: " + win.get_title() + " [" + win.get_wm_class() + "]");
-    // if this is a partial maximization, and we do not wish to undecorate
-    // half-maximized windows, make sure the window is decorated.
-    if (max !== Meta.MaximizeFlags.BOTH) {
-        undecorate(win);
-        return;
-    }
     undecorate(win);
 }
 

--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/metadata.json
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/metadata.json
@@ -16,6 +16,7 @@
     ],
     "url": "linuxmint.com",
     "description": "Undecorate windows its maximised.",
-    "last-edited": "1589528491",
+    "version": "0.4.0",
+    "last-edited": "1595014975",
     "uuid": "cinnamon-maximus@fmete"
 }

--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/metadata.json
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/metadata.json
@@ -16,7 +16,7 @@
     ],
     "url": "linuxmint.com",
     "description": "Undecorate windows its maximised.",
-    "version": "0.4.0",
-    "last-edited": "1595014975",
+    "version": "0.4.1",
+    "last-edited": "1595018210",
     "uuid": "cinnamon-maximus@fmete"
 }

--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/settings-schema.json
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/settings-schema.json
@@ -33,6 +33,11 @@
     "description": "Blacklist Apps (use \",\" for seperate apps, partial match!)",
     "default": "chromium"
   },
+  "keepQTAppsFocus" : {
+    "type" : "checkbox",
+    "default" : false,
+    "description": "Keep the focus for QT Apps (Experimental)"
+  },
   "enableLogs" : {
     "type" : "checkbox",
     "default" : false,

--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/settings-schema.json
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/settings-schema.json
@@ -30,7 +30,7 @@
   },
   "blacklist_apps": {
     "type": "entry",
-    "description": "Blacklist Apps (\"Recheck Blacklist Active\", please use \",\" for seperate apps)",
+    "description": "Blacklist Apps (use \",\" for seperate apps, partial match!)",
     "default": "chromium"
   },
   "enableLogs" : {


### PR DESCRIPTION
Various improvements:
1. Fix the undecorating of half-maximized windows (#277)
2. Remove the code related with usage of  `_GTK_HIDE_TITLEBAR_WHEN_MAXIMIZED`, that has been disabled some time ago.
3. List of ignored applications is translating to regular expression. It brings the partial-match and case-insensitive.
4. Fix the spelling of 'maximize'. The API uses this spelling, so bring it to uniformity.
5. Small code improvements like function renames.
6. Actualize the comments
7. Add the version string into the metadata.
