### PR TITLE
cinnamon-maximus@fmete: fix the metadata

### DIFF
--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/metadata.json
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/metadata.json
@@ -14,9 +14,8 @@
         "4.4",
         "4.6"
     ],
-    "url": "linuxmint.com",
-    "description": "Undecorate windows its maximised.",
+    "description": "Undecorate windows as you like.",
     "version": "0.4.1",
-    "last-edited": "1595018210",
-    "uuid": "cinnamon-maximus@fmete"
+    "uuid": "cinnamon-maximus@fmete",
+    "url": "https://cinnamon-spices.linuxmint.com/extensions"
 }


### PR DESCRIPTION
Due the `last-edited` attribute the `about` message box wasn't being shown. Removed.
Also actualize the `url` info.