### PR TITLE
gTile@shuairan: Change layout in settings dialog

### DIFF
--- a/gTile@shuairan/files/gTile@shuairan/po/da.po
+++ b/gTile@shuairan/files/gTile@shuairan/po/da.po
@@ -32,15 +32,15 @@ msgstr "gTile"
 #. gTile@shuairan->settings-schema.json->gridbutton4x->description
 #. gTile@shuairan->settings-schema.json->gridbutton3x->description
 #. gTile@shuairan->settings-schema.json->gridbutton1x->description
-msgid "Cols "
+msgid "Columns"
 msgstr "Kolonner"
 
 #. gTile@shuairan->settings-schema.json->gridbutton2x->units
 #. gTile@shuairan->settings-schema.json->gridbutton4x->units
 #. gTile@shuairan->settings-schema.json->gridbutton3x->units
 #. gTile@shuairan->settings-schema.json->gridbutton1x->units
-msgid "x "
-msgstr "x "
+msgid "x"
+msgstr "x"
 
 #. gTile@shuairan->settings-schema.json->gridbutton2y->description
 #. gTile@shuairan->settings-schema.json->gridbutton4y->description
@@ -53,23 +53,23 @@ msgstr "Rækker"
 #. gTile@shuairan->settings-schema.json->gridbutton4y->units
 #. gTile@shuairan->settings-schema.json->gridbutton3y->units
 #. gTile@shuairan->settings-schema.json->gridbutton1y->units
-msgid "y "
-msgstr "y "
+msgid "y"
+msgstr "y"
 
 #. gTile@shuairan->settings-schema.json->header2->description
-msgid "Button 2:"
+msgid "Layout for Button 2:"
 msgstr "Knap 2:"
 
 #. gTile@shuairan->settings-schema.json->header3->description
-msgid "Button 3:"
+msgid "Layout for Button 3:"
 msgstr "Knap 3:"
 
 #. gTile@shuairan->settings-schema.json->header1->description
-msgid "Button 1:"
+msgid "Layout for Button 1:"
 msgstr "Knap 1:"
 
 #. gTile@shuairan->settings-schema.json->header4->description
-msgid "Button 4:"
+msgid "Layout for Button 4:"
 msgstr "Knap 4:"
 
 #. gTile@shuairan->settings-schema.json->autoclose->description

--- a/gTile@shuairan/files/gTile@shuairan/po/gTile@shuairan.pot
+++ b/gTile@shuairan/files/gTile@shuairan/po/gTile@shuairan.pot
@@ -29,14 +29,14 @@ msgstr ""
 #. gTile@shuairan->settings-schema.json->gridbutton4x->description
 #. gTile@shuairan->settings-schema.json->gridbutton3x->description
 #. gTile@shuairan->settings-schema.json->gridbutton1x->description
-msgid "Cols "
+msgid "Columns"
 msgstr ""
 
 #. gTile@shuairan->settings-schema.json->gridbutton2x->units
 #. gTile@shuairan->settings-schema.json->gridbutton4x->units
 #. gTile@shuairan->settings-schema.json->gridbutton3x->units
 #. gTile@shuairan->settings-schema.json->gridbutton1x->units
-msgid "x "
+msgid "x"
 msgstr ""
 
 #. gTile@shuairan->settings-schema.json->gridbutton2y->description
@@ -50,23 +50,23 @@ msgstr ""
 #. gTile@shuairan->settings-schema.json->gridbutton4y->units
 #. gTile@shuairan->settings-schema.json->gridbutton3y->units
 #. gTile@shuairan->settings-schema.json->gridbutton1y->units
-msgid "y "
+msgid "y"
 msgstr ""
 
 #. gTile@shuairan->settings-schema.json->header2->description
-msgid "Button 2:"
+msgid "Layout for Button 2:"
 msgstr ""
 
 #. gTile@shuairan->settings-schema.json->header3->description
-msgid "Button 3:"
+msgid "Layout for Button 3:"
 msgstr ""
 
 #. gTile@shuairan->settings-schema.json->header1->description
-msgid "Button 1:"
+msgid "Layout for Button 1:"
 msgstr ""
 
 #. gTile@shuairan->settings-schema.json->header4->description
-msgid "Button 4:"
+msgid "Layout for Button 4:"
 msgstr ""
 
 #. gTile@shuairan->settings-schema.json->autoclose->description

--- a/gTile@shuairan/files/gTile@shuairan/po/hu.po
+++ b/gTile@shuairan/files/gTile@shuairan/po/hu.po
@@ -30,15 +30,15 @@ msgstr "gTile"
 #. gTile@shuairan->settings-schema.json->gridbutton4x->description
 #. gTile@shuairan->settings-schema.json->gridbutton3x->description
 #. gTile@shuairan->settings-schema.json->gridbutton1x->description
-msgid "Cols "
-msgstr "Oszlopok "
+msgid "Columns"
+msgstr "Oszlopok"
 
 #. gTile@shuairan->settings-schema.json->gridbutton2x->units
 #. gTile@shuairan->settings-schema.json->gridbutton4x->units
 #. gTile@shuairan->settings-schema.json->gridbutton3x->units
 #. gTile@shuairan->settings-schema.json->gridbutton1x->units
-msgid "x "
-msgstr "x "
+msgid "x"
+msgstr "x"
 
 #. gTile@shuairan->settings-schema.json->gridbutton2y->description
 #. gTile@shuairan->settings-schema.json->gridbutton4y->description
@@ -51,23 +51,23 @@ msgstr "Sorok"
 #. gTile@shuairan->settings-schema.json->gridbutton4y->units
 #. gTile@shuairan->settings-schema.json->gridbutton3y->units
 #. gTile@shuairan->settings-schema.json->gridbutton1y->units
-msgid "y "
-msgstr "y "
+msgid "y"
+msgstr "y"
 
 #. gTile@shuairan->settings-schema.json->header2->description
-msgid "Button 2:"
+msgid "Layout for Button 2:"
 msgstr "Gomb 2:"
 
 #. gTile@shuairan->settings-schema.json->header3->description
-msgid "Button 3:"
+msgid "Layout for Button 3:"
 msgstr "Gomb 3:"
 
 #. gTile@shuairan->settings-schema.json->header1->description
-msgid "Button 1:"
+msgid "Layout for Button 1:"
 msgstr "Gomb 1:"
 
 #. gTile@shuairan->settings-schema.json->header4->description
-msgid "Button 4:"
+msgid "Layout for Button 4:"
 msgstr "Gomb 4:"
 
 #. gTile@shuairan->settings-schema.json->autoclose->description

--- a/gTile@shuairan/files/gTile@shuairan/po/it.po
+++ b/gTile@shuairan/files/gTile@shuairan/po/it.po
@@ -30,15 +30,15 @@ msgstr "gTile"
 #. gTile@shuairan->settings-schema.json->gridbutton4x->description
 #. gTile@shuairan->settings-schema.json->gridbutton3x->description
 #. gTile@shuairan->settings-schema.json->gridbutton1x->description
-msgid "Cols "
-msgstr "Colonne "
+msgid "Columns"
+msgstr "Colonne"
 
 #. gTile@shuairan->settings-schema.json->gridbutton2x->units
 #. gTile@shuairan->settings-schema.json->gridbutton4x->units
 #. gTile@shuairan->settings-schema.json->gridbutton3x->units
 #. gTile@shuairan->settings-schema.json->gridbutton1x->units
-msgid "x "
-msgstr "x "
+msgid "x"
+msgstr "x"
 
 #. gTile@shuairan->settings-schema.json->gridbutton2y->description
 #. gTile@shuairan->settings-schema.json->gridbutton4y->description
@@ -51,23 +51,23 @@ msgstr "Righe"
 #. gTile@shuairan->settings-schema.json->gridbutton4y->units
 #. gTile@shuairan->settings-schema.json->gridbutton3y->units
 #. gTile@shuairan->settings-schema.json->gridbutton1y->units
-msgid "y "
-msgstr "y "
+msgid "y"
+msgstr "y"
 
 #. gTile@shuairan->settings-schema.json->header2->description
-msgid "Button 2:"
+msgid "Layout for Button 2:"
 msgstr "Tasto 2:"
 
 #. gTile@shuairan->settings-schema.json->header3->description
-msgid "Button 3:"
+msgid "Layout for Button 3:"
 msgstr "Tasto 3:"
 
 #. gTile@shuairan->settings-schema.json->header1->description
-msgid "Button 1:"
+msgid "Layout for Button 1:"
 msgstr "Tasto 1:"
 
 #. gTile@shuairan->settings-schema.json->header4->description
-msgid "Button 4:"
+msgid "Layout for Button 4:"
 msgstr "Tasto 4:"
 
 #. gTile@shuairan->settings-schema.json->autoclose->description

--- a/gTile@shuairan/files/gTile@shuairan/po/sv.po
+++ b/gTile@shuairan/files/gTile@shuairan/po/sv.po
@@ -30,15 +30,15 @@ msgstr "gTile"
 #. gTile@shuairan->settings-schema.json->gridbutton4x->description
 #. gTile@shuairan->settings-schema.json->gridbutton3x->description
 #. gTile@shuairan->settings-schema.json->gridbutton1x->description
-msgid "Cols "
-msgstr "Kolumner "
+msgid "Columns"
+msgstr "Kolumner"
 
 #. gTile@shuairan->settings-schema.json->gridbutton2x->units
 #. gTile@shuairan->settings-schema.json->gridbutton4x->units
 #. gTile@shuairan->settings-schema.json->gridbutton3x->units
 #. gTile@shuairan->settings-schema.json->gridbutton1x->units
-msgid "x "
-msgstr "x "
+msgid "x"
+msgstr "x"
 
 #. gTile@shuairan->settings-schema.json->gridbutton2y->description
 #. gTile@shuairan->settings-schema.json->gridbutton4y->description
@@ -51,23 +51,23 @@ msgstr "Rader"
 #. gTile@shuairan->settings-schema.json->gridbutton4y->units
 #. gTile@shuairan->settings-schema.json->gridbutton3y->units
 #. gTile@shuairan->settings-schema.json->gridbutton1y->units
-msgid "y "
-msgstr "y "
+msgid "y"
+msgstr "y"
 
 #. gTile@shuairan->settings-schema.json->header2->description
-msgid "Button 2:"
+msgid "Layout for Button 2:"
 msgstr "Knapp 2:"
 
 #. gTile@shuairan->settings-schema.json->header3->description
-msgid "Button 3:"
+msgid "Layout for Button 3:"
 msgstr "Knapp 3:"
 
 #. gTile@shuairan->settings-schema.json->header1->description
-msgid "Button 1:"
+msgid "Layout for Button 1:"
 msgstr "Knapp 1:"
 
 #. gTile@shuairan->settings-schema.json->header4->description
-msgid "Button 4:"
+msgid "Layout for Button 4:"
 msgstr "Knapp 4:"
 
 #. gTile@shuairan->settings-schema.json->autoclose->description

--- a/gTile@shuairan/files/gTile@shuairan/po/tr.po
+++ b/gTile@shuairan/files/gTile@shuairan/po/tr.po
@@ -30,15 +30,15 @@ msgstr "gTile"
 #. gTile@shuairan->settings-schema.json->gridbutton4x->description
 #. gTile@shuairan->settings-schema.json->gridbutton3x->description
 #. gTile@shuairan->settings-schema.json->gridbutton1x->description
-msgid "Cols "
+msgid "Columns"
 msgstr "Sütunlar"
 
 #. gTile@shuairan->settings-schema.json->gridbutton2x->units
 #. gTile@shuairan->settings-schema.json->gridbutton4x->units
 #. gTile@shuairan->settings-schema.json->gridbutton3x->units
 #. gTile@shuairan->settings-schema.json->gridbutton1x->units
-msgid "x "
-msgstr "x "
+msgid "x"
+msgstr "x"
 
 #. gTile@shuairan->settings-schema.json->gridbutton2y->description
 #. gTile@shuairan->settings-schema.json->gridbutton4y->description
@@ -51,23 +51,23 @@ msgstr "Satırlar"
 #. gTile@shuairan->settings-schema.json->gridbutton4y->units
 #. gTile@shuairan->settings-schema.json->gridbutton3y->units
 #. gTile@shuairan->settings-schema.json->gridbutton1y->units
-msgid "y "
-msgstr "y "
+msgid "y"
+msgstr "y"
 
 #. gTile@shuairan->settings-schema.json->header2->description
-msgid "Button 2:"
+msgid "Layout for Button 2:"
 msgstr "Düğme 2:"
 
 #. gTile@shuairan->settings-schema.json->header3->description
-msgid "Button 3:"
+msgid "Layout for Button 3:"
 msgstr "Düğme 3:"
 
 #. gTile@shuairan->settings-schema.json->header1->description
-msgid "Button 1:"
+msgid "Layout for Button 1:"
 msgstr "Düğme 1:"
 
 #. gTile@shuairan->settings-schema.json->header4->description
-msgid "Button 4:"
+msgid "Layout for Button 4:"
 msgstr "Düğme 4:"
 
 #. gTile@shuairan->settings-schema.json->autoclose->description

--- a/gTile@shuairan/files/gTile@shuairan/po/zh_CN.po
+++ b/gTile@shuairan/files/gTile@shuairan/po/zh_CN.po
@@ -29,15 +29,15 @@ msgstr "gTile"
 #. gTile@shuairan->settings-schema.json->gridbutton4x->description
 #. gTile@shuairan->settings-schema.json->gridbutton3x->description
 #. gTile@shuairan->settings-schema.json->gridbutton1x->description
-msgid "Cols "
+msgid "Columns"
 msgstr "列数"
 
 #. gTile@shuairan->settings-schema.json->gridbutton2x->units
 #. gTile@shuairan->settings-schema.json->gridbutton4x->units
 #. gTile@shuairan->settings-schema.json->gridbutton3x->units
 #. gTile@shuairan->settings-schema.json->gridbutton1x->units
-msgid "x "
-msgstr "x "
+msgid "x"
+msgstr "x"
 
 #. gTile@shuairan->settings-schema.json->gridbutton2y->description
 #. gTile@shuairan->settings-schema.json->gridbutton4y->description
@@ -50,23 +50,23 @@ msgstr "行数"
 #. gTile@shuairan->settings-schema.json->gridbutton4y->units
 #. gTile@shuairan->settings-schema.json->gridbutton3y->units
 #. gTile@shuairan->settings-schema.json->gridbutton1y->units
-msgid "y "
-msgstr "y "
+msgid "y"
+msgstr "y"
 
 #. gTile@shuairan->settings-schema.json->header2->description
-msgid "Button 2:"
+msgid "Layout for Button 2:"
 msgstr "按钮2："
 
 #. gTile@shuairan->settings-schema.json->header3->description
-msgid "Button 3:"
+msgid "Layout for Button 3:"
 msgstr "按钮3："
 
 #. gTile@shuairan->settings-schema.json->header1->description
-msgid "Button 1:"
+msgid "Layout for Button 1:"
 msgstr "按钮1："
 
 #. gTile@shuairan->settings-schema.json->header4->description
-msgid "Button 4:"
+msgid "Layout for Button 4:"
 msgstr "按钮4："
 
 #. gTile@shuairan->settings-schema.json->autoclose->description

--- a/gTile@shuairan/files/gTile@shuairan/settings-schema.json
+++ b/gTile@shuairan/files/gTile@shuairan/settings-schema.json
@@ -42,7 +42,7 @@
  },
  "header1" : {
     "type" : "header",
-    "description" : "Layout 1:"
+    "description" : "Layout for Button 1:"
  },
  "gridbutton1x": {
     "type" : "spinbutton",
@@ -70,7 +70,7 @@
  },
  "header2" : {
     "type" : "header",
-    "description" : "Layout 2:"
+    "description" : "Layout for Button 2:"
  },
  "gridbutton2x": {
     "type" : "spinbutton",
@@ -98,7 +98,7 @@
  },
  "header3" : {
     "type" : "header",
-    "description" : "Layout 3:"
+    "description" : "Layout for Button 3:"
  },
  "gridbutton3x": {
     "type" : "spinbutton",
@@ -126,7 +126,7 @@
  },
  "header4" : {
     "type" : "header",
-    "description" : "Layout 4:"
+    "description" : "Layout for Button 4:"
  },
  "gridbutton4x": {
     "type" : "spinbutton",

--- a/gTile@shuairan/files/gTile@shuairan/settings-schema.json
+++ b/gTile@shuairan/files/gTile@shuairan/settings-schema.json
@@ -42,7 +42,7 @@
  },
  "header1" : {
     "type" : "header",
-    "description" : "Button 1:"
+    "description" : "Layout 1:"
  },
  "gridbutton1x": {
     "type" : "spinbutton",
@@ -70,7 +70,7 @@
  },
  "header2" : {
     "type" : "header",
-    "description" : "Button 2:"
+    "description" : "Layout 2:"
  },
  "gridbutton2x": {
     "type" : "spinbutton",
@@ -98,7 +98,7 @@
  },
  "header3" : {
     "type" : "header",
-    "description" : "Button 3:"
+    "description" : "Layout 3:"
  },
  "gridbutton3x": {
     "type" : "spinbutton",
@@ -126,7 +126,7 @@
  },
  "header4" : {
     "type" : "header",
-    "description" : "Button 4:"
+    "description" : "Layout 4:"
  },
  "gridbutton4x": {
     "type" : "spinbutton",

--- a/gTile@shuairan/files/gTile@shuairan/settings-schema.json
+++ b/gTile@shuairan/files/gTile@shuairan/settings-schema.json
@@ -1,7 +1,16 @@
 {
+ "lastGridCols" : {
+    "type" : "generic",
+    "default" : 4
+ },
+ "lastGridRows" : {
+    "type" : "generic",
+    "default" : 4
+ },
+
  "headerKeys" : {
-	"type" : "header",
-	"description" : "Hotkeys:"
+    "type" : "header",
+    "description" : "Hotkeys:"
  },
 
  "hotkey": {
@@ -9,16 +18,35 @@
     "default" : "<Super>g",
     "description" : "Global Hotkey for gTile"
  },
+
+ "seperator0" : {
+    "type" : "separator"
+ },
+ "headerBehavior" : {
+    "type" : "header",
+    "description" : "Behavior:"
+ },
+ "animation" : {
+    "type" : "checkbox",
+    "default" : "true",
+    "description" : "Animation"
+ },
+ "autoclose" : {
+    "type" : "checkbox",
+    "default" : "true",
+    "description" : "Auto-Close"
+ },
+
  "seperator1" : {
-	"type" : "separator"
+    "type" : "separator"
  },
  "header1" : {
-	"type" : "header",
-	"description" : "Button 1:"
+    "type" : "header",
+    "description" : "Button 1:"
  },
  "gridbutton1x": {
     "type" : "spinbutton",
-	"indent" : "true",
+    "indent" : "true",
     "default" : 2,
     "min" : 1,
     "max" : 20,
@@ -28,114 +56,96 @@
  },
  "gridbutton1y": {
     "type" : "spinbutton",
-	"indent" : "true",
+    "indent" : "true",
     "default" : 2,
     "min" : 1,
     "max" : 20,
     "units" : "y ",
-	"step" : 1,
+    "step" : 1,
     "description" : "Rows"
  },
+ 
  "seperator2" : {
-	"type" : "separator"
+    "type" : "separator"
  },
  "header2" : {
-	"type" : "header",
-	"description" : "Button 2:"
+    "type" : "header",
+    "description" : "Button 2:"
  },
  "gridbutton2x": {
     "type" : "spinbutton",
-	"indent" : "true",
+    "indent" : "true",
     "default" : 3,
     "min" : 1,
     "max" : 20,
     "units" : "x ",
-	"step" : 1,
+    "step" : 1,
     "description" : "Cols "
  },
  "gridbutton2y": {
     "type" : "spinbutton",
-	"indent" : "true",
+    "indent" : "true",
     "default" : 2,
     "min" : 1,
     "max" : 20,
     "units" : "y ",
-	"step" : 1,
+    "step" : 1,
     "description" : "Rows"
  },
+ 
  "seperator3" : {
-	"type" : "separator"
+    "type" : "separator"
  },
  "header3" : {
-	"type" : "header",
-	"description" : "Button 3:"
+    "type" : "header",
+    "description" : "Button 3:"
  },
  "gridbutton3x": {
     "type" : "spinbutton",
-	"indent" : "true",
+    "indent" : "true",
     "default" : 4,
     "min" : 1,
     "max" : 20,
     "units" : "x ",
-	"step" : 1,
+    "step" : 1,
     "description" : "Cols "
  },
  "gridbutton3y": {
     "type" : "spinbutton",
-	"indent" : "true",
+    "indent" : "true",
     "default" : 4,
     "min" : 1,
     "max" : 20,
     "units" : "y ",
-	"step" : 1,
+    "step" : 1,
     "description" : "Rows"
  },
+ 
  "seperator4" : {
-	"type" : "separator"
+    "type" : "separator"
  },
  "header4" : {
-	"type" : "header",
-	"description" : "Button 4:"
+    "type" : "header",
+    "description" : "Button 4:"
  },
  "gridbutton4x": {
     "type" : "spinbutton",
-	"indent" : "true",
+    "indent" : "true",
     "default" : 6,
     "min" : 1,
     "max" : 20,
     "units" : "x ",
-	"step" : 1,
+    "step" : 1,
     "description" : "Cols "
  },
  "gridbutton4y": {
     "type" : "spinbutton",
-	"indent" : "true",
+    "indent" : "true",
     "default" : 6,
     "min" : 1,
     "max" : 20,
     "units" : "y ",
-	"step" : 1,
+    "step" : 1,
     "description" : "Rows"
- },
- "seperator5" : {
-	"type" : "separator"
- },
- "autoclose" : {
-	"type" : "checkbox",
-	"default" : "true",
-	"description" : "Auto-Close"
- },
- "animation" : {
-	"type" : "checkbox",
-	"default" : "true",
-	"description" : "Animation"
- },
- "lastGridCols" : {
-	"type" : "generic",
-	"default" : 4
- },
- "lastGridRows" : {
-	"type" : "generic",
-	"default" : 4
  }
 }

--- a/gTile@shuairan/files/gTile@shuairan/settings-schema.json
+++ b/gTile@shuairan/files/gTile@shuairan/settings-schema.json
@@ -50,9 +50,9 @@
     "default" : 2,
     "min" : 1,
     "max" : 20,
-    "units" : "x ",
-	"step" : 1,
-    "description" : "Cols "
+    "units" : "x",
+    "step" : 1,
+    "description" : "Columns"
  },
  "gridbutton1y": {
     "type" : "spinbutton",
@@ -60,7 +60,7 @@
     "default" : 2,
     "min" : 1,
     "max" : 20,
-    "units" : "y ",
+    "units" : "y",
     "step" : 1,
     "description" : "Rows"
  },
@@ -78,9 +78,9 @@
     "default" : 3,
     "min" : 1,
     "max" : 20,
-    "units" : "x ",
+    "units" : "x",
     "step" : 1,
-    "description" : "Cols "
+    "description" : "Columns"
  },
  "gridbutton2y": {
     "type" : "spinbutton",
@@ -88,7 +88,7 @@
     "default" : 2,
     "min" : 1,
     "max" : 20,
-    "units" : "y ",
+    "units" : "y",
     "step" : 1,
     "description" : "Rows"
  },
@@ -106,9 +106,9 @@
     "default" : 4,
     "min" : 1,
     "max" : 20,
-    "units" : "x ",
+    "units" : "x",
     "step" : 1,
-    "description" : "Cols "
+    "description" : "Columns"
  },
  "gridbutton3y": {
     "type" : "spinbutton",
@@ -116,7 +116,7 @@
     "default" : 4,
     "min" : 1,
     "max" : 20,
-    "units" : "y ",
+    "units" : "y",
     "step" : 1,
     "description" : "Rows"
  },
@@ -134,9 +134,9 @@
     "default" : 6,
     "min" : 1,
     "max" : 20,
-    "units" : "x ",
+    "units" : "x",
     "step" : 1,
-    "description" : "Cols "
+    "description" : "Columns"
  },
  "gridbutton4y": {
     "type" : "spinbutton",
@@ -144,7 +144,7 @@
     "default" : 6,
     "min" : 1,
     "max" : 20,
-    "units" : "y ",
+    "units" : "y",
     "step" : 1,
     "description" : "Rows"
  }


### PR DESCRIPTION
The original settings dialog had the entries for `Animiation` and `Auto-Close` immediately after the 4th button – without spacings or a heading:
- Move those two settings near the top under their own heading `Behavior`.
- Also move the two settings `lastGridCols` and `lastGridRows`, to the very first place (but since they are not shown, that does not change the layout of the settings dialog).

@veryangryman 
@jaszhix 