### PR TITLE
gTile@shuairan: Making Space and Enter work for single tile areas

### DIFF
--- a/gTile@shuairan/files/gTile@shuairan/extension.js
+++ b/gTile@shuairan/files/gTile@shuairan/extension.js
@@ -1099,6 +1099,8 @@ Grid.prototype = {
 
   _bindKeyControls: function() {
     Main.keybindingManager.addHotKey('gTile-close', 'Escape', Lang.bind(this, toggleTiling));
+    Main.keybindingManager.addHotKey('gTile-tile1', 'space', Lang.bind(this, this._keyTile));
+    Main.keybindingManager.addHotKey('gTile-tile2', 'Return', Lang.bind(this, this._keyTile));
     for (let index in KEYCONTROL) {
       let key = KEYCONTROL[index];
       let type = index;
@@ -1110,37 +1112,27 @@ Grid.prototype = {
     }
   },
 
-  _bindKeyControlsTile: function() {
-    Main.keybindingManager.addHotKey('gTile-tile1', 'space', Lang.bind(this, this._keyTile));
-    Main.keybindingManager.addHotKey('gTile-tile2', 'Return', Lang.bind(this, this._keyTile));
-  },
-
   _removeKeyControls: function() {
     this.rowKey = -1;
     this.colKey = -1;
     Main.keybindingManager.removeHotKey('gTile-close');
+    Main.keybindingManager.removeHotKey('gTile-tile1');
+    Main.keybindingManager.removeHotKey('gTile-tile2');
     this._removeKeyControlsTile();
     for (let type in KEYCONTROL) {
       Main.keybindingManager.removeHotKey(type);
     }
   },
 
-  _removeKeyControlsTile: function() {
-    Main.keybindingManager.removeHotKey('gTile-tile1');
-    Main.keybindingManager.removeHotKey('gTile-tile2');
-  },
-
   _onKeyPressEvent: function(type) {
     let modifier = type.indexOf('meta', type.length - 4) !== -1;
 
     if (modifier && this.keyElement) {
-      this._bindKeyControlsTile();
       if (!this.elementsDelegate.activated) {
         this.keyElement._onButtonPress();
       }
     } else if (this.keyElement) {
       this.elementsDelegate.reset();
-      this._removeKeyControlsTile();
     }
 
     switch (type) {
@@ -1175,6 +1167,7 @@ Grid.prototype = {
 
   _keyTile: function() {
     if (this.keyElement) {
+      this.keyElement._onButtonPress();
       this.keyElement._onButtonPress();
       this.colKey = -1;
       this.rowKey = -1;

--- a/gTile@shuairan/files/gTile@shuairan/extension.js
+++ b/gTile@shuairan/files/gTile@shuairan/extension.js
@@ -1118,7 +1118,6 @@ Grid.prototype = {
     Main.keybindingManager.removeHotKey('gTile-close');
     Main.keybindingManager.removeHotKey('gTile-tile1');
     Main.keybindingManager.removeHotKey('gTile-tile2');
-    this._removeKeyControlsTile();
     for (let type in KEYCONTROL) {
       Main.keybindingManager.removeHotKey(type);
     }


### PR DESCRIPTION
Fixes #291

In order to tile a window to an area consisting of a single tile, prior to this change, one would have to navigate to a tile using the arrow keys, press shift and an arrow key to begin a multi-tile area, followed by shift and the arrow key of the opposite direction to reduce the area again to a single tile, and then press space or enter to tile the window. Without the intermediate step of shift-arrow back and forth, the space and enter keys would not be registered as hotkeys but sent to the focused window instead where they would result in accidental input as described in issue #291.

It's a quick fix, but it seems to be working well for me.