### PR TITLE
Adapt to clutter having paint-context now (invert window extension)

### DIFF
--- a/rnbdsh@negateWindow/files/rnbdsh@negateWindow/extension.js
+++ b/rnbdsh@negateWindow/files/rnbdsh@negateWindow/extension.js
@@ -18,9 +18,8 @@ const InvertWindowEffect = new Lang.Class({
 	Name: 'InvertWindowEffect',
 	Extends: Clutter.ShaderEffect,
 
-	_init: function(params) {
-		this.parent(params);
-		this.set_shader_source(' \
+	vfunc_get_static_shader_source: function() {
+		return ' \
 			uniform sampler2D tex; \
 			void main() { \
 				vec4 color = texture2D(tex, cogl_tex_coord_in[0].st); \
@@ -31,12 +30,12 @@ const InvertWindowEffect = new Lang.Class({
 				color.rgb *= color.a; \
 				cogl_color_out = color * cogl_color_in; \
 			} \
-		');
+		';
 	},
 
-	vfunc_paint_target: function() {
+	vfunc_paint_target: function(paint_context) {
 		this.set_uniform_value("tex", 0);
-		this.parent();
+		this.parent(paint_context);
 	}
 });
 

--- a/rnbdsh@negateWindow/files/rnbdsh@negateWindow/metadata.json
+++ b/rnbdsh@negateWindow/files/rnbdsh@negateWindow/metadata.json
@@ -2,7 +2,7 @@
     "website": "https://github.com/rnbdsh/negateWindow", 
     "url": "https://github.com/rnbdsh/negateWindow", 
     "description": "A Cinnamon extension that allows to negate the window-color when you press super+i.", 
-    "version": "0.01", 
+    "version": "0.02", 
     "cinnamon-version": [
         "2.8", 
         "3.0", 


### PR DESCRIPTION
Same change as in https://github.com/maiself/gnome-shell-extension-invert-color/commit/0e70aae1671c4fe4a5b42392fc588e1e5cd6f259

Proof that it works for me:
![image](https://user-images.githubusercontent.com/9084941/176150254-dbbcd577-7b2b-4984-af39-7ff381d876c3.png)

Feel free to also adapt other changes that have been on the gnome extension in the meanwhile, like stacking multiple invert effects on each other.