### PR TITLE
transparent-panels@germanfr: Fix for 5.4

### DIFF
--- a/transparent-panels@germanfr/files/transparent-panels@germanfr/metadata.json
+++ b/transparent-panels@germanfr/files/transparent-panels@germanfr/metadata.json
@@ -1,6 +1,6 @@
 {
 	"name": "Transparent panels",
-	"version": "4.0~20181106",
+	"version": "4.0~20220727",
 	"description": "Transparentize your panels when there are no any maximized windows",
 	"url": "https://github.com/germanfr/cinnamon-transparent-panels",
 	"website": "https://github.com/germanfr/cinnamon-transparent-panels",

--- a/transparent-panels@germanfr/files/transparent-panels@germanfr/policies.js
+++ b/transparent-panels@germanfr/files/transparent-panels@germanfr/policies.js
@@ -19,6 +19,7 @@
 
 const Meta = imports.gi.Meta;
 const SignalManager = imports.misc.signalManager;
+const config = imports.misc.config;
 
 const META_WINDOW_MAXIMIZED = (Meta.MaximizeFlags.VERTICAL | Meta.MaximizeFlags.HORIZONTAL);
 
@@ -59,11 +60,15 @@ MaximizedPolicy.prototype = {
 
 	enable: function () {
 		this._signals = new SignalManager.SignalManager(null);
-		this._signals.connect(global.window_manager, "maximize", this._on_window_appeared, this);
+
+		if (config.PACKAGE_VERSION < "5.4") {
+			this._signals.connect(global.window_manager, "maximize", this._on_window_appeared, this);
+			this._signals.connect(global.window_manager, "unmaximize", this._on_window_disappeared, this);
+		}
+
 		this._signals.connect(global.window_manager, "map", this._on_window_appeared, this);
 
 		this._signals.connect(global.window_manager, "minimize", this._on_window_disappeared, this);
-		this._signals.connect(global.window_manager, "unmaximize", this._on_window_disappeared, this);
 		this._signals.connect(global.screen, "window-removed", this.lookup_all_monitors, this);
 		this._signals.connect(global.window_manager, "switch-workspace", this.lookup_all_monitors, this);
 

--- a/transparent-panels@germanfr/files/transparent-panels@germanfr/policies.js
+++ b/transparent-panels@germanfr/files/transparent-panels@germanfr/policies.js
@@ -151,7 +151,7 @@ MaximizedPolicy.prototype = {
 	},
 
 	_on_window_size_changed: function (wm, win, change) {
-		if (change === Meta.SizeChange.MAXIMIZE || change === Meta.SizeChange.TILE) {
+		if (change === Meta.SizeChange.MAXIMIZE) {
 			this._on_window_appeared(wm, win);
 		} else if (change === Meta.SizeChange.UNMAXIMIZE) {
 			this._on_window_disappeared(wm, win);

--- a/transparent-panels@germanfr/files/transparent-panels@germanfr/policies.js
+++ b/transparent-panels@germanfr/files/transparent-panels@germanfr/policies.js
@@ -153,7 +153,7 @@ MaximizedPolicy.prototype = {
 	_on_window_size_changed: function (wm, win, change) {
 		if (change === Meta.SizeChange.MAXIMIZE) {
 			this._on_window_appeared(wm, win);
-		} else if (change === Meta.SizeChange.UNMAXIMIZE) {
+		} else if (change === Meta.SizeChange.UNMAXIMIZE || change === Meta.SizeChange.TILE) {
 			this._on_window_disappeared(wm, win);
 		}
 	},

--- a/transparent-panels@germanfr/files/transparent-panels@germanfr/policies.js
+++ b/transparent-panels@germanfr/files/transparent-panels@germanfr/policies.js
@@ -64,6 +64,8 @@ MaximizedPolicy.prototype = {
 		if (config.PACKAGE_VERSION < "5.4") {
 			this._signals.connect(global.window_manager, "maximize", this._on_window_appeared, this);
 			this._signals.connect(global.window_manager, "unmaximize", this._on_window_disappeared, this);
+		} else {
+			this._signals.connect(global.window_manager, "size-change", this._on_window_size_changed, this);
 		}
 
 		this._signals.connect(global.window_manager, "map", this._on_window_appeared, this);

--- a/transparent-panels@germanfr/files/transparent-panels@germanfr/policies.js
+++ b/transparent-panels@germanfr/files/transparent-panels@germanfr/policies.js
@@ -149,6 +149,14 @@ MaximizedPolicy.prototype = {
 		this.lookup_windows_state(win.get_monitor());
 	},
 
+	_on_window_size_changed: function (wm, win, change) {
+		if (change === Meta.SizeChange.MAXIMIZE) {
+			this._on_window_appeared(wm, win);
+		} else if (change === Meta.SizeChange.UNMAXIMIZE) {
+			this._on_window_disappeared(wm, win);
+		}
+	},
+
 	_on_desktop_focused: function (desktop) {
 		if(desktop.get_window_type() !== Meta.WindowType.DESKTOP)
 			return;

--- a/transparent-panels@germanfr/files/transparent-panels@germanfr/policies.js
+++ b/transparent-panels@germanfr/files/transparent-panels@germanfr/policies.js
@@ -66,6 +66,7 @@ MaximizedPolicy.prototype = {
 			this._signals.connect(global.window_manager, "unmaximize", this._on_window_disappeared, this);
 		} else {
 			this._signals.connect(global.window_manager, "size-change", this._on_window_size_changed, this);
+			this._signals.connect(global.window_manager, "unminimize", this._on_window_appeared, this);
 		}
 
 		this._signals.connect(global.window_manager, "map", this._on_window_appeared, this);

--- a/transparent-panels@germanfr/files/transparent-panels@germanfr/policies.js
+++ b/transparent-panels@germanfr/files/transparent-panels@germanfr/policies.js
@@ -151,7 +151,7 @@ MaximizedPolicy.prototype = {
 	},
 
 	_on_window_size_changed: function (wm, win, change) {
-		if (change === Meta.SizeChange.MAXIMIZE) {
+		if (change === Meta.SizeChange.MAXIMIZE || change === Meta.SizeChange.TILE) {
 			this._on_window_appeared(wm, win);
 		} else if (change === Meta.SizeChange.UNMAXIMIZE) {
 			this._on_window_disappeared(wm, win);


### PR DESCRIPTION
* Fixes #394
* Fixes #396 (duplicate)

Tested only on 5.4, the version check is supposed to work for earlier versions but you should have a look. I suspect it's going to work fine on the earlier versions.

@germanfr 

@brownsr This PR is now ready