### PR TITLE
cinnamon-maximus@fmete: Fix broken window ID getter

### DIFF
--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
@@ -135,18 +135,25 @@ function logMessage(message, alwaysLog = false) {
 /** Guesses the X ID of a window.
  *
  * After muffin 2.4 the get_xwindow() returns the integer value
- * instead Window object. So no need use a lot of hacks.
+ * instead Window object. So no need use a lot of hacks
+ *
+ * After Cinnamon 5.4.12 (or possibly earlier), get_xwindow no
+ * longer exists but get_description returns the ID
  */
 function guessWindowXID(win) {
     let id = null;
+    let additionalErrorMsg = null;
     try {
-        id = win.get_xwindow();
+        id = win.get_description();
         if (id)
             return id;
     } catch (err) {
+      additionalErrorMsg = err;
+      // Could call 'xprop -root _NET_ACTIVE_WINDOW' here as a
+      // fallback if/when get_description changes
     }
     // debugging for when people find bugs.. always logging this message.
-    logMessage("Could not find XID for window with title '${win.title}", true);
+    logMessage("Could not find XID for window with title '${win.title}" + (additionalErrorMsg?": " + additionalErrorMsg:""), true);
     return null;
 }
 


### PR DESCRIPTION
get_xwindow no longer exists so guessWindowXID always fails and falls back to using the window title, which always selects the bottom-most window of a given title where multiple windows exist with the same title.

Replacing it with get_description gets the correct ID and yields the correct behavior of decorating and undecorating the currently focused window

I also added the exception message to the log message to make debugging in the future easier should the API change again

Also added a comment for a potential workaround that would be agnostic to the cinnamon extension API changing which would utilize an external call to xprop to get the active window ID which might be preferred considering this extension already depends on an external call to xprop anyway. Let me know if you'd rather I implement that version

Using Cinnamon 5.4.12 on Mint 21

Fixes #428 