### PR TITLE
cinnamon-maximus@fmete: Fix undecorate when tile

### DIFF
--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
@@ -311,7 +311,7 @@ function onSizeChange(shellwm, actor, change) {
     if (change === Meta.SizeChange.UNMAXIMIZE) {
         onUnmaximize(shellwm, actor);
     }
-    if (change === Meta.SizeChange.TILE && settings.undecorateTile == true) {
+    if (!!Meta.SizeChange.TILE && change === Meta.SizeChange.TILE && settings.undecorateTile == true) {
         onMaximize(shellwm, actor);
     }
 }

--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
@@ -234,7 +234,7 @@ function shouldAffect(win) {
         verdict = false;
     }
 
-    if (isHalfMaximized(win)) {
+    if (isHalfMaximized(win) && settings.undecorateTile === false) {
         verdict = false;
     }
 

--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
@@ -311,6 +311,9 @@ function onSizeChange(shellwm, actor, change) {
     if (change === Meta.SizeChange.UNMAXIMIZE) {
         onUnmaximize(shellwm, actor);
     }
+    if (change === Meta.SizeChange.TILE && settings.undecorateTile == true) {
+        onMaximize(shellwm, actor);
+    }
 }
 
 /** Called when a window is maximized, including half-maximization.
@@ -508,7 +511,11 @@ function startUndecorating() {
             }
         }
         if (settings.undecorateTile == true) {
-            tileEventID = global.window_manager.connect("tile", onMaximize);
+            try {
+                tileEventID = global.window_manager.connect("tile", onMaximize);
+            } catch (e) {
+                logMessage(`ignoring exception on connecting to tile signal`);
+            }
         }
     }
     /* this is needed to prevent Metacity from interpreting an attempted drag


### PR DESCRIPTION
With current version of cinnamon (5.4.12) when setting "Undecorate when tile" is on error will be thrown in .xsession-errors file:
```
Gjs-Message: 23:09:05.183: JS LOG: [LookingGlass/error] [Error: No signal 'tile' on object 'CinnamonWM']: Failed to evaluate 'enable' function on extension: cinnamon-maximus@fmete
```

Tile signal is no longer present and was moved to size-change signal as a param.

This PR should be mostly backwards compatible.