### PR TITLE
cinnamon-maximus@fmete: Undecorate window if it's fully maximized

### DIFF
--- a/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
+++ b/cinnamon-maximus@fmete/files/cinnamon-maximus@fmete/extension.js
@@ -319,7 +319,7 @@ function onSizeChange(shellwm, actor, change) {
     if (change === Meta.SizeChange.UNMAXIMIZE) {
         onUnmaximize(shellwm, actor);
     }
-    if (!!Meta.SizeChange.TILE && change === Meta.SizeChange.TILE && settings.undecorateTile == true) {
+    if (!!Meta.SizeChange.TILE && change === Meta.SizeChange.TILE) {
         onMaximize(shellwm, actor);
     }
 }


### PR DESCRIPTION
this covers the case when window is maximized by dragging it to the top (="tiled" to both sides)

`undecorateTile` setting should only affect half-maximized windows (which is checked inside `onMaximize` anyway - see `shouldAffect` function)