### PR TITLE
transparent-panels@germanfr: update state when a new monitor is added or removed

### DIFF
--- a/transparent-panels@germanfr/files/transparent-panels@germanfr/extension.js
+++ b/transparent-panels@germanfr/files/transparent-panels@germanfr/extension.js
@@ -27,6 +27,7 @@ const Panel = imports.ui.panel;
 const Settings = imports.ui.settings;
 const St = imports.gi.St;
 const Util = imports.misc.util;
+const SignalManager = imports.misc.signalManager;
 
 let Filter, Policies;
 if (typeof require !== 'undefined') {
@@ -57,7 +58,7 @@ function MyExtension(meta) {
 MyExtension.prototype = {
 	_init: function (meta) {
 		this.meta = meta;
-		this._signals = null;
+		this._signals = new SignalManager.SignalManager(null);
 		this._panel_status = new Array(Main.panelManager.panelCount);
 		for(let i = 0; i < this._panel_status.length; i++)
 			this._panel_status[i] = false;
@@ -74,6 +75,8 @@ MyExtension.prototype = {
 		this.settings.bind("panel-right", "enable_position_right", this.on_settings_changed);
 		this.settings.bind("panel-bottom", "enable_position_bottom", this.on_settings_changed);
 		this.settings.bind("panel-left", "enable_position_left", this.on_settings_changed);
+
+		this._signals.connect(Main.layoutManager, 'monitors-changed', () => this.on_state_change(-1), this);
 
 		this._classname = this.theme_defined ? this.transparency_type : this.transparency_type + INTERNAL_PREFIX;
 
@@ -94,6 +97,8 @@ MyExtension.prototype = {
 		this.policy.disable();
 		this.settings.finalize();
 		this.settings = null;
+		this._signals.disconnectAllSignals();
+		this._signals = null;
 
 		Main.getPanels().forEach(panel => this.make_transparent(panel, false));
 	},


### PR DESCRIPTION
When adding or removing a new monitor the state of the extension resets/removes the panel transparency, now it will update the state of the panel a guarantee that the panel continues with the transparency.

cc @germanfr