### PR TITLE
Address persistent demands-attention issue in focus-new-window@mdpenguin

### DIFF
--- a/focus-new-window@mdpenguin/files/focus-new-window@mdpenguin/extension.js
+++ b/focus-new-window@mdpenguin/files/focus-new-window@mdpenguin/extension.js
@@ -46,11 +46,13 @@ class AttentionHandler {
 
     if (wmclass) {
       if (!settings.raiseSome) {
-        Main.activateWindow(window);
+        window.raise();
+        window.focus(global.get_current_time());
         return;
       }
       else if (programList.includes(wmclass.toLowerCase()) && window.has_focus() === false) {
-        Main.activateWindow(window);
+        window.raise();
+        window.focus(global.get_current_time());
         return;
       }
       else {
@@ -58,7 +60,8 @@ class AttentionHandler {
 
         for (let i = 0; i < ignored_classes.length; i++) {
           if (wmclass.toLowerCase().includes(ignored_classes[i].toLowerCase())) {
-            window.activate(global.get_current_time());
+            window.raise();
+            window.focus(global.get_current_time());
             return;
           }
         }

--- a/focus-new-window@mdpenguin/files/focus-new-window@mdpenguin/metadata.json
+++ b/focus-new-window@mdpenguin/files/focus-new-window@mdpenguin/metadata.json
@@ -3,7 +3,7 @@
     "name": "Focus New Window",
     "url": "https://codeberg.org/mdpenguin/focus-new-window",
     "description": "A Cinnamon extension that ensures new windows will receive focus",
-    "version": "1.0.0",
-    "cinnamon-version": ["5.8","6.0","6.2"],
+    "version": "1.0.2",
+    "cinnamon-version": ["5.8", "6.0", "6.2"],
     "author": "mdpenguin"
 }


### PR DESCRIPTION
Raise and focus the new window instead of activating it in focus-new-window@mdpenguin.

This addresses the issue described in https://github.com/linuxmint/cinnamon/issues/12269 where the new window demands attention even though it is already focused.