### PR TITLE
Update opacity-slider@neatnit supports cinnamon version 6.2

### DIFF
--- a/opacity-slider@neatnit/files/opacity-slider@neatnit/metadata.json
+++ b/opacity-slider@neatnit/files/opacity-slider@neatnit/metadata.json
@@ -5,5 +5,5 @@
     "description": "Change a window's opacity from the title bar right-click menu.",
     "url": "https://codeberg.org/NeatNit/cinnamon-opacity-slider",
     "author": "NeatNit",
-    "cinnamon-version": ["5.6", "6.0"]
+    "cinnamon-version": ["5.6", "6.0", "6.2"]
 }


### PR DESCRIPTION
I just upgraded to Linux Mint 22 and confirmed it works fine.

Is this metadata used for anything? I checked a few other extensions and they don't seem to keep this list updated.

Also, I don't know if this extension works on versions before 5.6. Does this prevent people from even trying? (Assuming there even are people using earlier Cinnamon versions today)