### PR TITLE
[CinnamonMagicLamp@klangman] Remove the need to change Effect settings

### DIFF
--- a/CinnamonMagicLamp@klangman/CHANGELOG.md
+++ b/CinnamonMagicLamp@klangman/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.0.2
+
+* Removed the need to change the System-Settings->Effect settings to "none" for the Minimize/Unminimize options. This is now accomplished by intercepting a cinnamon API and forcing it to disable the Cinnamon Minimize/Unminimize effects while the MagicLamp extension is enabled.
+* Fixed some minor typos in the README.
+
 ## 1.0.1
 
 * Initial version committed to cinnamon spices

--- a/CinnamonMagicLamp@klangman/README.md
+++ b/CinnamonMagicLamp@klangman/README.md
@@ -4,17 +4,13 @@ A compiz like magic lamp effect for the Cinnamon desktop based on hermes83's Gno
 
 This Cinnamon extension will create a Magic Lamp minimize and unminimize effect
 
-## IMPORTANT
-
-You must disable the Cinnamon Minimize and Unminimize effects as they will interfere with the operation of the Magic Lamp effect. Open the Menu->Preferences->Effects application and set the "New windows or unminimizing existing ones" and "Minimize windows" features to "None".
-
 ## Requirements
 
 Cinnamon 5.6.8 (Mint 21.1) or better.
 
 To properly animate in relation to the window-list icon, you need to be using a window-list applet that sets the icon geometry. Otherwise the animation will animate from/to the middle of the monitor on the Cinnamon panel edge rather than an animation specific to the window. The pre-installed "Window list" and "Grouped window list" applets work fine as does "Cassia Window list" (version 2.3.2 or better). CobiWindowList does not currently set icon geometry.
 
-This applet requires no other packages other than what is included in a default initialization of Mint 21.1 or better.
+This extension requires no other packages other than what is included in a default installation of Mint 21.1 or better.
 
 ## Known issues
 
@@ -27,12 +23,11 @@ The Steam client for some reason does not support window cloning when minimized,
 3. Click the "Download" tab and then click the "Magic Lamp Effect" entry
 4. Click the "Install" button on the right and then return to the "Manage" tab
 6. Select the new "Magic Lamp Effect" entry and then click the "+" button at the bottom of the window
-7. **Important:** Open the Menu->Preferences->Effects application and change the Minimize and Unminimize effect options to "None"
-8. Use the "gears" icon next to the "Magic Lamp Effect" entry to open the setting window and setup the preferred behaviour
+7. Use the "gears" icon next to the "Magic Lamp Effect" entry to open the setting window and setup the preferred behaviour
 
 ## Feedback
 
-Please leave a comment here on cinnamon-spices.linuxmint.com or you can create an issue on my "Cinnamon Magic Lap" development GitHub repository if you encounter any issues with this extension:
+Please leave a comment here on cinnamon-spices.linuxmint.com or you can create an issue on my "Cinnamon Magic Lamp" development GitHub repository if you encounter any issues with this extension:
 
 https://github.com/klangman/CinnamonMagicLamp
 

--- a/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/5.6/ShouldAnimateManager.js
+++ b/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/5.6/ShouldAnimateManager.js
@@ -1,0 +1,113 @@
+/*
+ * ShouldAnimateManager.js
+ * Copyright (C) 2024 Kevin Langman <klangman@gmail.com>
+ *
+ * ShouldAnimateManager is free software: you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * ShouldAnimateManager is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>. *
+ *
+ * The purpose of this module is to coordinate overriding the Main.wm._shouldAnimate()
+ * function with more than one extension by "monkey-patching" the function. This class
+ * will check if there is an existing override or not, install the override if needed
+ * and track handlers.
+ *
+ * A new entry will need to provide an event to intercept, a handler function and
+ * a extension name (uuid). If the event is already being handled by some other extension
+ * then the extension name of the current handler will be returned to indicate an error.
+ *
+ * The handler function can return true or false which will then be returned to the caller
+ * of _shouldAnimate(). If the handler would like to allow the original _shouldAnimate()
+ * function to run, then the handler should return RUN_ORIGINAL_FUNCTION and the return
+ * value from the original function will be returned to the caller.
+ *
+*/
+
+const Main = imports.ui.main;
+const Meta = imports.gi.Meta;
+
+const Events = {
+   Minimize:      1,
+   Unminimize:    2,
+   MapWindow:     4,
+   DestroyWindow: 8
+}
+
+const RUN_ORIGINAL_FUNCTION = 2
+
+class ShouldAnimateManager {
+
+   constructor(uuid) {
+      this._uuid = uuid;
+   }
+
+   connect(event, handler) {
+      if (Main.wm._shouldAnimateManager) {
+         for (let i=0 ; i<Main.wm._shouldAnimateManager.length ; i++) {
+            if ((Main.wm._shouldAnimateManager[i].event & event) != 0) {
+               return Main.wm._shouldAnimateManager[i].owner;
+            }
+         }
+         log( `Adding new ShouldAnimateManager handler for ${this._uuid} events ${event}` );
+         Main.wm._shouldAnimateManager.push( {event: event, handler: handler, owner: this._uuid, override: this.handler} );
+      } else {
+         log( `Installed ShouldAnimateManager handler for ${this._uuid} events ${event}` );
+         Main.wm._shouldAnimateManager = [ {event: event, handler: handler, owner: this._uuid, override: this.handler} ];
+         Main.wm._shouldAnimateManager_Original_Function = Main.wm._shouldAnimate;
+         Main.wm._shouldAnimate = this.handler;
+      }
+      return null;
+   }
+
+   disconnect() {
+      log( "in disconnect" );
+      for (let i=0 ; i<Main.wm._shouldAnimateManager.length ; i++) {
+         if (Main.wm._shouldAnimateManager[i].owner == this._uuid) {
+            Main.wm._shouldAnimateManager.splice( i, 1 );
+            // Setup a new _shouldAnimate override or restore the original if there are no manager entries left.
+            if (Main.wm._shouldAnimateManager.length === 0) {
+               log( `Removing the last ShouldAnimateManager entry (for ${this._uuid}), reinstalling the original handler function` );
+               Main.wm._shouldAnimate = Main.wm._shouldAnimateManager_Original_Function;
+               Main.wm._shouldAnimateManager_Original_Function = null;
+               Main.wm._shouldAnimateManager = null;
+               return;
+            } else {
+               log( `Removing the ShouldAnimateManager handler for ${this._uuid} and installing the override provided by ${Main.wm._shouldAnimateManager[0].owner}` );
+               Main.wm._shouldAnimate = Main.wm._shouldAnimateManager[0].override;
+            }
+         }
+      }
+   }
+
+   handler(actor, types) {
+      const isNormalWindow = actor.meta_window.window_type == Meta.WindowType.NORMAL;
+      const isDialogWindow = actor.meta_window.window_type == Meta.WindowType.MODAL_DIALOG || actor.meta_window.window_type == Meta.WindowType.DIALOG;
+
+      if (isNormalWindow || isDialogWindow) {
+         let stack = (new Error()).stack;
+         let event  = (stack.includes('_minimizeWindow@'  )) ? Events.Minimize      : 0;
+         event     += (stack.includes('_unminimizeWindow@')) ? Events.Unminimize    : 0;
+         event     += (stack.includes('_mapWindow@'       )) ? Events.MapWindow     : 0;
+         event     += (stack.includes('_destroyWindow@'   )) ? Events.DestroyWindow : 0;
+
+         for (let i=0 ; i<Main.wm._shouldAnimateManager.length ; i++) {
+            if (event === (Main.wm._shouldAnimateManager[i].event & event)) {
+               let ret = Main.wm._shouldAnimateManager[i].handler(actor, types, event);
+               if (ret != RUN_ORIGINAL_FUNCTION) {
+                  return ret;
+               }
+            }
+         }
+      }
+      return Main.wm._shouldAnimateManager_Original_Function.apply(this, [actor, types]);
+   }
+
+}

--- a/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/5.6/settings-schema.json
+++ b/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/5.6/settings-schema.json
@@ -46,10 +46,5 @@
     "step": 1,
     "description": "Y Tiles",
     "tooltip": "This effects the quality and the costs of the animation"
-  },
-
-  "showNotification": {
-     "type": "generic",
-     "default": 1
   }
 }

--- a/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/metadata.json
+++ b/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "CinnamonMagicLamp@klangman",
   "name": "Magic Lamp Effect",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A minimize/unminimize magic lamp effect based on hermes83's Gnome extension",
   "url": "https://github.com/klangman/CinnamonMagicLamp",
   "website": "https://github.com/klangman/CinnamonMagicLamp",

--- a/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/po/CinnamonMagicLamp@klangman.pot
+++ b/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/po/CinnamonMagicLamp@klangman.pot
@@ -1,34 +1,36 @@
-# SOME DESCRIPTIVE TITLE.
+# MAGIC LAMP EFFECT
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# klangman, 2024
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: CinnamonMagicLamp@klangman 1.0.1\n"
+"Project-Id-Version: CinnamonMagicLamp@klangman 1.0.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-08-18 10:47-0400\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"POT-Creation-Date: 2024-09-02 00:30-0400\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: 5.6/extension.js:75
-msgid "has been enabled"
+#. 5.6/extension.js:80
+msgid "ERROR"
 msgstr ""
 
-#: 5.6/extension.js:76
-msgid ""
-"Please set the Cinnamon minimize and unminimize effects to None. These "
-"effects will interfere with the Cinnamon Magic Lap effects."
+#. 5.6/extension.js:80
+msgid "was NOT enabled"
 msgstr ""
 
-#: 5.6/extension.js:79
-msgid "Open Cinnamon Effects"
+#. 5.6/extension.js:81
+msgid "The existing extension"
+msgstr ""
+
+#. 5.6/extension.js:81
+msgid "conflicts with this extension."
 msgstr ""
 
 #. metadata.json->name

--- a/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/po/ca.po
+++ b/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/po/ca.po
@@ -1,6 +1,6 @@
-# SOME DESCRIPTIVE TITLE.
+# MAGIC LAMP EFFECT
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# klangman, 2024
 #
 #, fuzzy
 msgid ""
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonMagicLamp@klangman 1.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-08-18 10:47-0400\n"
+"POT-Creation-Date: 2024-09-02 00:30-0400\n"
 "PO-Revision-Date: 2024-08-18 20:40+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,22 +18,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#: 5.6/extension.js:75
-msgid "has been enabled"
+#. 5.6/extension.js:80
+msgid "ERROR"
+msgstr ""
+
+#. 5.6/extension.js:80
+#, fuzzy
+msgid "was NOT enabled"
 msgstr "ha estat activat"
 
-#: 5.6/extension.js:76
-msgid ""
-"Please set the Cinnamon minimize and unminimize effects to None. These "
-"effects will interfere with the Cinnamon Magic Lap effects."
+#. 5.6/extension.js:81
+msgid "The existing extension"
 msgstr ""
-"Si, us plau, establiu els efectes de Cinnamon de minimitzar i "
-"desminimitzar a 'Cap'. Aquests efectes interferirien amb els de la llàntia "
-"màgica de Cinnamon."
 
-#: 5.6/extension.js:79
-msgid "Open Cinnamon Effects"
-msgstr "Obrir efectes de Cinnamon"
+#. 5.6/extension.js:81
+msgid "conflicts with this extension."
+msgstr ""
 
 #. metadata.json->name
 msgid "Magic Lamp Effect"
@@ -43,8 +43,8 @@ msgstr "Efecte de Llàntia Màgica"
 msgid ""
 "A minimize/unminimize magic lamp effect based on hermes83's Gnome extension"
 msgstr ""
-"Un efecte de llàntia màgica en minimitzar/desminimitzar basat en "
-"l'extensió de Gnome d'hermes83"
+"Un efecte de llàntia màgica en minimitzar/desminimitzar basat en l'extensió "
+"de Gnome d'hermes83"
 
 #. 5.6->settings-schema.json->keybinding-header->description
 msgid "Cinnamon Magic Lamp Settings"
@@ -67,8 +67,8 @@ msgid ""
 "Using 'default' will result in a curved effect where using 'sine' will "
 "result in a more wavy effect"
 msgstr ""
-"Utilitzar 'per defecte' crearà un efecte de corba, mentre que 'sinus' "
-"crearà un efecte més ondulat"
+"Utilitzar 'per defecte' crearà un efecte de corba, mentre que 'sinus' crearà "
+"un efecte més ondulat"
 
 #. 5.6->settings-schema.json->duration->units
 msgid "ms"

--- a/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/po/es.po
+++ b/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/po/es.po
@@ -1,13 +1,13 @@
-# SOME DESCRIPTIVE TITLE.
+# MAGIC LAMP EFFECT
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# klangman, 2024
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: CinnamonMagicLamp@klangman 1.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-08-18 10:47-0400\n"
+"POT-Creation-Date: 2024-09-02 00:30-0400\n"
 "PO-Revision-Date: 2024-08-18 12:36-0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,21 +17,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#: 5.6/extension.js:75
-msgid "has been enabled"
+#. 5.6/extension.js:80
+msgid "ERROR"
+msgstr ""
+
+#. 5.6/extension.js:80
+#, fuzzy
+msgid "was NOT enabled"
 msgstr "ha sido activado"
 
-#: 5.6/extension.js:76
-msgid ""
-"Please set the Cinnamon minimize and unminimize effects to None. These "
-"effects will interfere with the Cinnamon Magic Lap effects."
+#. 5.6/extension.js:81
+msgid "The existing extension"
 msgstr ""
-"Configure los efectos de minimizar y desminimizar de Cinnamon como "
-"Ninguno. Estos efectos interferirán con los efectos de Cinnamon Magic Lamp."
 
-#: 5.6/extension.js:79
-msgid "Open Cinnamon Effects"
-msgstr "Abrir efectos de Cinnamon"
+#. 5.6/extension.js:81
+msgid "conflicts with this extension."
+msgstr ""
 
 #. metadata.json->name
 msgid "Magic Lamp Effect"

--- a/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/po/pt.po
+++ b/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/po/pt.po
@@ -1,6 +1,6 @@
-# SOME DESCRIPTIVE TITLE.
+# MAGIC LAMP EFFECT
 # This file is put in the public domain.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# klangman, 2024
 #
 #, fuzzy
 msgid ""
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonMagicLamp@klangman 1.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-08-18 10:47-0400\n"
+"POT-Creation-Date: 2024-09-02 00:30-0400\n"
 "PO-Revision-Date: 2024-08-19 03:48-0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,22 +18,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#: 5.6/extension.js:75
-msgid "has been enabled"
+#. 5.6/extension.js:80
+msgid "ERROR"
+msgstr ""
+
+#. 5.6/extension.js:80
+#, fuzzy
+msgid "was NOT enabled"
 msgstr "foi ativado"
 
-#: 5.6/extension.js:76
-msgid ""
-"Please set the Cinnamon minimize and unminimize effects to None. These "
-"effects will interfere with the Cinnamon Magic Lap effects."
+#. 5.6/extension.js:81
+msgid "The existing extension"
 msgstr ""
-"Por favor, redefina os efeitos de minimizar e não minimizar do Cinnamon "
-"para Nenhum. Estes efeitos irão interferir com os efeitos desta extensão "
-"Lâmpada Mágica do Cinnamon."
 
-#: 5.6/extension.js:79
-msgid "Open Cinnamon Effects"
-msgstr "Abrir Efeitos do Cinnamon"
+#. 5.6/extension.js:81
+msgid "conflicts with this extension."
+msgstr ""
 
 #. metadata.json->name
 msgid "Magic Lamp Effect"
@@ -43,8 +43,8 @@ msgstr "Efeito da Lâmpada Mágica"
 msgid ""
 "A minimize/unminimize magic lamp effect based on hermes83's Gnome extension"
 msgstr ""
-"Um efeito de lâmpada mágica minimizar/desminimizar baseado na extensão "
-"Gnome do hermes83"
+"Um efeito de lâmpada mágica minimizar/desminimizar baseado na extensão Gnome "
+"do hermes83"
 
 #. 5.6->settings-schema.json->keybinding-header->description
 msgid "Cinnamon Magic Lamp Settings"


### PR DESCRIPTION
Use _shouldAnimate() patching to prevent Cinnamon from animating the Minimize and Unminimize events. This means that users no longer need to disable the Effect settings in Cinnamon manually. Also means that the Cinnamon New Window animation can be enabled and active along with Magic Lap effects (so you don't have to give up new window fade in effects in order to enable Magic Lamp).

This change introduces a class to manage patching _shouldAnimate(). My next extension will also need to patch _shouldAnimate() so I needed a way to coordinate the patching so that the two extensions can coexist. The ShouldAnimateManager class will be used in both extensions. This class will manage the patching of _shouldAnimate() and allow both extensions to intercept different calling contexts of _shouldAnimate().

Some README changes.