### PR TITLE
[CinnamonBurnMyWindows@klangman] App specific setting & "none" option

### DIFF
--- a/CinnamonBurnMyWindows@klangman/CHANGELOG.md
+++ b/CinnamonBurnMyWindows@klangman/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 0.9.2
+
+* Added application specific effect settings that override the default effects setting when a specific application window is opened/closed
+* Added a "none" options to the effect drop-down lists which will perform no effect and allow the cinnamon default effect to apply
+* Added a button in the General configuration tab which will add an "Application Specific Settings" table entry for the application of the window that last had the focused.
+
 ## 0.9.1
 
 * Initial version committed to cinnamon spices

--- a/CinnamonBurnMyWindows@klangman/README.md
+++ b/CinnamonBurnMyWindows@klangman/README.md
@@ -17,7 +17,7 @@ This extension needs the Cinnamon.GLSLEffect class which is only available in Ci
 
 ## Known issues
 
-In the setting configure window under the "Effect Settings" tab, when changing the "Show setting for effect" drop-down to select a different effect, sometimes the contents under the "Effect Specific Settings" title will not properly update. Because of this only a subset of the available options are visible. I believe this is a Cinnamon bug. You can force Cinnamon to properly redraw the options by selecting the "General" tab then selecting the "Effect Settings" tab again. After that, the complete set of "Effect Specific Settings" should be visible.
+In the setting configure window under the "Effect Settings" tab, when changing the "Show setting for effect" drop-down to select a different effect, sometimes the contents under the "Effect Specific Settings" title will not properly update. Because of this, only a subset of the available options are visible. I believe this is a Cinnamon bug. You can force Cinnamon to properly redraw the options by selecting the "General" tab then selecting the "Effect Settings" tab again. After that, the complete set of "Effect Specific Settings" should be visible.
 
 When closing the Steam Client "setting" window the 'close window effect' does not show the windows contents, resulting in the closing effect to show where the window had existed but otherwise has no negative effect.
 
@@ -57,10 +57,6 @@ Because Cinnamon is missing a required API, the following effects are disabled. 
 - PaintBrush
 - Snap Of Disintegration
 - TRex Attack
-
-## Possible future enhancements
-
-- Specifying effects that apply to specific application windows. i.e Selecting which effect occurs when closing Firefox.
 
 ## Installation
 

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/ShouldAnimateManager.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/ShouldAnimateManager.js
@@ -88,21 +88,23 @@ class ShouldAnimateManager {
    }
 
    handler(actor, types) {
-      const isNormalWindow = actor.meta_window.window_type == Meta.WindowType.NORMAL;
-      const isDialogWindow = actor.meta_window.window_type == Meta.WindowType.MODAL_DIALOG || actor.meta_window.window_type == Meta.WindowType.DIALOG;
+      if (actor) {
+         const isNormalWindow = actor.meta_window.window_type == Meta.WindowType.NORMAL;
+         const isDialogWindow = actor.meta_window.window_type == Meta.WindowType.MODAL_DIALOG || actor.meta_window.window_type == Meta.WindowType.DIALOG;
 
-      if (isNormalWindow || isDialogWindow) {
-         let stack = (new Error()).stack;
-         let event  = (stack.includes('_minimizeWindow@'  )) ? Events.Minimize      : 0;
-         event     += (stack.includes('_unminimizeWindow@')) ? Events.Unminimize    : 0;
-         event     += (stack.includes('_mapWindow@'       )) ? Events.MapWindow     : 0;
-         event     += (stack.includes('_destroyWindow@'   )) ? Events.DestroyWindow : 0;
+         if (isNormalWindow || isDialogWindow) {
+            let stack = (new Error()).stack;
+            let event  = (stack.includes('_minimizeWindow@'  )) ? Events.Minimize      : 0;
+            event     += (stack.includes('_unminimizeWindow@')) ? Events.Unminimize    : 0;
+            event     += (stack.includes('_mapWindow@'       )) ? Events.MapWindow     : 0;
+            event     += (stack.includes('_destroyWindow@'   )) ? Events.DestroyWindow : 0;
 
-         for (let i=0 ; i<Main.wm._shouldAnimateManager.length ; i++) {
-            if (event === (Main.wm._shouldAnimateManager[i].event & event)) {
-               let ret = Main.wm._shouldAnimateManager[i].handler(actor, types, event);
-               if (ret != RUN_ORIGINAL_FUNCTION) {
-                  return ret;
+            for (let i=0 ; i<Main.wm._shouldAnimateManager.length ; i++) {
+               if (event === (Main.wm._shouldAnimateManager[i].event & event)) {
+                  let ret = Main.wm._shouldAnimateManager[i].handler(actor, types, event);
+                  if (ret != RUN_ORIGINAL_FUNCTION) {
+                     return ret;
+                  }
                }
             }
          }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/settings-schema.json
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/settings-schema.json
@@ -6,7 +6,7 @@
     "general-page" : {
       "type" : "page",
       "title" : "General",
-      "sections" : ["general-settings"]
+      "sections" : ["general-settings", "app-specific-settings"]
     },
     "effects-page" : {
       "type" : "page",
@@ -23,6 +23,12 @@
       "type" : "section",
       "title" : "Burn My Windows General Settings",
       "keys" : ["open-window-effect", "close-window-effect"]
+    },
+
+    "app-specific-settings" : {
+      "type" : "section",
+      "title" : "Application Specific Settings",
+      "keys" : ["app-rules","app-rules-button"]
     },
 
     "effect-selector-section" : {
@@ -54,6 +60,63 @@
       "title" : "Effects included in the randomized sets:",
       "keys" : ["random-title", "apparition-random-include", "doom-random-include", "energize-a-random-include", "energize-b-random-include", "glide-random-include", "glitch-random-include", "hexagon-random-include", "incinerate-random-include", "pixelate-random-include", "pixel-wheel-random-include", "pixel-wipe-random-include", "portal-random-include", "tv-effect-random-include", "tv-glitch-random-include", "wisps-random-include"]
     }
+  },
+
+  "app-rules": {
+    "type" : "list",
+    "description" : "Application Specific Rules",
+    "columns" : [
+        {"id": "enabled",     "title": "Enabled",      "type": "boolean", "default": true},
+        {"id": "open",        "title": "Open Effect",  "type": "integer", "default": 0, "options": {
+            "Apparition": 0,
+            "Doom": 2,
+            "Energize A": 3,
+            "Energize B": 4,
+            "Glide": 6,
+            "Glitch": 7,
+            "Hexagon": 8,
+            "Incinerate": 9,
+            "Pixelate": 12,
+            "Pixel Wheel": 13,
+            "Pixel Wipe": 14,
+            "Portal": 15,
+            "TV Effect": 18,
+            "TV Glitch": 19,
+            "Wisps": 20,
+            "Randomized": 999,
+            "None": 1000
+           }
+        },
+        {"id": "close",       "title": "Close Effect", "type": "integer", "default": 0, "options": {
+            "Apparition": 0,
+            "Doom": 2,
+            "Energize A": 3,
+            "Energize B": 4,
+            "Glide": 6,
+            "Glitch": 7,
+            "Hexagon": 8,
+            "Incinerate": 9,
+            "Pixelate": 12,
+            "Pixel Wheel": 13,
+            "Pixel Wipe": 14,
+            "Portal": 15,
+            "TV Effect": 18,
+            "TV Glitch": 19,
+            "Wisps": 20,
+            "Randomized": 999,
+            "None": 1000
+           }
+        },
+        {"id": "application", "title": "Application",  "type": "string"}
+    ],
+    "tooltip": "A list of application with special effect rules",
+    "default": []
+  },
+  "app-rules-button" : {
+    "type" : "button",
+    "description" : "Add entry for the application of the most recently focused window",
+    "callback" : "on_config_button_pressed",
+    "tooltip" : "Focus a window you want to enable application specific setting for then return here and press this button."
   },
 
   "random-title" : {
@@ -260,7 +323,8 @@
       "TV Effect": 18,
       "TV Glitch": 19,
       "Wisps": 20,
-      "Randomized": 999
+      "Randomized": 999,
+      "None": 1000
     },
     "description": "Open window effect"
   },
@@ -284,7 +348,8 @@
       "TV Effect": 18,
       "TV Glitch": 19,
       "Wisps": 20,
-      "Randomized": 999
+      "Randomized": 999,
+      "None": 1000
     },
     "description": "Close window effect"
   },

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/metadata.json
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "CinnamonBurnMyWindows@klangman",
   "name": "Burn My Windows",
-  "version": "0.9.1",
+  "version": "0.9.2",
   "description": "Window open/close effects based on the Burn-My-Windows Gnome extension by Schneegans",
   "url": "https://github.com/klangman/CinnamonBurnMyWindows",
   "website": "https://github.com/klangman/CinnamonBurnMyWindows",

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/CinnamonBurnMyWindows@klangman.pot
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/CinnamonBurnMyWindows@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.1\n"
+"Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-02 23:13-0400\n"
+"POT-Creation-Date: 2024-09-08 23:29-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,20 +17,26 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.2/extension.js:191
+#. 6.2/extension.js:200 6.2/extension.js:415
 msgid "Error"
 msgstr ""
 
-#. 6.2/extension.js:191
+#. 6.2/extension.js:200
 msgid "was NOT enabled"
 msgstr ""
 
-#. 6.2/extension.js:192
+#. 6.2/extension.js:201
 msgid "The existing extension"
 msgstr ""
 
-#. 6.2/extension.js:192
+#. 6.2/extension.js:201
 msgid "conflicts with this extension."
+msgstr ""
+
+#. 6.2/extension.js:416
+msgid ""
+"The previously focused window is not backed by an application and therefore "
+"application specific effects can not be applied to that window"
 msgstr ""
 
 #. 6.2->settings-schema.json->apparition-random-include->description
@@ -223,6 +229,10 @@ msgstr ""
 msgid "Burn My Windows General Settings"
 msgstr ""
 
+#. 6.2->settings-schema.json->app-specific-settings->title
+msgid "Application Specific Settings"
+msgstr ""
+
 #. 6.2->settings-schema.json->effect-selector-section->title
 msgid "Effect Selector"
 msgstr ""
@@ -233,6 +243,40 @@ msgstr ""
 
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->description
+msgid "Application Specific Rules"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Enabled"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Open Effect"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Close Effect"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Application"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->tooltip
+msgid "A list of application with special effect rules"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules-button->description
+msgid "Add entry for the application of the most recently focused window"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules-button->tooltip
+msgid ""
+"Focus a window you want to enable application specific setting for then "
+"return here and press this button."
 msgstr ""
 
 #. 6.2->settings-schema.json->random-title->description
@@ -246,6 +290,11 @@ msgstr ""
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 msgid "Randomized"
+msgstr ""
+
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+msgid "None"
 msgstr ""
 
 #. 6.2->settings-schema.json->open-window-effect->description

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/ca.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-02 23:13-0400\n"
+"POT-Creation-Date: 2024-09-08 23:29-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,21 +18,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.2/extension.js:191
+#. 6.2/extension.js:200 6.2/extension.js:415
 msgid "Error"
 msgstr "Error"
 
-#. 6.2/extension.js:191
+#. 6.2/extension.js:200
 msgid "was NOT enabled"
 msgstr "no s'ha activat"
 
-#. 6.2/extension.js:192
+#. 6.2/extension.js:201
 msgid "The existing extension"
 msgstr "L'extensió existent"
 
-#. 6.2/extension.js:192
+#. 6.2/extension.js:201
 msgid "conflicts with this extension."
 msgstr "conflictivitza amb aquesta extensió."
+
+#. 6.2/extension.js:416
+msgid ""
+"The previously focused window is not backed by an application and therefore "
+"application specific effects can not be applied to that window"
+msgstr ""
 
 #. 6.2->settings-schema.json->apparition-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
@@ -226,6 +232,11 @@ msgstr "Efectes aleatoris"
 msgid "Burn My Windows General Settings"
 msgstr "Opcions generals de Burn My Windows"
 
+#. 6.2->settings-schema.json->app-specific-settings->title
+#, fuzzy
+msgid "Application Specific Settings"
+msgstr "Opcions específiques d'efectes"
+
 #. 6.2->settings-schema.json->effect-selector-section->title
 msgid "Effect Selector"
 msgstr "Selector d'efecte"
@@ -237,6 +248,43 @@ msgstr "Opcions específiques d'efectes"
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
 msgstr "Efectes inclosos als conjunts aleatoris:"
+
+#. 6.2->settings-schema.json->app-rules->description
+msgid "Application Specific Rules"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Enabled"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+#, fuzzy
+msgid "Open Effect"
+msgstr "Efecte"
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+#, fuzzy
+msgid "Close Effect"
+msgstr "Efecte de tancament de finestra"
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+#, fuzzy
+msgid "Application"
+msgstr "Aparició"
+
+#. 6.2->settings-schema.json->app-rules->tooltip
+msgid "A list of application with special effect rules"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules-button->description
+msgid "Add entry for the application of the most recently focused window"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules-button->tooltip
+msgid ""
+"Focus a window you want to enable application specific setting for then "
+"return here and press this button."
+msgstr ""
 
 #. 6.2->settings-schema.json->random-title->description
 msgid "Effect"
@@ -250,6 +298,11 @@ msgstr "Mostrar les opcions per efecte:"
 #. 6.2->settings-schema.json->close-window-effect->options
 msgid "Randomized"
 msgstr "Aleatori"
+
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+msgid "None"
+msgstr ""
 
 #. 6.2->settings-schema.json->open-window-effect->description
 msgid "Open window effect"

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/es.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-02 23:13-0400\n"
+"POT-Creation-Date: 2024-09-08 23:29-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,21 +17,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. 6.2/extension.js:191
+#. 6.2/extension.js:200 6.2/extension.js:415
 msgid "Error"
 msgstr "Error"
 
-#. 6.2/extension.js:191
+#. 6.2/extension.js:200
 msgid "was NOT enabled"
 msgstr "no estaba habilitado"
 
-#. 6.2/extension.js:192
+#. 6.2/extension.js:201
 msgid "The existing extension"
 msgstr "La extensión existente"
 
-#. 6.2/extension.js:192
+#. 6.2/extension.js:201
 msgid "conflicts with this extension."
 msgstr "entra en conflicto con esta extensión."
+
+#. 6.2/extension.js:416
+msgid ""
+"The previously focused window is not backed by an application and therefore "
+"application specific effects can not be applied to that window"
+msgstr ""
 
 #. 6.2->settings-schema.json->apparition-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
@@ -225,6 +231,11 @@ msgstr "Efectos aleatorios"
 msgid "Burn My Windows General Settings"
 msgstr "Configuración general de Burn My Windows"
 
+#. 6.2->settings-schema.json->app-specific-settings->title
+#, fuzzy
+msgid "Application Specific Settings"
+msgstr "Ajustes específicos del efecto"
+
 #. 6.2->settings-schema.json->effect-selector-section->title
 msgid "Effect Selector"
 msgstr "Selector de efecto"
@@ -236,6 +247,43 @@ msgstr "Ajustes específicos del efecto"
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
 msgstr "Efectos incluidos en las series aleatorias:"
+
+#. 6.2->settings-schema.json->app-rules->description
+msgid "Application Specific Rules"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Enabled"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+#, fuzzy
+msgid "Open Effect"
+msgstr "Efecto"
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+#, fuzzy
+msgid "Close Effect"
+msgstr "Efecto para cerrar ventana"
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+#, fuzzy
+msgid "Application"
+msgstr "Aparición"
+
+#. 6.2->settings-schema.json->app-rules->tooltip
+msgid "A list of application with special effect rules"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules-button->description
+msgid "Add entry for the application of the most recently focused window"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules-button->tooltip
+msgid ""
+"Focus a window you want to enable application specific setting for then "
+"return here and press this button."
+msgstr ""
 
 #. 6.2->settings-schema.json->random-title->description
 msgid "Effect"
@@ -249,6 +297,11 @@ msgstr "Muestra la configuración del efecto:"
 #. 6.2->settings-schema.json->close-window-effect->options
 msgid "Randomized"
 msgstr "Aleatorio"
+
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+msgid "None"
+msgstr ""
 
 #. 6.2->settings-schema.json->open-window-effect->description
 msgid "Open window effect"
@@ -369,8 +422,7 @@ msgstr "Mezclas de aditivos"
 #. 6.2->settings-schema.json->hexagon-additive-blending->tooltip
 msgid "You may want to enable this for dark window themes."
 msgstr ""
-"Es posible que desee activar esta opción para los temas de ventanas "
-"oscuras."
+"Es posible que desee activar esta opción para los temas de ventanas oscuras."
 
 #. 6.2->settings-schema.json->incinerate-turbulence->description
 msgid "Turbulence"


### PR DESCRIPTION
1. Added application specific effect settings that override the default effects setting when a specific application window is opened/closed
2. Added a "none" options to the effect drop-down lists which will perform no effect and allow the cinnamon default effect to apply
3. Added a button in the General configuration tab which will add an "Application Specific Settings" table entry for the application of the window that last had the focused.