### PR TITLE
[compiz-windows-effect@hermes83.github.com] Fix two bugs

### DIFF
--- a/compiz-windows-effect@hermes83.github.com/files/compiz-windows-effect@hermes83.github.com/extension.js
+++ b/compiz-windows-effect@hermes83.github.com/files/compiz-windows-effect@hermes83.github.com/extension.js
@@ -115,7 +115,7 @@ class CompizWindowsEffectExtension {
                     effect.destroy();
                 }
             }
-        });
+        }, this );
     }
 
     onBeginGrabOp(display, screen, window, op) {
@@ -211,7 +211,7 @@ class CompizWindowsEffectExtension {
 }
 
 const WobblyEffect = new Lang.Class({
-    Name: 'WobblyEffect',
+    Name: `WobblyEffect_${Math.floor(Math.random() * 100000) + 1}`,
     Extends: Clutter.DeformEffect,
 
     _init: function(op) {


### PR DESCRIPTION
1. Fixed a bug in the disable() method where 'this' is not defined resulting in a failure to properly clean up after disabling the extension.
2. Fixed the class register so that it uses a random number in the name to avoid a failure if the extension is re-enabled without a cinnamon restart.