### PR TITLE
[slider@mohammad-sn] Prevent loading in Cinnamon 4+

### DIFF
--- a/slider@mohammad-sn/files/slider@mohammad-sn/po/ca.po
+++ b/slider@mohammad-sn/files/slider@mohammad-sn/po/ca.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# SLIDER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Odyssey <odysseyhyd@gmail.com>, 2024
@@ -7,8 +7,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-02 21:59+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
+"extensions/issues\n"
+"POT-Creation-Date: 2024-09-26 21:42-0400\n"
 "PO-Revision-Date: 2024-07-25 18:25+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -17,6 +18,18 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
+
+#. extension.js:133
+msgid "ERROR"
+msgstr ""
+
+#. extension.js:133
+msgid "Slider was NOT enabled"
+msgstr ""
+
+#. extension.js:134
+msgid "This extension is currently incompatible with your version of Cinnamon."
+msgstr ""
 
 #. metadata.json->description
 msgid "Yet another nice transition effect for ws switching."

--- a/slider@mohammad-sn/files/slider@mohammad-sn/po/da.po
+++ b/slider@mohammad-sn/files/slider@mohammad-sn/po/da.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# SLIDER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# mohammad-sn, 2017
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-02 21:59+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
+"extensions/issues\n"
+"POT-Creation-Date: 2024-09-26 21:42-0400\n"
 "PO-Revision-Date: 2021-03-02 23:01+0100\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -17,6 +18,18 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. extension.js:133
+msgid "ERROR"
+msgstr ""
+
+#. extension.js:133
+msgid "Slider was NOT enabled"
+msgstr ""
+
+#. extension.js:134
+msgid "This extension is currently incompatible with your version of Cinnamon."
+msgstr ""
 
 #. metadata.json->description
 msgid "Yet another nice transition effect for ws switching."
@@ -53,93 +66,3 @@ msgstr "Baggrundens zoomniveau:"
 #. settings-schema.json->vertical-position->description
 msgid "Background Vertical Position:"
 msgstr "Baggrundens lodrette placering:"
-
-#~ msgid "easeInOutBounce"
-#~ msgstr "easeInOutBounce"
-
-#~ msgid "easeInOutExpo"
-#~ msgstr "easeInOutExpo"
-
-#~ msgid "easeOutCubic"
-#~ msgstr "easeOutCubic"
-
-#~ msgid "easeInOutCubic"
-#~ msgstr "easeInOutCubic"
-
-#~ msgid "easeInOutCirc"
-#~ msgstr "easeInOutCirc"
-
-#~ msgid "easeInQuart"
-#~ msgstr "easeInQuart"
-
-#~ msgid "easeInBounce"
-#~ msgstr "easeInBounce"
-
-#~ msgid "easeOutQuad"
-#~ msgstr "easeOutQuad"
-
-#~ msgid "easeInQuint"
-#~ msgstr "easeInQuint"
-
-#~ msgid "easeOutElastic"
-#~ msgstr "easeOutElastic"
-
-#~ msgid "easeOutQuint"
-#~ msgstr "easeOutQuint"
-
-#~ msgid "easeInOutElastic"
-#~ msgstr "easeInOutElastic"
-
-#~ msgid "easeInExpo"
-#~ msgstr "easeInExpo"
-
-#~ msgid "easeInOutSine"
-#~ msgstr "easeInOutSine"
-
-#~ msgid "easeInOutQuad"
-#~ msgstr "easeInOutQuad"
-
-#~ msgid "easeInQuad"
-#~ msgstr "easeInQuad"
-
-#~ msgid "easeOutSine"
-#~ msgstr "easeOutSine"
-
-#~ msgid "easeOutExpo"
-#~ msgstr "easeOutExpo"
-
-#~ msgid "easeOutBounce"
-#~ msgstr "easeOutBounce"
-
-#~ msgid "easeOutBack"
-#~ msgstr "easeOutBack"
-
-#~ msgid "easeInOutQuint"
-#~ msgstr "easeInOutQuint"
-
-#~ msgid "easeOutCirc"
-#~ msgstr "easeOutCirc"
-
-#~ msgid "easeInCirc"
-#~ msgstr "easeInCirc"
-
-#~ msgid "easeInElastic"
-#~ msgstr "easeInElastic"
-
-#~ msgid "easeInBack"
-#~ msgstr "easeInBack"
-
-#~ msgid "easeInSine"
-#~ msgstr "easeInSine"
-
-#~ msgid "easeOutQuart"
-#~ msgstr "easeOutQuart"
-
-#~ msgid "easeInOutQuart"
-#~ msgstr "easeInOutQuart"
-
-#~ msgid "easeInCubic"
-#~ msgstr "easeInCubic"
-
-#~ msgid "easeInOutBack"
-#~ msgstr "easeInOutBack"

--- a/slider@mohammad-sn/files/slider@mohammad-sn/po/de.po
+++ b/slider@mohammad-sn/files/slider@mohammad-sn/po/de.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# SLIDER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# mohammad-sn, 2017
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-02 21:59+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
+"extensions/issues\n"
+"POT-Creation-Date: 2024-09-26 21:42-0400\n"
 "PO-Revision-Date: 2021-03-02 23:00+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,6 +18,18 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. extension.js:133
+msgid "ERROR"
+msgstr ""
+
+#. extension.js:133
+msgid "Slider was NOT enabled"
+msgstr ""
+
+#. extension.js:134
+msgid "This extension is currently incompatible with your version of Cinnamon."
+msgstr ""
 
 #. metadata.json->description
 msgid "Yet another nice transition effect for ws switching."
@@ -53,93 +66,3 @@ msgstr "Hintergrund vergrößern um:"
 #. settings-schema.json->vertical-position->description
 msgid "Background Vertical Position:"
 msgstr "Vertikale Position des Hintergrundes:"
-
-#~ msgid "easeInOutBounce"
-#~ msgstr "easeInOutBounce"
-
-#~ msgid "easeInOutExpo"
-#~ msgstr "easeInOutExpo"
-
-#~ msgid "easeOutCubic"
-#~ msgstr "easeOutCubic"
-
-#~ msgid "easeInOutCubic"
-#~ msgstr "easeInOutCubic"
-
-#~ msgid "easeInOutCirc"
-#~ msgstr "easeInOutCirc"
-
-#~ msgid "easeInQuart"
-#~ msgstr "easeInQuart"
-
-#~ msgid "easeInBounce"
-#~ msgstr "easeInBounce"
-
-#~ msgid "easeOutQuad"
-#~ msgstr "easeOutQuad"
-
-#~ msgid "easeInQuint"
-#~ msgstr "easeInQuint"
-
-#~ msgid "easeOutElastic"
-#~ msgstr "easeOutElastic"
-
-#~ msgid "easeOutQuint"
-#~ msgstr "easeOutQuint"
-
-#~ msgid "easeInOutElastic"
-#~ msgstr "easeInOutElastic"
-
-#~ msgid "easeInExpo"
-#~ msgstr "easeInExpo"
-
-#~ msgid "easeInOutSine"
-#~ msgstr "easeInOutSine"
-
-#~ msgid "easeInOutQuad"
-#~ msgstr "easeInOutQuad"
-
-#~ msgid "easeInQuad"
-#~ msgstr "easeInQuad"
-
-#~ msgid "easeOutSine"
-#~ msgstr "easeOutSine"
-
-#~ msgid "easeOutExpo"
-#~ msgstr "easeOutExpo"
-
-#~ msgid "easeOutBounce"
-#~ msgstr "easeOutBounce"
-
-#~ msgid "easeOutBack"
-#~ msgstr "easeOutBack"
-
-#~ msgid "easeInOutQuint"
-#~ msgstr "easeInOutQuint"
-
-#~ msgid "easeOutCirc"
-#~ msgstr "easeOutCirc"
-
-#~ msgid "easeInCirc"
-#~ msgstr "easeInCirc"
-
-#~ msgid "easeInElastic"
-#~ msgstr "easeInElastic"
-
-#~ msgid "easeInBack"
-#~ msgstr "easeInBack"
-
-#~ msgid "easeInSine"
-#~ msgstr "easeInSine"
-
-#~ msgid "easeOutQuart"
-#~ msgstr "easeOutQuart"
-
-#~ msgid "easeInOutQuart"
-#~ msgstr "easeInOutQuart"
-
-#~ msgid "easeInCubic"
-#~ msgstr "easeInCubic"
-
-#~ msgid "easeInOutBack"
-#~ msgstr "easeInOutBack"

--- a/slider@mohammad-sn/files/slider@mohammad-sn/po/es.po
+++ b/slider@mohammad-sn/files/slider@mohammad-sn/po/es.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# SLIDER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# mohammad-sn, 2017
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-02 21:59+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
+"extensions/issues\n"
+"POT-Creation-Date: 2024-09-26 21:42-0400\n"
 "PO-Revision-Date: 2023-11-03 12:02-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -16,6 +17,18 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4\n"
+
+#. extension.js:133
+msgid "ERROR"
+msgstr ""
+
+#. extension.js:133
+msgid "Slider was NOT enabled"
+msgstr ""
+
+#. extension.js:134
+msgid "This extension is currently incompatible with your version of Cinnamon."
+msgstr ""
 
 #. metadata.json->description
 msgid "Yet another nice transition effect for ws switching."

--- a/slider@mohammad-sn/files/slider@mohammad-sn/po/eu.po
+++ b/slider@mohammad-sn/files/slider@mohammad-sn/po/eu.po
@@ -1,14 +1,15 @@
-# SOME DESCRIPTIVE TITLE.
+# SLIDER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# mohammad-sn, 2017
 #
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-02 21:59+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
+"extensions/issues\n"
+"POT-Creation-Date: 2024-09-26 21:42-0400\n"
 "PO-Revision-Date: 2024-05-30 9:50+1\n"
 "Last-Translator: Muxutruk <muxutruk2@users.noreply.github.com>\n"
 "Language-Team: Basque <muxutruk2@users.noreply.github.com>\n"
@@ -16,6 +17,18 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#. extension.js:133
+msgid "ERROR"
+msgstr ""
+
+#. extension.js:133
+msgid "Slider was NOT enabled"
+msgstr ""
+
+#. extension.js:134
+msgid "This extension is currently incompatible with your version of Cinnamon."
+msgstr ""
 
 #. metadata.json->description
 msgid "Yet another nice transition effect for ws switching."

--- a/slider@mohammad-sn/files/slider@mohammad-sn/po/hu.po
+++ b/slider@mohammad-sn/files/slider@mohammad-sn/po/hu.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# SLIDER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# mohammad-sn, 2017
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-02 21:59+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
+"extensions/issues\n"
+"POT-Creation-Date: 2024-09-26 21:42-0400\n"
 "PO-Revision-Date: 2021-09-26 08:38+0200\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
@@ -16,6 +17,18 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
+
+#. extension.js:133
+msgid "ERROR"
+msgstr ""
+
+#. extension.js:133
+msgid "Slider was NOT enabled"
+msgstr ""
+
+#. extension.js:134
+msgid "This extension is currently incompatible with your version of Cinnamon."
+msgstr ""
 
 #. metadata.json->description
 msgid "Yet another nice transition effect for ws switching."

--- a/slider@mohammad-sn/files/slider@mohammad-sn/po/it.po
+++ b/slider@mohammad-sn/files/slider@mohammad-sn/po/it.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# SLIDER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# mohammad-sn, 2017
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-02 21:59+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
+"extensions/issues\n"
+"POT-Creation-Date: 2024-09-26 21:42-0400\n"
 "PO-Revision-Date: 2022-06-03 11:17+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -17,6 +18,18 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#. extension.js:133
+msgid "ERROR"
+msgstr ""
+
+#. extension.js:133
+msgid "Slider was NOT enabled"
+msgstr ""
+
+#. extension.js:134
+msgid "This extension is currently incompatible with your version of Cinnamon."
+msgstr ""
 
 #. metadata.json->description
 msgid "Yet another nice transition effect for ws switching."

--- a/slider@mohammad-sn/files/slider@mohammad-sn/po/nl.po
+++ b/slider@mohammad-sn/files/slider@mohammad-sn/po/nl.po
@@ -1,13 +1,14 @@
-# SOME DESCRIPTIVE TITLE.
+# SLIDER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# mohammad-sn, 2017
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-02 21:59+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
+"extensions/issues\n"
+"POT-Creation-Date: 2024-09-26 21:42-0400\n"
 "PO-Revision-Date: 2024-04-17 09:55+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -15,6 +16,18 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#. extension.js:133
+msgid "ERROR"
+msgstr ""
+
+#. extension.js:133
+msgid "Slider was NOT enabled"
+msgstr ""
+
+#. extension.js:134
+msgid "This extension is currently incompatible with your version of Cinnamon."
+msgstr ""
 
 #. metadata.json->description
 msgid "Yet another nice transition effect for ws switching."

--- a/slider@mohammad-sn/files/slider@mohammad-sn/po/pt_BR.po
+++ b/slider@mohammad-sn/files/slider@mohammad-sn/po/pt_BR.po
@@ -1,4 +1,4 @@
-# SOME DESCRIPTIVE TITLE.
+# SLIDER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # Marcelo Aof, 2021.
@@ -6,17 +6,30 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-02 21:59+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
+"extensions/issues\n"
+"POT-Creation-Date: 2024-09-26 21:42-0400\n"
 "PO-Revision-Date: 2021-09-26 21:23-0300\n"
+"Last-Translator: Marcelo Aof\n"
 "Language-Team: \n"
+"Language: pt_BR\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.0\n"
-"Last-Translator: Marcelo Aof\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
-"Language: pt_BR\n"
+
+#. extension.js:133
+msgid "ERROR"
+msgstr ""
+
+#. extension.js:133
+msgid "Slider was NOT enabled"
+msgstr ""
+
+#. extension.js:134
+msgid "This extension is currently incompatible with your version of Cinnamon."
+msgstr ""
 
 #. metadata.json->description
 msgid "Yet another nice transition effect for ws switching."

--- a/slider@mohammad-sn/files/slider@mohammad-sn/po/ro.po
+++ b/slider@mohammad-sn/files/slider@mohammad-sn/po/ro.po
@@ -1,26 +1,41 @@
-# SOME DESCRIPTIVE TITLE.
+# SLIDER
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# mohammad-sn, 2017
 #
 msgid ""
 msgstr ""
-"Content-Transfer-Encoding: 8bit\n"
-"Content-Type: text/plain; charset=UTF-8\n"
-"Language: ro\n"
-"Language-Team: \n"
-"Last-Translator: \n"
-"MIME-Version: 1.0\n"
-"PO-Revision-Date: 2022-08-06 01:54+0200\n"
-"POT-Creation-Date: 2021-03-02 21:59+0000\n"
-"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n==0 || (n!=1 && n%100>=1 && n%100<=19) ? 1 : 2);\n"
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
+"extensions/issues\n"
+"POT-Creation-Date: 2024-09-26 21:42-0400\n"
+"PO-Revision-Date: 2022-08-06 01:54+0200\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: ro\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=3; plural=(n==1 ? 0 : n==0 || (n!=1 && n%100>=1 && "
+"n%100<=19) ? 1 : 2);\n"
 "X-Generator: Poedit 3.0.1\n"
+
+#. extension.js:133
+msgid "ERROR"
+msgstr ""
+
+#. extension.js:133
+msgid "Slider was NOT enabled"
+msgstr ""
+
+#. extension.js:134
+msgid "This extension is currently incompatible with your version of Cinnamon."
+msgstr ""
 
 #. metadata.json->description
 msgid "Yet another nice transition effect for ws switching."
-msgstr "Încă un efect de tranziție frumos pentru trecerea la alt spațiu de lucru."
+msgstr ""
+"Încă un efect de tranziție frumos pentru trecerea la alt spațiu de lucru."
 
 #. metadata.json->name
 msgid "Slider"

--- a/slider@mohammad-sn/files/slider@mohammad-sn/po/ru.po
+++ b/slider@mohammad-sn/files/slider@mohammad-sn/po/ru.po
@@ -2,8 +2,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-02 21:59+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
+"extensions/issues\n"
+"POT-Creation-Date: 2024-09-26 21:42-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: blogdron\n"
 "Language-Team: \n"
@@ -12,6 +13,18 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.1\n"
+
+#. extension.js:133
+msgid "ERROR"
+msgstr ""
+
+#. extension.js:133
+msgid "Slider was NOT enabled"
+msgstr ""
+
+#. extension.js:134
+msgid "This extension is currently incompatible with your version of Cinnamon."
+msgstr ""
 
 #. metadata.json->description
 msgid "Yet another nice transition effect for ws switching."

--- a/slider@mohammad-sn/files/slider@mohammad-sn/po/slider@mohammad-sn.pot
+++ b/slider@mohammad-sn/files/slider@mohammad-sn/po/slider@mohammad-sn.pot
@@ -1,21 +1,33 @@
-# SOME DESCRIPTIVE TITLE.
-# Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
-# This file is distributed under the same license as the PACKAGE package.
-# FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
+# SLIDER
+# This file is put in the public domain.
+# mohammad-sn, 2017
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: PACKAGE VERSION\n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-02 21:59+0000\n"
-"PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
-"Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
-"Language-Team: LANGUAGE <LL@li.org>\n"
+"Project-Id-Version: slider@mohammad-sn 0.7\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
+"extensions/issues\n"
+"POT-Creation-Date: 2024-09-26 21:42-0400\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
 "Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
+
+#. extension.js:133
+msgid "ERROR"
+msgstr ""
+
+#. extension.js:133
+msgid "Slider was NOT enabled"
+msgstr ""
+
+#. extension.js:134
+msgid "This extension is currently incompatible with your version of Cinnamon."
+msgstr ""
 
 #. metadata.json->description
 msgid "Yet another nice transition effect for ws switching."

--- a/slider@mohammad-sn/files/slider@mohammad-sn/po/zh_CN.po
+++ b/slider@mohammad-sn/files/slider@mohammad-sn/po/zh_CN.po
@@ -2,8 +2,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: \n"
-"Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-03-02 21:59+0000\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
+"extensions/issues\n"
+"POT-Creation-Date: 2024-09-26 21:42-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: 张鹏 <scbeta@qq.com>\n"
 "Language-Team: \n"
@@ -13,6 +14,18 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 "X-Generator: Poedit 3.4.4\n"
+
+#. extension.js:133
+msgid "ERROR"
+msgstr ""
+
+#. extension.js:133
+msgid "Slider was NOT enabled"
+msgstr ""
+
+#. extension.js:134
+msgid "This extension is currently incompatible with your version of Cinnamon."
+msgstr ""
 
 #. metadata.json->description
 msgid "Yet another nice transition effect for ws switching."
@@ -49,93 +62,3 @@ msgstr "背景缩放级别："
 #. settings-schema.json->vertical-position->description
 msgid "Background Vertical Position:"
 msgstr "背景垂直位置："
-
-#~ msgid "easeInOutBounce"
-#~ msgstr "easeInOutBounce"
-
-#~ msgid "easeInOutExpo"
-#~ msgstr "easeInOutExpo"
-
-#~ msgid "easeOutCubic"
-#~ msgstr "easeOutCubic"
-
-#~ msgid "easeInOutCubic"
-#~ msgstr "easeInOutCubic"
-
-#~ msgid "easeInOutCirc"
-#~ msgstr "easeInOutCirc"
-
-#~ msgid "easeInQuart"
-#~ msgstr "easeInQuart"
-
-#~ msgid "easeInBounce"
-#~ msgstr "easeInBounce"
-
-#~ msgid "easeOutQuad"
-#~ msgstr "easeOutQuad"
-
-#~ msgid "easeInQuint"
-#~ msgstr "easeInQuint"
-
-#~ msgid "easeOutElastic"
-#~ msgstr "easeOutElastic"
-
-#~ msgid "easeOutQuint"
-#~ msgstr "easeOutQuint"
-
-#~ msgid "easeInOutElastic"
-#~ msgstr "easeInOutElastic"
-
-#~ msgid "easeInExpo"
-#~ msgstr "easeInExpo"
-
-#~ msgid "easeInOutSine"
-#~ msgstr "easeInOutSine"
-
-#~ msgid "easeInOutQuad"
-#~ msgstr "easeInOutQuad"
-
-#~ msgid "easeInQuad"
-#~ msgstr "easeInQuad"
-
-#~ msgid "easeOutSine"
-#~ msgstr "easeOutSine"
-
-#~ msgid "easeOutExpo"
-#~ msgstr "easeOutExpo"
-
-#~ msgid "easeOutBounce"
-#~ msgstr "easeOutBounce"
-
-#~ msgid "easeOutBack"
-#~ msgstr "easeOutBack"
-
-#~ msgid "easeInOutQuint"
-#~ msgstr "easeInOutQuint"
-
-#~ msgid "easeOutCirc"
-#~ msgstr "easeOutCirc"
-
-#~ msgid "easeInCirc"
-#~ msgstr "easeInCirc"
-
-#~ msgid "easeInElastic"
-#~ msgstr "easeInElastic"
-
-#~ msgid "easeInBack"
-#~ msgstr "easeInBack"
-
-#~ msgid "easeInSine"
-#~ msgstr "easeInSine"
-
-#~ msgid "easeOutQuart"
-#~ msgstr "easeOutQuart"
-
-#~ msgid "easeInOutQuart"
-#~ msgstr "easeInOutQuart"
-
-#~ msgid "easeInCubic"
-#~ msgstr "easeInCubic"
-
-#~ msgid "easeInOutBack"
-#~ msgstr "easeInOutBack"


### PR DESCRIPTION
This extension has been very broken for many years. The changes here just prevent the extension from breaking the desktop by refusing to operate when the cinnamon major version is 4 or higher. If the extension is ever fixed the code can be removed.