### PR TITLE
[CinnamonMagicLamp@klangman] Fix for restore/maximize effects

### DIFF
--- a/CinnamonMagicLamp@klangman/CHANGELOG.md
+++ b/CinnamonMagicLamp@klangman/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.0.3
+
+* Fix an issue that caused some default Cinnamon effect (i.e. Restore and Maximize effects) to be disabled when Magic Lamp effects were enabled.
+
 ## 1.0.2
 
 * Removed the need to change the System-Settings->Effect settings to "none" for the Minimize/Unminimize options. This is now accomplished by intercepting a cinnamon API and forcing it to disable the Cinnamon Minimize/Unminimize effects while the MagicLamp extension is enabled.

--- a/CinnamonMagicLamp@klangman/README.md
+++ b/CinnamonMagicLamp@klangman/README.md
@@ -1,6 +1,6 @@
 # CinnamonMagicLamp
 
-A compiz like magic lamp effect for the Cinnamon desktop based on hermes83's Gnome extension (https://github.com/hermes83/compiz-alike-magic-lamp-effect)
+A compiz like magic lamp effect for the Cinnamon desktop based on hermes83's Gnome extension (https://github.com/hermes83/compiz-alike-magic-lamp-effect). **Please see Feedback section below to report issues, DO NOT open issues on hermes83's Gnome extension github**
 
 This Cinnamon extension will create a Magic Lamp minimize and unminimize effect
 
@@ -8,13 +8,13 @@ This Cinnamon extension will create a Magic Lamp minimize and unminimize effect
 
 Cinnamon 5.6.8 (Mint 21.1) or better.
 
-To properly animate in relation to the window-list icon, you need to be using a window-list applet that sets the icon geometry. Otherwise the animation will animate from/to the middle of the monitor on the Cinnamon panel edge rather than an animation specific to the window. The pre-installed "Window list" and "Grouped window list" applets work fine as does "Cassia Window list" (version 2.3.2 or better). CobiWindowList does not currently set icon geometry.
+To properly animate in relation to the window-list icon, you need to be using a window-list applet that sets the icon geometry. Otherwise the animation will animate from/to the middle of the monitor on the Cinnamon panel edge rather than an animation specific to the window and it's window-list icon. The pre-installed "Window list" and "Grouped window list" applets work fine as does "Cassia Window list" (version 2.3.2 or better). CobiWindowList does not currently set icon geometry.
 
 This extension requires no other packages other than what is included in a default installation of Mint 21.1 or better.
 
 ## Known issues
 
-The Steam client for some reason does not support window cloning when minimized, therefore the "minimize" effect will show a blank/black window rather than the correct window contents. Other application might have the same behaviour but I have not seen any yet.
+For some reason the Steam client does not support window cloning when minimized, therefore the "minimize" effect will show a blank/black window rather than the correct window contents. I have not seen any other applications show this behaviour.
 
 ## Installation
 

--- a/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/5.6/ShouldAnimateManager.js
+++ b/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/5.6/ShouldAnimateManager.js
@@ -68,7 +68,6 @@ class ShouldAnimateManager {
    }
 
    disconnect() {
-      log( "in disconnect" );
       for (let i=0 ; i<Main.wm._shouldAnimateManager.length ; i++) {
          if (Main.wm._shouldAnimateManager[i].owner == this._uuid) {
             Main.wm._shouldAnimateManager.splice( i, 1 );
@@ -88,21 +87,23 @@ class ShouldAnimateManager {
    }
 
    handler(actor, types) {
-      const isNormalWindow = actor.meta_window.window_type == Meta.WindowType.NORMAL;
-      const isDialogWindow = actor.meta_window.window_type == Meta.WindowType.MODAL_DIALOG || actor.meta_window.window_type == Meta.WindowType.DIALOG;
+      if (actor) {
+         const isNormalWindow = actor.meta_window.window_type == Meta.WindowType.NORMAL;
+         const isDialogWindow = actor.meta_window.window_type == Meta.WindowType.MODAL_DIALOG || actor.meta_window.window_type == Meta.WindowType.DIALOG;
 
-      if (isNormalWindow || isDialogWindow) {
-         let stack = (new Error()).stack;
-         let event  = (stack.includes('_minimizeWindow@'  )) ? Events.Minimize      : 0;
-         event     += (stack.includes('_unminimizeWindow@')) ? Events.Unminimize    : 0;
-         event     += (stack.includes('_mapWindow@'       )) ? Events.MapWindow     : 0;
-         event     += (stack.includes('_destroyWindow@'   )) ? Events.DestroyWindow : 0;
+         if (isNormalWindow || isDialogWindow) {
+            let stack = (new Error()).stack;
+            let event  = (stack.includes('_minimizeWindow@'  )) ? Events.Minimize      : 0;
+            event     += (stack.includes('_unminimizeWindow@')) ? Events.Unminimize    : 0;
+            event     += (stack.includes('_mapWindow@'       )) ? Events.MapWindow     : 0;
+            event     += (stack.includes('_destroyWindow@'   )) ? Events.DestroyWindow : 0;
 
-         for (let i=0 ; i<Main.wm._shouldAnimateManager.length ; i++) {
-            if (event === (Main.wm._shouldAnimateManager[i].event & event)) {
-               let ret = Main.wm._shouldAnimateManager[i].handler(actor, types, event);
-               if (ret != RUN_ORIGINAL_FUNCTION) {
-                  return ret;
+            for (let i=0 ; i<Main.wm._shouldAnimateManager.length ; i++) {
+               if (event && event === (Main.wm._shouldAnimateManager[i].event & event)) {
+                  let ret = Main.wm._shouldAnimateManager[i].handler(actor, types, event);
+                  if (ret != RUN_ORIGINAL_FUNCTION) {
+                     return ret;
+                  }
                }
             }
          }

--- a/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/metadata.json
+++ b/CinnamonMagicLamp@klangman/files/CinnamonMagicLamp@klangman/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "CinnamonMagicLamp@klangman",
   "name": "Magic Lamp Effect",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "A minimize/unminimize magic lamp effect based on hermes83's Gnome extension",
   "url": "https://github.com/klangman/CinnamonMagicLamp",
   "website": "https://github.com/klangman/CinnamonMagicLamp",


### PR DESCRIPTION
The ShouldAnimateManager was failing to call the original Cinnamon _shouldAnimate() function for cases where the event context was not one that the manager is currently interested in. This meant that some Cinnamon's effects like maximize and restore (and maybe others) were failing to execute.