### PR TITLE
[CinnamonBurnMyWindows@klangman] Fix for forcing Cinnamon effects on

### DIFF
--- a/CinnamonBurnMyWindows@klangman/CHANGELOG.md
+++ b/CinnamonBurnMyWindows@klangman/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.9.4
+
+* Fixed an issue that could interfere with other Cinnamon effects by returning true from Cinnamon's _shouldAnimate(). Some effects like Restore and Manximize might occur even when they were disabled in the Cinnamon Effects setting application. Also some BurnMyWindows effect could happen on events other than window open/close events (but I didn't ever see this occur myself).
+
 ## 0.9.3
 
 * Fix Randomized effects so that when the Doom effect is enabled under "Random Effects" it can actually be randomly selected for use

--- a/CinnamonBurnMyWindows@klangman/README.md
+++ b/CinnamonBurnMyWindows@klangman/README.md
@@ -27,7 +27,7 @@ The Doom open effect seems to finish animating at a noticeably lower position th
 
 All open window effects seem to animate in a location that is one pixel off the windows real location. This causes a very small (nearly unnoticeable) jump of the window after the animation has finished. The only exception is "Doom", which as stated above has a more pronounced jump.
 
-The window shadows are not part of the animation and therefore they suddenly appear right after the animation completes.
+The window shadows are not part of the animation and therefore they suddenly appear or disappear right after or before the animation.
 
 ### Currently these effects are working in Cinnamon:
 

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/ShouldAnimateManager.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/ShouldAnimateManager.js
@@ -68,7 +68,6 @@ class ShouldAnimateManager {
    }
 
    disconnect() {
-      log( "in disconnect" );
       for (let i=0 ; i<Main.wm._shouldAnimateManager.length ; i++) {
          if (Main.wm._shouldAnimateManager[i].owner == this._uuid) {
             Main.wm._shouldAnimateManager.splice( i, 1 );
@@ -100,7 +99,7 @@ class ShouldAnimateManager {
             event     += (stack.includes('_destroyWindow@'   )) ? Events.DestroyWindow : 0;
 
             for (let i=0 ; i<Main.wm._shouldAnimateManager.length ; i++) {
-               if (event === (Main.wm._shouldAnimateManager[i].event & event)) {
+               if (event && event === (Main.wm._shouldAnimateManager[i].event & event)) {
                   let ret = Main.wm._shouldAnimateManager[i].handler(actor, types, event);
                   if (ret != RUN_ORIGINAL_FUNCTION) {
                      return ret;

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/metadata.json
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "CinnamonBurnMyWindows@klangman",
   "name": "Burn My Windows",
-  "version": "0.9.3",
+  "version": "0.9.4",
   "description": "Window open/close effects based on the Burn-My-Windows Gnome extension by Schneegans",
   "url": "https://github.com/klangman/CinnamonBurnMyWindows",
   "website": "https://github.com/klangman/CinnamonBurnMyWindows",


### PR DESCRIPTION
The ShouldAnimateManager was failing to call the original Cinnamon _shouldAnimate() function for cases where the event context was not one that the manager is currently interested in. This meant that some Cinnamon's effects like maximize and restore would apply even if the Cinnamon Effects settings had them disabled.