### PR TITLE
[DesktopCube@yare] Version 2.0.0

### DIFF
--- a/DesktopCube@yare/CHANGELOG.md
+++ b/DesktopCube@yare/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.0.0
+
+* Added ability to use Cube effect when changing the workspace via the "Workspace Switcher" applet
+* Added ability to use Cube effect when changing the workspace by activating a window on a different workspace
+* Added ability to use Cube effect when using the workspace "Direct Navigation" hotkeys
+* Enabled showing the desktop icons during the Cube effect
+* Allow the Cube to queue up hotkey press actions rather than ignoring hotkey presses during the Cube animation
+* Changed the "Animation duration" option to be a number of seconds (0.1 to 4 seconds)
+* Changed the Pullaway setting to be a "Cube size" as a percentage of the screen size
+* Added button to the Cube config which will launch the keyboard setting dialog as a convenient access to setting workspace related hotkeys
+* The Cube rotation and the scale down to the target Cube size effects will now run in parallel, this saves animation time and makes the animation look smoother. As a side effect, the easing for the scale down action is now hard-coded to "easeNone" and the user defined "Scale effect" is used only for the "Unscale" action. This is assuming there is a need to scale at all, ie. the Cube size is not 100%, in the "Cube size is 100%" case the easing will still apply.
+* The "Rotate easing" effect is now only applied to the ending of the rotate when there is no 2nd rotation that is need and there is no immediate unscaling needed. Likewise, easing is only applied at the start of the rotate when there is no scaling needed (i.e only when hot-keys are used a 2nd time while holding the modifier keys). This makes the whole animation smoother particularly when Bounce/Back/Elastic easing is used.
+* Added a button to the Desktop Cube setting dialog under the "Effect Easing" section which will open the easing information website
+
 ## 1.1.0
 
 * Fixed the "not animating" issue under Mint 21+

--- a/DesktopCube@yare/README.md
+++ b/DesktopCube@yare/README.md
@@ -2,7 +2,55 @@
 
 Compiz Cube-like animation for workspace switching
 
-Using the standard workspace switching hotkeys Ctrl+Alt+Left/Right will show a rotating cube with the workspaces on the cube faces as the workspace switching animation.
+Switching the current workspace using any of the below described methods will show a rotating cube animation with the workspaces on the cube faces.
 
-It should now be working perfectly under all versions of Mint21+ without having to set CLUTTER_PAINT environment variable!
-I tested: Mint 21 / 21.1 / 21.3 / 22 and Fedora Cinnamon-Spin 40
+It should work well under all versions of Mint21+ without having to set the CLUTTER_PAINT environment variable.
+
+## Requirements
+
+Version 2 requires Cinnamon 5.4 (Mint 21) or better
+
+The older Desktop Cube version (with limited features) will be used on older Cinnamon versions.
+
+Tested on: Mint 21 / 21.1 / 21.3 / 22 and Fedora Cinnamon-Spin 40.
+
+## When is the Cube effect used?
+
+There are a number of ways to switch the current workspace, all of following will be handled by Desktop Cube starting with version 2:
+
+1. The "Switch to left/right workspace" hotkeys (under Keyboard settings, Shortcuts tab, Workspace category) Default hotkey: Ctrl + Alt + Left/Right_Arrow_Keys
+
+2. The "Switch to workspace 1-12" hotkeys (under Keyboard settings, Shortcuts tab, Workspace/Direct Navigation category) Default hotkey: unassigned
+
+3. Using the "Move window to the left/right workspace" hotkeys (under Keyboard settings, Shortcuts tab, Windows/Inter-workspace category) Default hotkey: Shift + Ctrl + Alt + Left/Right_Arrow_Keys
+
+4. Clicking on a workspace button in the "Workspace Switcher" applet (can be disabled in the configuration)
+
+5. When changing the focus to a window on another workspace by using the Window-List or Alt-Tab when they are configured to show windows from other workspaces. (can be disabled in the configuration)
+
+When switching the current workspace using Expo ("workspace selection screen" Default hotkey: Ctrl + Alt + Up_Arrow_Key) by clicking on a different workspace, the Desktop Cube effect will not be used. Since the Expo is not really a "face" on the cube it would break the Cube concept a bit, therefore I left it as is since I felt it was more logical that way.
+
+If you know of other methods of switching the workspace where the Desktop Cube effect is not currently used, please let me know so I can see if I can find a way to enable the Desktop Cube for that path as well. 
+
+## Known Issues
+
+1. When using Desktop Cube with two or more Monitors attached, the Cube will be placed in the middle of the overall desktop which will likely appear spit between the monitors, kind of ruining the effect.
+   
+   At some point I plan on adding options to control how the Cube is displayed on multi-monitor setups, but it might be a while before I find the time to work on that.
+
+2. If you enable the "Include Panels" option in the Desktop Cube configuration, the panels will disappear while the cube is turning and then reappear when it is done. This is far from idea, so I recommend that you leave this option disabled so that the panels remain hidden only reappearing after returning to the normal desktop.
+
+## Installation
+
+- Right click on the cinnamon panel and click "System Settings"
+- Click on the "Extensions" icon under the "Preferences" category
+- Click the "Download" tab and then click the "Desktop Cube" entry
+- Click the "Install" button on the right and then return to the "Manage" tab
+- Select the new "Desktop Cube" entry and then click the "+" button at the bottom of the window
+- Use the "gears" icon next to the "Desktop Cube" entry to open the setting window and setup the preferred behavior
+
+## Feedback
+
+Please leave a comment here on cinnamon-spices.linuxmint.com
+
+To report a bug or submit a feature request, open an issue here: [GitHub Spices Repo](https://github.com/linuxmint/cinnamon-spices-extensions/issues/new/choose)

--- a/DesktopCube@yare/README.md
+++ b/DesktopCube@yare/README.md
@@ -30,15 +30,15 @@ There are a number of ways to switch the current workspace, all of following wil
 
 When switching the current workspace using Expo ("workspace selection screen" Default hotkey: Ctrl + Alt + Up_Arrow_Key) by clicking on a different workspace, the Desktop Cube effect will not be used. Since the Expo is not really a "face" on the cube it would break the Cube concept a bit, therefore I left it as is since I felt it was more logical that way.
 
-If you know of other methods of switching the workspace where the Desktop Cube effect is not currently used, please let me know so I can see if I can find a way to enable the Desktop Cube for that path as well. 
+If you know of other methods of switching the workspace where the Desktop Cube effect is not currently used, please let me know so I can see if I can find a way to enable the Desktop Cube for that path as well.
 
 ## Known Issues
 
 1. When using Desktop Cube with two or more Monitors attached, the Cube will be placed in the middle of the overall desktop which will likely appear spit between the monitors, kind of ruining the effect.
-   
+
    At some point I plan on adding options to control how the Cube is displayed on multi-monitor setups, but it might be a while before I find the time to work on that.
 
-2. If you enable the "Include Panels" option in the Desktop Cube configuration, the panels will disappear while the cube is turning and then reappear when it is done. This is far from idea, so I recommend that you leave this option disabled so that the panels remain hidden only reappearing after returning to the normal desktop.
+2. If you enable the "Include Panels" option in the Desktop Cube configuration, the panels will disappear while the cube is turning and then reappear when it is done. This is far from ideal, so I recommend that you leave this option disabled so that the panels remain hidden, only reappearing after returning to the normal desktop.
 
 ## Installation
 

--- a/DesktopCube@yare/files/DesktopCube@yare/5.4/extension.js
+++ b/DesktopCube@yare/files/DesktopCube@yare/5.4/extension.js
@@ -10,15 +10,20 @@ const Panel = imports.ui.panel;
 const Tweener = imports.ui.tweener;
 const Settings = imports.ui.settings;
 const Util = imports.misc.util; // Needed for spawnCommandLine()
+const SignalManager = imports.misc.signalManager;
 
-
+let enabled;
 let settings;
+let signalManager;
 let bindings = [
     ['switch-to-workspace-left', '_showWorkspaceSwitcher'],
     ['switch-to-workspace-right', '_showWorkspaceSwitcher'],
     ['move-to-workspace-left', '_moveWindowToWorkspaceLeft'],
     ['move-to-workspace-right', '_moveWindowToWorkspaceRight']
 ];
+
+let original_mw_moveToWorkspace;
+let original_main_activateWindow;
 
 const isFinalized = function(obj) {
     return obj && GObject.Object.prototype.toString.call(obj).indexOf('FINALIZED') > -1;
@@ -35,7 +40,15 @@ const setPanelsOpacity = function(opacity) {
 const Callbacks = {
     on_btn_cs_workspaces_pressed: function() {
         Util.spawnCommandLine('bash -c \'cinnamon-settings workspaces\'');
-    } // End of on_btn_cs_workspaces_pressed
+    }, // End of on_btn_cs_workspaces_pressed
+
+    on_btn_cs_keyboard_pressed: function() {
+        Util.spawnCommandLine('bash -c \'cinnamon-settings keyboard -t 1\'');
+    }, // End of on_btn_cs_keyboard_pressed
+
+    on_btn_cs_easing_pressed: function() {
+        Util.spawnCommandLine('bash -c \'/usr/bin/xdg-open https://easings.net/\'');
+    } // End of on_btn_cs_keyboard_pressed
 }
 
 function Cube() {
@@ -43,22 +56,35 @@ function Cube() {
 }
 
 Cube.prototype = {
-    _init: function(display, window, binding) {
+    _init: function(display, window, binding, faces, direction) {
+        let binding_type = null;
         this.from = null;
         this.to = null;
         this.isAnimating = false;
         this.destroy_requested = false;
+        this.transitions = [];             // An array of Meta.MotionDirection values for each face transiation that is queued up
+        this.firstRotate = true;
+        this.pullaway = (100-settings.pullawayPercent)/100/2;
 
-        let [binding_type, , , direction] = binding.get_name().split('-');
-        direction = Meta.MotionDirection[direction.toUpperCase()];
+        if (faces === undefined)
+           faces =1;
+
+        // If we have not been given a direction, then we need to determine it by looking at the hotkey binding
+        if (direction === undefined) {
+           let [newBinding_type, , , newDirection] = binding.get_name().split('-');
+           direction = Meta.MotionDirection[newDirection.toUpperCase()];
+           binding_type = newBinding_type;
+        }
+        for( let i = 0 ; i < faces ; i++ ) {
+           this.transitions.push(direction);
+        }
         this.direction = direction;
         this.last_direction = direction;
 
-        if (direction !== Meta.MotionDirection.RIGHT
-            && direction !== Meta.MotionDirection.LEFT)
+        if (direction !== Meta.MotionDirection.RIGHT && direction !== Meta.MotionDirection.LEFT)
             return;
 
-        let active_workspace = global.screen.get_active_workspace();
+        let active_workspace = global.workspace_manager.get_active_workspace();
         let new_workspace = active_workspace.get_neighbor(direction);
 
         if (active_workspace.index() === new_workspace.index()) return;
@@ -82,8 +108,10 @@ Cube.prototype = {
 
         Main.pushModal(this.actor);
 
-        let mask = binding.get_mask();
-        this._modifierMask = imports.ui.appSwitcher.appSwitcher.primaryModifier(mask);
+        if (binding) {
+           let mask = binding.get_mask();
+           this._modifierMask = imports.ui.appSwitcher.appSwitcher.primaryModifier(mask);
+        }
         global.window_group.hide();
 
         setPanelsOpacity(0);
@@ -91,7 +119,13 @@ Cube.prototype = {
         if (binding_type === 'move' && window.get_window_type() !== Meta.WindowType.DESKTOP) {
             this.moveWindow(window, direction);
         }
-        this.startAnimate(direction);
+        if (binding_type === null && window) {
+           // We are switching workspaces to activate a window on a workspace other than the current one
+           // We need to keep track of the target window so that it can be activated when the animation is done
+           this.activateWindow = window;
+        }
+        this.current_face_index = global.workspace_manager.get_active_workspace_index();
+        this.startAnimate();
         this.actor.show();
     },
 
@@ -160,7 +194,7 @@ Cube.prototype = {
             return false;
         }
 
-        let active_workspace = global.screen.get_active_workspace();
+        let active_workspace = global.workspace_manager.get_active_workspace();
         let new_workspace = active_workspace.get_neighbor(direction);
 
         let active_index = active_workspace.index();
@@ -170,8 +204,9 @@ Cube.prototype = {
         Mainloop.idle_add(() => {
             // Unless this is done a bit later,
             // window is sometimes not activated
-            if (window.get_workspace() === global.screen.get_active_workspace()) {
-                window.activate(global.get_current_time());
+            if (window.get_workspace() === global.workspace_manager.get_active_workspace()) {
+                //window.activate(global.get_current_time());
+                Main.activateWindow(window);
             }
         });
 
@@ -181,7 +216,7 @@ Cube.prototype = {
 
     getWorkspaceCloneScaled: function(workspaceIndex, direction) {
         let clone = this.getWorkspaceClone(workspaceIndex);
-        clone.set_scale(1 - 2 * settings.pullaway, 1 - 2 * settings.pullaway);
+        clone.set_scale(1 - 2 * (this.pullaway), 1 - 2 * (this.pullaway));
         clone.x = global.stage.width / 2;
         return clone;
     },
@@ -300,7 +335,7 @@ Cube.prototype = {
 
     // I hide the desktop icons for now while rotating until a solution to
     // the artifacts may be found.
-    setDesktopClonesVisible: function(workspace_clone, visible) {
+    /*setDesktopClonesVisible: function(workspace_clone, visible) {
         let desktopClones = workspace_clone.desktopClones;
         for (let i = 0; i < desktopClones.length; i++) {
             let clone = desktopClones[i];
@@ -318,19 +353,26 @@ Cube.prototype = {
                 });
             }
         }
-    },
+    },*/
 
-    startAnimate: function(direction, window) {
-        let active_workspace = global.screen.get_active_workspace();
-        let new_workspace = active_workspace.get_neighbor(direction);
+    startAnimate: function(window) {
+        let active_workspace;
+        let new_workspace;
+
+        // Get the current cube face and the face we are transitioning to
+        let nWorkspaces = global.workspace_manager.get_n_workspaces();
+        let direction = this.transitions.shift();
+        active_workspace = global.workspace_manager.get_workspace_by_index( this.current_face_index );
+        new_workspace = active_workspace.get_neighbor(direction);
+        this.current_face_index = new_workspace.index();
 
         let from_workspace;
         let to_workspace;
-        let needScale = true;
+        this.needScale = true;
 
         if (this.to != null) {
             from_workspace = this.to;
-            needScale = false;
+            this.needScale = false;
             if (active_workspace.index() === new_workspace.index()) {
                 //this.bounce(from_workspace, direction);
                 this.isAnimating = true;
@@ -368,10 +410,12 @@ Cube.prototype = {
         this.to = to_workspace;
         this.last_direction = direction;
 
-        new_workspace.activate(global.get_current_time());
+        if (this.transitions.length === 0) {
+           new_workspace.activate(global.get_current_time());
+        }
         this.sortWindowClones(this.from);
         this.sortWindowClones(this.to);
-        this.prepare(from_workspace, to_workspace, direction, needScale);
+        this.prepare(from_workspace, to_workspace, direction, this.needScale);
     },
 
     prepare: function(from, to, direction, needScale) {
@@ -380,25 +424,25 @@ Cube.prototype = {
 
         if (direction === Meta.MotionDirection.LEFT) {
             let x_pos = 0;
-            if (!needScale) x_pos = global.stage.width * settings.pullaway;
+            if (!needScale) x_pos = global.stage.width * (this.pullaway);
             from.move_anchor_point_from_gravity(Clutter.Gravity.WEST);
             from.set_position(x_pos, global.stage.height / 2);
 
             to.move_anchor_point_from_gravity(Clutter.Gravity.EAST);
-            to.set_position(global.stage.width * settings.pullaway, global.stage.height / 2);
+            to.set_position(global.stage.width * (this.pullaway), global.stage.height / 2);
             to.rotation_angle_y = -90;
         } else {
             let x_pos = global.stage.width;
-            if (!needScale) x_pos = x_pos * (1 - settings.pullaway);
+            if (!needScale) x_pos = x_pos * (1 - (this.pullaway));
             from.move_anchor_point_from_gravity(Clutter.Gravity.EAST);
             from.set_position(x_pos, global.stage.height / 2);
 
             to.move_anchor_point_from_gravity(Clutter.Gravity.WEST);
-            to.set_position(global.stage.width * (1 - settings.pullaway), global.stage.height / 2);
+            to.set_position(global.stage.width * (1 - (this.pullaway)), global.stage.height / 2);
             to.rotation_angle_y = 90;
         }
 
-        to.set_scale(1 - 2 * settings.pullaway, 1 - 2 * settings.pullaway);
+        to.set_scale(1 - 2 * (this.pullaway), 1 - 2 * (this.pullaway));
         from.get_parent().set_child_above_sibling(from, null);
         if (needScale)
            this.scale(from, to, direction);
@@ -411,31 +455,32 @@ Cube.prototype = {
 
         let x_pos;
         if (direction === Meta.MotionDirection.LEFT) {
-            x_pos = global.stage.width * settings.pullaway;
+            x_pos = global.stage.width * (this.pullaway);
         } else {
-            x_pos = global.stage.width * (1 - settings.pullaway);
+            x_pos = global.stage.width * (1 - (this.pullaway));
         }
 
-        if (settings.pullaway > 0.2) {
-            this.setDesktopClonesVisible(from, false);
-            this.setDesktopClonesVisible(to, false);
-        }
+        //if (settings.pullaway > 0.2) {
+        //    this.setDesktopClonesVisible(from, false);
+        //    this.setDesktopClonesVisible(to, false);
+        //}
         Tweener.addTween(from, {
-            scale_x: 1 - 2 * settings.pullaway,
-            scale_y: 1 - 2 * settings.pullaway,
+            scale_x: 1 - 2 * (this.pullaway),
+            scale_y: 1 - 2 * (this.pullaway),
             x: x_pos,
             transition: settings.getScaleEffect(),
-            time: settings.animationTime,
-            onCompleteParams: [from, to, direction],
-            onComplete: this.rotate_mid,
+            time: settings.animationTimeSec * 0.25,
+            //onCompleteParams: [from, to, direction],
+            //onComplete: this.rotate_mid,
             onCompleteScope: this,
         });
+        this.rotate_mid(from, to, direction);
     },
 
     rotate_mid: function(from, to, direction) {
         this.isAnimating = true;
-        this.setDesktopClonesVisible(from, false);
-        this.setDesktopClonesVisible(to, false);
+        //this.setDesktopClonesVisible(from, false);
+        //this.setDesktopClonesVisible(to, false);
       from.show();
       to.show();
 
@@ -452,15 +497,15 @@ Cube.prototype = {
         Tweener.addTween(from, {
             x: global.stage.width / 2,
             rotation_angle_y: angle_from,
-            transition: settings.getRotateEffect(),
-            time: settings.animationTime,
+            transition: (!this.firstRotate || (this.needScale && settings.pullawayPercent!=100))?settings.getRotateEffect():settings.getRotateEffectStart(),
+            time: settings.animationTimeSec * 0.25,
         });
 
         Tweener.addTween(to, {
             x: global.stage.width / 2,
             rotation_angle_y: angle_to,
-            transition: settings.getRotateEffect(),
-            time: settings.animationTime,
+            transition: (!this.firstRotate || (this.needScale && settings.pullawayPercent!=100))?settings.getRotateEffect():settings.getRotateEffectStart(),
+            time: settings.animationTimeSec * 0.25,
             onCompleteParams: [from, to, direction],
             onComplete: this.rotate_end,
             onCompleteScope: this,
@@ -475,25 +520,25 @@ Cube.prototype = {
         let x_pos;
         let angle_from;
         if (direction === Meta.MotionDirection.LEFT) {
-            x_pos = global.stage.width * (1 - settings.pullaway);
+            x_pos = global.stage.width * (1 - (this.pullaway));
             angle_from = 90;
         } else {
-            x_pos = global.stage.width * settings.pullaway;
+            x_pos = global.stage.width * (this.pullaway);
             angle_from = -90;
         }
 
         Tweener.addTween(from, {
             x: x_pos,
             rotation_angle_y: angle_from,
-            transition: settings.getUnrotateEffect(),
-            time: settings.animationTime,
+            transition: (this.transitions.length===0 && this._modifierMask)?settings.getUnrotateEffectEnd():settings.getUnrotateEffect(),
+            time: settings.animationTimeSec * 0.25,
         });
 
         Tweener.addTween(to, {
             x: x_pos,
             rotation_angle_y: 0,
-            transition: settings.getUnrotateEffect(),
-            time: settings.animationTime,
+            transition: (this.transitions.length===0 && this._modifierMask)?settings.getUnrotateEffectEnd():settings.getUnrotateEffect(),
+            time: settings.animationTimeSec * 0.25,
             onComplete: this.unsetIsAnimating,
             onCompleteScope: this,
         });
@@ -505,24 +550,24 @@ Cube.prototype = {
         let x_pos;
         if (direction === Meta.MotionDirection.LEFT) {
             to.move_anchor_point_from_gravity(Clutter.Gravity.EAST);
-            to.set_position(global.stage.width * (1 - settings.pullaway), global.stage.height / 2);
+            to.set_position(global.stage.width * (1 - (this.pullaway)), global.stage.height / 2);
             x_pos = global.stage.width;
         } else {
             to.move_anchor_point_from_gravity(Clutter.Gravity.WEST);
-            to.set_position(global.stage.width * settings.pullaway, global.stage.height / 2);
+            to.set_position(global.stage.width * (this.pullaway), global.stage.height / 2);
             x_pos = 0;
         }
 
-        if (settings.pullaway > 0.2) {
-            this.setDesktopClonesVisible(from, true);
-            this.setDesktopClonesVisible(to, true);
-        }
+        //if (settings.pullaway > 0.2) {
+        //    this.setDesktopClonesVisible(from, true);
+        //    this.setDesktopClonesVisible(to, true);
+        //}
         Tweener.addTween(to, {
             scale_x: 1.0,
             scale_y: 1.0,
             x: x_pos,
             transition: settings.getUnscaleEffect(),
-            time: settings.animationTime,
+            time: settings.animationTimeSec * 0.25,
             onComplete: this.destroy,
             onCompleteScope: this,
         });
@@ -562,55 +607,147 @@ Cube.prototype = {
     },*/
 
     unsetIsAnimating: function() {
-        if (settings.pullaway <= 0.2) {
-            this.setDesktopClonesVisible(this.from, true);
-            this.setDesktopClonesVisible(this.to, true);
-        }
+        //if (settings.pullaway <= 0.2) {
+        //    this.setDesktopClonesVisible(this.from, true);
+        //    this.setDesktopClonesVisible(this.to, true);
+        //}
         this.isAnimating = false;
-        if (this.destroy_requested) this.onDestroy();
-        Main.wm.showWorkspaceOSD();
-        Meta.remove_clutter_debug_flags( 0, 1 << 6, 0 ); // CLUTTER_DEBUG_CONTINUOUS_REDRAW
+        if (this.transitions.length == 0) {
+           if (this.destroy_requested) this.onDestroy();
+           Meta.remove_clutter_debug_flags( 0, 1 << 6, 0 ); // CLUTTER_DEBUG_CONTINUOUS_REDRAW
+           Main.wm.showWorkspaceOSD();
+           if (this._modifierMask === undefined) {
+               if (this.isAnimating) {
+                   this.destroy_requested = true;
+               } else {
+                   this.onDestroy();
+               }
+           }
+        } else {
+           this.firstRotate = false;
+           this.startAnimate(null);
+           return;
+        }
+        this.original_ws_index = global.workspace_manager.get_active_workspace_index();
     },
 
     _keyPressEvent: function(actor, event) {
-        if (this.isAnimating) return true;
-
         let workspace;
         let windows;
         let window;
         let event_state = Cinnamon.get_event_state(event);
         let action = global.display.get_keybinding_action(event.get_key_code(), event_state);
+        let new_workspace;
         switch (action) {
         case Meta.KeyBindingAction.MOVE_TO_WORKSPACE_LEFT:
              this.direction = Meta.MotionDirection.LEFT;
-             workspace = global.screen.get_active_workspace().index();
+             this.transitions.push(Meta.MotionDirection.LEFT);
+             workspace = global.workspace_manager.get_active_workspace().index();
              windows = this.getWorkspaceWindows(workspace);
              window = windows[windows.length - 1];
              this.moveWindow(window, this.direction);
-                 this.startAnimate(this.direction, window);
+             this.startAnimate(window);
              return true;
 
         case Meta.KeyBindingAction.MOVE_TO_WORKSPACE_RIGHT:
              this.direction = Meta.MotionDirection.RIGHT;
-             workspace = global.screen.get_active_workspace().index();
+             this.transitions.push(Meta.MotionDirection.RIGHT);
+             workspace = global.workspace_manager.get_active_workspace().index();
              windows = this.getWorkspaceWindows(workspace);
              window = windows[windows.length - 1];
              this.moveWindow(window, this.direction);
-                 this.startAnimate(this.direction, window);
+             this.startAnimate(window);
              return true;
 
         case Meta.KeyBindingAction.WORKSPACE_LEFT:
-            this.direction = Meta.MotionDirection.LEFT;
-            this.startAnimate(this.direction);
+            if (this.isAnimating) {
+               this.transitions.push(Meta.MotionDirection.LEFT);
+            } else {
+               this.transitions.push(Meta.MotionDirection.LEFT);
+               this.startAnimate();
+            }
             return true;
 
         case Meta.KeyBindingAction.WORKSPACE_RIGHT:
-            this.direction = Meta.MotionDirection.RIGHT;
-            this.startAnimate(this.direction);
+            if (this.isAnimating) {
+               this.transitions.push(Meta.MotionDirection.RIGHT);
+            } else {
+               this.transitions.push(Meta.MotionDirection.RIGHT);
+               this.startAnimate();
+            }
             return true;
+
+        case Meta.KeyBindingAction.WORKSPACE_1:
+           this._keyActionWorkspace(0);
+           return true;
+
+        case Meta.KeyBindingAction.WORKSPACE_2:
+           this._keyActionWorkspace(1);
+           return true;
+
+        case Meta.KeyBindingAction.WORKSPACE_3:
+           this._keyActionWorkspace(2);
+           return true;
+
+        case Meta.KeyBindingAction.WORKSPACE_4:
+           this._keyActionWorkspace(3);
+           return true;
+
+        case Meta.KeyBindingAction.WORKSPACE_5:
+           this._keyActionWorkspace(4);
+           return true;
+
+        case Meta.KeyBindingAction.WORKSPACE_6:
+           this._keyActionWorkspace(5);
+           return true;
+
+        case Meta.KeyBindingAction.WORKSPACE_7:
+           this._keyActionWorkspace(6);
+           return true;
+
+        case Meta.KeyBindingAction.WORKSPACE_8:
+           this._keyActionWorkspace(7);
+           return true;
+
+        case Meta.KeyBindingAction.WORKSPACE_9:
+           this._keyActionWorkspace(8);
+           return true;
+
+        case Meta.KeyBindingAction.WORKSPACE_10:
+           this._keyActionWorkspace(9);
+           return true;
+
+        case Meta.KeyBindingAction.WORKSPACE_11:
+           this._keyActionWorkspace(10);
+           return true;
+
+        case Meta.KeyBindingAction.WORKSPACE_12:
+           this._keyActionWorkspace(11);
+           return true;
+
         }
 
         return true;
+    },
+
+    // Change the workspace to parm ws_cur
+    _keyActionWorkspace: function(ws_idx) {
+        let newWS = global.workspace_manager.get_workspace_by_index(ws_idx);
+        if (!newWS) return;
+        if (this.isAnimating) {
+            let [transitions_needed, direction] = getTransitionsAndDirection(newWS, this.current_face_index, this.transitions);
+                for (let i=0 ; i<transitions_needed ; i++) {
+                    this.transitions.push(direction);
+                }
+        } else {
+            let [transitions_needed, direction] = getTransitionsAndDirection(newWS);
+            if (transitions_needed) {
+                for (let i=0 ; i<transitions_needed ; i++) {
+                    this.transitions.push(direction);
+                }
+                this.startAnimate();
+            }
+        }
     },
 
     _keyReleaseEvent: function() {
@@ -620,6 +757,7 @@ Cube.prototype = {
         if (state === 0) {
             if (this.isAnimating) {
                 this.destroy_requested = true;
+                this._modifierMask = undefined;
             } else {
                 this.onDestroy();
             }
@@ -641,12 +779,7 @@ Cube.prototype = {
     dimBackground: function() {
         this._backgroundGroup.show();
         let background = this._backgroundGroup.get_children()[0];
-        Tweener.addTween(background, {
-            //dim_factor: 0.0,
-            opacity: 10,
-            time: settings.animationTime * 0,
-            transition: 'easeOutQuad'
-        });
+        background.set_opacity(10);
     },
 
     /*undimBackground: function() {
@@ -660,7 +793,8 @@ Cube.prototype = {
 
     onDestroy: function() {
         if (isFinalized(this.from) || isFinalized(this.to)) return;
-        this.unscale(this.from, this.to, this.direction);
+        //if (this._modifierMask)
+           this.unscale(this.from, this.to, this.direction);
     },
 
     destroy: function() {
@@ -674,11 +808,104 @@ Cube.prototype = {
         if (!isFinalized(this.actor)) this.actor.destroy();
         if (!isFinalized(this.metaBackgroundActor)) this.metaBackgroundActor.destroy();
         if (!isFinalized(this._backgroundGroup)) this._backgroundGroup.destroy();
+        if (this.activateWindow) {
+           Main.activateWindow(this.activateWindow);
+        }
     }
 };
 
+function getTransitionsAndDirection(workspace, cur_ws_idx, pending_transitions) {
+    let direction;
+    // Determine the current workspace index, taking into account any past/pending cube transitions
+    let curWS = (cur_ws_idx)?cur_ws_idx:global.workspace_manager.get_active_workspace_index();
+    if (pending_transitions && pending_transitions.length > 0) {
+       let nWorkspaces = global.workspace_manager.get_n_workspaces();
+       for (let i=0 ; i < pending_transitions.length ; i++) {
+          if (pending_transitions[i] === Meta.MotionDirection.LEFT)
+             curWS--;
+          else
+             curWS++;
+       }
+       if (curWS > 0){
+          curWS = nWorkspaces + curWS;
+       } else if (curWS >= nWorkspaces) {
+          curWS = curWS - nWorkspaces;
+       }
+    }
+    // Handle the case were no transitions are needed
+    let newWS = workspace.index();
+    if (curWS === newWS) {
+       return([0,0]);
+    }
+    // Calculate the number and direction of the transitions needed
+    let transitions_needed = Math.abs(curWS-newWS);
+    let nWorkspaces = global.workspace_manager.get_n_workspaces();
+    if (curWS > newWS) {
+       if (transitions_needed > nWorkspaces/2) {
+          direction = Meta.MotionDirection.RIGHT;
+          transitions_needed = nWorkspaces - transitions_needed;
+       } else  {
+          direction = Meta.MotionDirection.LEFT;
+       }
+    } else {
+       if (transitions_needed > nWorkspaces/2) {
+          direction = Meta.MotionDirection.LEFT;
+          transitions_needed = nWorkspaces - transitions_needed;
+       } else  {
+          direction = Meta.MotionDirection.RIGHT;
+       }
+    }
+    return([transitions_needed, direction]);
+}
+
+// Our handler for the left/right hotkeys
 function onSwitch(display, window, binding) {
     new Cube(display, window, binding);
+}
+
+// Our handler for the "Switch to workspace #" hotkeys.
+// This needs to be able to handle cases where the extension has been disabled
+// since I have yet to find a way to restore the original handler on disable.
+function switchToWorkspace(display, window, binding) {
+   let [, , , newWSIdx] = binding.get_name().split('-');
+   newWSIdx--;
+   let new_workspace = global.workspace_manager.get_workspace_by_index(newWSIdx);
+   if (!enabled) {
+      // Allow Cinnamon to play the switcher sound if it's enabled.
+      Main.soundManager.play('switch');
+      new_workspace.activate(global.get_current_time());
+      Main.wm.showWorkspaceOSD();
+   } else {
+      let [transitions_needed, direction] = getTransitionsAndDirection(new_workspace);
+      if (transitions_needed)
+         new Cube(null, null, binding, transitions_needed, direction);
+   }
+}
+
+// Our version of moveToWorkspace() which will be Monkey Patched over the Cinnamon version
+// This is how we handle the workspace switching initiated by the "Workspace Switcher" applet
+function moveToWorkspace(workspace, direction_hint) {
+    let [transitions_needed, direction] = getTransitionsAndDirection(workspace);
+    if (transitions_needed)
+       new Cube(null, null, null, transitions_needed, direction);
+}
+
+// Our version of activateWindow which will be Monkey Patched over the cinnamon version
+// Here we will check if target window is on a different workspace and use the Cube if needed
+function activateWindow(window, time, workspaceNum) {
+   let activeWorkspaceNum = global.workspace_manager.get_active_workspace_index();
+   if (workspaceNum === undefined) {
+      let windowsWS = window.get_workspace();
+      workspaceNum = windowsWS.index();
+   }
+
+   if (!Main.expo._shown && activeWorkspaceNum !== workspaceNum) {
+      let newWS = global.workspace_manager.get_workspace_by_index(workspaceNum);
+      let [transitions_needed, direction] = getTransitionsAndDirection(newWS);
+      new Cube(null, window, null, transitions_needed, direction);
+   } else {
+      original_main_activateWindow(window, time, workspaceNum);
+   }
 }
 
 function CubeSettings(uuid) {
@@ -688,42 +915,94 @@ function CubeSettings(uuid) {
 CubeSettings.prototype = {
     _init: function(uuid) {
         this.settings = new Settings.ExtensionSettings(this, uuid);
-        this.settings.bindProperty(Settings.BindingDirection.IN, 'animationTime', 'animationTime', null);
-        this.settings.bindProperty(Settings.BindingDirection.IN, 'pullaway', 'pullaway', null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, 'animationTimeSec', 'animationTimeSec', null);
+        this.settings.bindProperty(Settings.BindingDirection.IN, 'pullawayPercent', 'pullawayPercent', null);
         this.settings.bindProperty(Settings.BindingDirection.IN, 'newScaleEffect', 'newScaleEffect', null);
         this.settings.bindProperty(Settings.BindingDirection.IN, 'newRotateEffect', 'newRotateEffect', null);
         this.settings.bindProperty(Settings.BindingDirection.IN, 'includePanels', 'includePanels', null);
     },
 
     getScaleEffect: function() {
-       return "easeIn" + settings.newScaleEffect;
+       return "easeNone"; //"easeIn" + settings.newScaleEffect;
     },
 
     getUnscaleEffect: function() {
        return "easeOut" + settings.newScaleEffect;
     },
 
-    getRotateEffect: function() {
+    getRotateEffectStart: function() {
        return "easeIn" + settings.newRotateEffect;
     },
 
+    getRotateEffect: function() {
+       return "easeInExpo"; //"easeIn" + settings.newRotateEffect;
+    },
+
     getUnrotateEffect: function() {
+       return "easeOutExpo"; //"easeOut" + settings.newRotateEffect;
+    },
+
+    getUnrotateEffectEnd: function() {
        return "easeOut" + settings.newRotateEffect;
     }
 };
 
+function toggleMoveToWorkspacePatch() {
+   if (original_mw_moveToWorkspace) {
+      Main.wm.moveToWorkspace = original_mw_moveToWorkspace;
+      original_mw_moveToWorkspace = null;
+   } else {
+      original_mw_moveToWorkspace = Main.wm.moveToWorkspace;
+      Main.wm.moveToWorkspace = moveToWorkspace;
+   }
+}
+
+function toggleActivateWindowPatch() {
+   if (original_main_activateWindow) {
+      Main.activateWindow = original_main_activateWindow;
+      original_main_activateWindow = null;
+   } else {
+      original_main_activateWindow = Main.activateWindow;
+      Main.activateWindow = activateWindow;
+   }
+}
+
 function init(metadata) {
     settings = new CubeSettings(metadata.uuid);
+    signalManager = new SignalManager.SignalManager(null);
 }
 
 function enable() {
+    // Override the keybindings functions
     for (let i = 0; i < bindings.length; i++) {
         Meta.keybindings_set_custom_handler(bindings[i][0], onSwitch);
+    }
+    enabled = true;
+    for (let i = 0 ; i <= 12 ; i++) {
+       Meta.keybindings_set_custom_handler('switch-to-workspace-' + i, switchToWorkspace );
+    }
+    signalManager.connect(settings.settings, "changed::patchmoveToWorkspace", toggleMoveToWorkspacePatch);
+    signalManager.connect(settings.settings, "changed::patchActivateWindow", toggleActivateWindowPatch);
+    if (settings.settings.getValue("patchmoveToWorkspace")) {
+       // Monkey patch moveToWorkspace()
+       original_mw_moveToWorkspace = Main.wm.moveToWorkspace;
+       Main.wm.moveToWorkspace = moveToWorkspace;
+    }
+    if (settings.settings.getValue("patchActivateWindow")) {
+       // Monkey patch activateWindow()
+       original_main_activateWindow = Main.activateWindow;
+       Main.activateWindow = activateWindow;
     }
     return Callbacks
 }
 
 function disable() {
+    enabled = false;
+    // Reset the keybinding functions to what they were originally
+    // I believe the original handlers for the switch-to-workspace-# hotkeys
+    // are not implemented in javascript?? So I just leave my handler in
+    // place to switch workspaces, it will only use the Cube Effect when
+    // 'enabled' is set to true!
     for (let i = 0; i < bindings.length; i++) {
         Meta.keybindings_set_custom_handler(
             bindings[i][0],
@@ -733,4 +1012,13 @@ function disable() {
             )
         );
     }
+    if (original_mw_moveToWorkspace) {
+       // Undo the monkey patch of moveToWorkspace()
+       Main.wm.moveToWorkspace = original_mw_moveToWorkspace;
+    }
+    if (original_main_activateWindow) {
+       // Undo the monkey patch of activateWindow()
+       Main.activateWindow = original_main_activateWindow;
+    }
+    signalManager.disconnectAllSignals();
 }

--- a/DesktopCube@yare/files/DesktopCube@yare/5.4/settings-schema.json
+++ b/DesktopCube@yare/files/DesktopCube@yare/5.4/settings-schema.json
@@ -1,100 +1,99 @@
 {
-  "header1" : {
-    "type" : "header",
-    "description" : "General"
-  },
-  "animationTimeSec" : {
-    "type" : "scale",
-    "description" : "Animation duration (seconds)",
-    "min" : 0.1,
-    "max" : 4.0,
-    "default": 0.95,
-    "step" : 0.05
-  },
-  "pullawayPercent" : {
-    "type" : "scale",
-    "description" : "Cube size (percent of screen size)",
-    "min" : 33,
-    "max" : 100,
-    "default" : 90,
-    "step" : 1
-  },
-  "includePanels" : {
-    "type" : "checkbox",
-    "description" : "Include Panels",
-    "default" : false
-  },
-  "patchmoveToWorkspace" : {
-    "type" : "checkbox",
-    "description" : "Use Cube effect with the Workspace Switcher applet",
-    "tooltip": "Override the moveToWorkspace() API so that the Cube effect is used by the Workspace Switcher Applet when changing the current workspace",
-    "default" : true
-  },
-  "patchActivateWindow" : {
-    "type" : "checkbox",
-    "description" : "Use Cube effect when changing focus causes a workspace switch",
-    "tooltip": "Override the activateWindow() API so that when a window on another workspace is given the focus, the Cube effect is used to change the current workspace",
-    "default" : true
-  },
-  "sep1": {
-    "type": "separator"
-  },
-  "header2" : {
-    "type" : "header",
-    "description" : "Effect Easing"
-  },
-  "newScaleEffect": {
-    "type": "combobox",
-    "description": "Scale easing",
-    "default": "Quad",
-    "options": {
-      "Back": "Back",
-      "Bounce": "Bounce",
-      "Circ": "Circ",
-      "Cubic": "Cubic",
-      "Elastic": "Elastic",
-      "Expo": "Expo",
-      "Sine": "Sine",
-      "Quad": "Quad",
-      "Quart": "Quart",
-      "Quint": "Quint"
+    "header1": {
+        "type": "header",
+        "description": "General"
+    },
+    "animationTimeSec": {
+        "type": "scale",
+        "description": "Animation duration (seconds)",
+        "min": 0.1,
+        "max": 4.0,
+        "default": 0.95,
+        "step": 0.05
+    },
+    "pullawayPercent": {
+        "type": "scale",
+        "description": "Cube size (percent of screen size)",
+        "min": 33,
+        "max": 100,
+        "default": 90,
+        "step": 1
+    },
+    "includePanels": {
+        "type": "checkbox",
+        "description": "Include Panels",
+        "default": false
+    },
+    "patchmoveToWorkspace": {
+        "type": "checkbox",
+        "description": "Use Cube effect with the Workspace Switcher applet",
+        "tooltip": "Override the moveToWorkspace() API so that the Cube effect is used by the Workspace Switcher Applet when changing the current workspace",
+        "default": true
+    },
+    "patchActivateWindow": {
+        "type": "checkbox",
+        "description": "Use Cube effect when changing focus causes a workspace switch",
+        "tooltip": "Override the activateWindow() API so that when a window on another workspace is given the focus, the Cube effect is used to change the current workspace",
+        "default": true
+    },
+    "sep1": {
+        "type": "separator"
+    },
+    "header2": {
+        "type": "header",
+        "description": "Effect Easing"
+    },
+    "newScaleEffect": {
+        "type": "combobox",
+        "description": "Scale easing",
+        "default": "Quad",
+        "options": {
+            "Back": "Back",
+            "Bounce": "Bounce",
+            "Circ": "Circ",
+            "Cubic": "Cubic",
+            "Elastic": "Elastic",
+            "Expo": "Expo",
+            "Sine": "Sine",
+            "Quad": "Quad",
+            "Quart": "Quart",
+            "Quint": "Quint"
+        }
+    },
+    "newRotateEffect": {
+        "type": "combobox",
+        "description": "Rotate easing",
+        "default": "Quad",
+        "options": {
+            "Back": "Back",
+            "Bounce": "Bounce",
+            "Circ": "Circ",
+            "Cubic": "Cubic",
+            "Elastic": "Elastic",
+            "Expo": "Expo",
+            "Sine": "Sine",
+            "Quad": "Quad",
+            "Quart": "Quart",
+            "Quint": "Quint"
+        }
+    },
+    "easing_btn": {
+        "type": "button",
+        "description": "Open easing information website",
+        "callback": "on_btn_cs_easing_pressed"
+    },
+    "header3": {
+        "type": "header",
+        "description": "System Settings"
+    },
+    "workspaces_btn": {
+        "type": "button",
+        "description": "Open Cinnamon Settings to manage Workspaces",
+        "callback": "on_btn_cs_workspaces_pressed"
+    },
+    "hotkeys_btn": {
+        "type": "button",
+        "description": "Open Cinnamon Keyboard Settings to manage Workspace hotkeys",
+        "callback": "on_btn_cs_keyboard_pressed"
     }
-  },
-  "newRotateEffect": {
-    "type": "combobox",
-    "description": "Rotate easing",
-    "default": "Quad",
-    "options": {
-      "Back": "Back",
-      "Bounce": "Bounce",
-      "Circ": "Circ",
-      "Cubic": "Cubic",
-      "Elastic": "Elastic",
-      "Expo": "Expo",
-      "Sine": "Sine",
-      "Quad": "Quad",
-      "Quart": "Quart",
-      "Quint": "Quint"
-    }
-  },
-  "easing_btn": {
-    "type": "button",
-    "description": "Open easing information website",
-    "callback": "on_btn_cs_easing_pressed"
-  },
-
-  "header3": {
-    "type" : "header",
-    "description" : "System Settings"
-  },
-  "workspaces_btn": {
-    "type": "button",
-    "description": "Open Cinnamon Settings to manage Workspaces",
-    "callback": "on_btn_cs_workspaces_pressed"
-  },
-  "hotkeys_btn": {
-    "type": "button",
-    "description": "Open Cinnamon Keyboard Settings to manage Workspace hotkeys",
-    "callback": "on_btn_cs_keyboard_pressed"
-  }
 }

--- a/DesktopCube@yare/files/DesktopCube@yare/5.4/settings-schema.json
+++ b/DesktopCube@yare/files/DesktopCube@yare/5.4/settings-schema.json
@@ -3,37 +3,49 @@
     "type" : "header",
     "description" : "General"
   },
-  "animationTime" : {
+  "animationTimeSec" : {
     "type" : "scale",
-    "description" : "Animation duration",
-    "min" : 0.10,
-    "max" : 1.0,
-    "default": 0.15,
+    "description" : "Animation duration (seconds)",
+    "min" : 0.1,
+    "max" : 4.0,
+    "default": 0.95,
     "step" : 0.05
   },
-  "pullaway" : {
+  "pullawayPercent" : {
     "type" : "scale",
-    "description" : "Pullaway proportion from screen",
-    "min" : 0.00,
-    "max" : 0.3333,
-    "default" : 0.05,
-    "step" : 0.0001
+    "description" : "Cube size (percent of screen size)",
+    "min" : 33,
+    "max" : 100,
+    "default" : 90,
+    "step" : 1
   },
   "includePanels" : {
     "type" : "checkbox",
     "description" : "Include Panels",
     "default" : false
   },
+  "patchmoveToWorkspace" : {
+    "type" : "checkbox",
+    "description" : "Use Cube effect with the Workspace Switcher applet",
+    "tooltip": "Override the moveToWorkspace() API so that the Cube effect is used by the Workspace Switcher Applet when changing the current workspace",
+    "default" : true
+  },
+  "patchActivateWindow" : {
+    "type" : "checkbox",
+    "description" : "Use Cube effect when changing focus causes a workspace switch",
+    "tooltip": "Override the activateWindow() API so that when a window on another workspace is given the focus, the Cube effect is used to change the current workspace",
+    "default" : true
+  },
   "sep1": {
     "type": "separator"
   },
   "header2" : {
     "type" : "header",
-    "description" : "Effects"
+    "description" : "Effect Easing"
   },
   "newScaleEffect": {
     "type": "combobox",
-    "description": "Scale effect",
+    "description": "Scale easing",
     "default": "Quad",
     "options": {
       "Back": "Back",
@@ -50,7 +62,7 @@
   },
   "newRotateEffect": {
     "type": "combobox",
-    "description": "Rotate effect",
+    "description": "Rotate easing",
     "default": "Quad",
     "options": {
       "Back": "Back",
@@ -65,6 +77,12 @@
       "Quint": "Quint"
     }
   },
+  "easing_btn": {
+    "type": "button",
+    "description": "Open easing information website",
+    "callback": "on_btn_cs_easing_pressed"
+  },
+
   "header3": {
     "type" : "header",
     "description" : "System Settings"
@@ -73,5 +91,10 @@
     "type": "button",
     "description": "Open Cinnamon Settings to manage Workspaces",
     "callback": "on_btn_cs_workspaces_pressed"
+  },
+  "hotkeys_btn": {
+    "type": "button",
+    "description": "Open Cinnamon Keyboard Settings to manage Workspace hotkeys",
+    "callback": "on_btn_cs_keyboard_pressed"
   }
 }

--- a/DesktopCube@yare/files/DesktopCube@yare/metadata.json
+++ b/DesktopCube@yare/files/DesktopCube@yare/metadata.json
@@ -16,7 +16,7 @@
         "4.6",
         "5.4"
     ],
-    "version": "1.1.0",
+    "version": "2.0.0",
     "uuid": "DesktopCube@yare",
     "name": "Desktop Cube",
     "description": "Compiz Cube-like animation for workspace switching",

--- a/DesktopCube@yare/files/DesktopCube@yare/po/DesktopCube@yare.pot
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/DesktopCube@yare.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: DesktopCube@yare 1.1.0\n"
+"Project-Id-Version: DesktopCube@yare 2.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-06 09:45-0400\n"
+"POT-Creation-Date: 2024-11-20 10:20-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -31,22 +31,18 @@ msgid "General"
 msgstr ""
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
 msgid "Animation duration"
 msgstr ""
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
 msgid "Pullaway proportion from screen"
 msgstr ""
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr ""
 
 #. 2.0->settings-schema.json->scaleEffect->description
-#. 5.4->settings-schema.json->newScaleEffect->description
 msgid "Scale effect"
 msgstr ""
 
@@ -72,8 +68,44 @@ msgstr ""
 msgid "Open Cinnamon Settings to manage Workspaces"
 msgstr ""
 
+#. 5.4->settings-schema.json->animationTimeSec->description
+msgid "Animation duration (seconds)"
+msgstr ""
+
+#. 5.4->settings-schema.json->pullawayPercent->description
+msgid "Cube size (percent of screen size)"
+msgstr ""
+
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Cube effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Cube effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Cube effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Cube effect is used to change the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->header2->description
+msgid "Effect Easing"
+msgstr ""
+
+#. 5.4->settings-schema.json->newScaleEffect->description
+msgid "Scale easing"
 msgstr ""
 
 #. 5.4->settings-schema.json->newScaleEffect->options
@@ -127,5 +159,13 @@ msgid "Quint"
 msgstr ""
 
 #. 5.4->settings-schema.json->newRotateEffect->description
-msgid "Rotate effect"
+msgid "Rotate easing"
+msgstr ""
+
+#. 5.4->settings-schema.json->easing_btn->description
+msgid "Open easing information website"
+msgstr ""
+
+#. 5.4->settings-schema.json->hotkeys_btn->description
+msgid "Open Cinnamon Keyboard Settings to manage Workspace hotkeys"
 msgstr ""

--- a/DesktopCube@yare/files/DesktopCube@yare/po/ca.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/ca.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-06 09:45-0400\n"
+"POT-Creation-Date: 2024-11-20 10:20-0500\n"
 "PO-Revision-Date: 2024-08-25 22:27+0200\n"
 "Last-Translator: \n"
 "Language-Team: Odyssey <odysseyhyd@gmail.com>\n"
@@ -33,22 +33,18 @@ msgid "General"
 msgstr "General"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
 msgid "Animation duration"
 msgstr "Duració de l'animació"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
 msgid "Pullaway proportion from screen"
 msgstr "Distància de separació entre la pantalla"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Efectes"
 
 #. 2.0->settings-schema.json->scaleEffect->description
-#. 5.4->settings-schema.json->newScaleEffect->description
 msgid "Scale effect"
 msgstr "Efecte d'allunyament de pantalla"
 
@@ -74,9 +70,47 @@ msgstr "Configuració del sistema"
 msgid "Open Cinnamon Settings to manage Workspaces"
 msgstr "Obrir la configuració de Cinnamon per gestionar els espais de treball"
 
+#. 5.4->settings-schema.json->animationTimeSec->description
+#, fuzzy
+msgid "Animation duration (seconds)"
+msgstr "Duració de l'animació"
+
+#. 5.4->settings-schema.json->pullawayPercent->description
+msgid "Cube size (percent of screen size)"
+msgstr ""
+
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
 msgstr "Incloure els taulers"
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Cube effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Cube effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Cube effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Cube effect is used to change the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->header2->description
+#, fuzzy
+msgid "Effect Easing"
+msgstr "Efectes"
+
+#. 5.4->settings-schema.json->newScaleEffect->description
+msgid "Scale easing"
+msgstr ""
 
 #. 5.4->settings-schema.json->newScaleEffect->options
 #. 5.4->settings-schema.json->newRotateEffect->options
@@ -129,5 +163,15 @@ msgid "Quint"
 msgstr "Quinta"
 
 #. 5.4->settings-schema.json->newRotateEffect->description
-msgid "Rotate effect"
+#, fuzzy
+msgid "Rotate easing"
 msgstr "Efecte de rotació"
+
+#. 5.4->settings-schema.json->easing_btn->description
+msgid "Open easing information website"
+msgstr ""
+
+#. 5.4->settings-schema.json->hotkeys_btn->description
+#, fuzzy
+msgid "Open Cinnamon Keyboard Settings to manage Workspace hotkeys"
+msgstr "Obrir la configuració de Cinnamon per gestionar els espais de treball"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/da.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-06 09:45-0400\n"
+"POT-Creation-Date: 2024-11-20 10:20-0500\n"
 "PO-Revision-Date: 2022-08-07 15:06+0200\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -33,22 +33,18 @@ msgid "General"
 msgstr "Generelt"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
 msgid "Animation duration"
 msgstr "Animationens varighed"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
 msgid "Pullaway proportion from screen"
 msgstr "Formindskelsesgrad"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Effekter"
 
 #. 2.0->settings-schema.json->scaleEffect->description
-#. 5.4->settings-schema.json->newScaleEffect->description
 msgid "Scale effect"
 msgstr "Starteffekt"
 
@@ -74,8 +70,46 @@ msgstr "Systemindstillinger"
 msgid "Open Cinnamon Settings to manage Workspaces"
 msgstr "Åbn Cinnamons indstillinger for at administrere arbejdsområder"
 
+#. 5.4->settings-schema.json->animationTimeSec->description
+#, fuzzy
+msgid "Animation duration (seconds)"
+msgstr "Animationens varighed"
+
+#. 5.4->settings-schema.json->pullawayPercent->description
+msgid "Cube size (percent of screen size)"
+msgstr ""
+
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Cube effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Cube effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Cube effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Cube effect is used to change the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->header2->description
+#, fuzzy
+msgid "Effect Easing"
+msgstr "Effekter"
+
+#. 5.4->settings-schema.json->newScaleEffect->description
+msgid "Scale easing"
 msgstr ""
 
 #. 5.4->settings-schema.json->newScaleEffect->options
@@ -130,5 +164,14 @@ msgstr ""
 
 #. 5.4->settings-schema.json->newRotateEffect->description
 #, fuzzy
-msgid "Rotate effect"
+msgid "Rotate easing"
 msgstr "Effekt for slutrotation"
+
+#. 5.4->settings-schema.json->easing_btn->description
+msgid "Open easing information website"
+msgstr ""
+
+#. 5.4->settings-schema.json->hotkeys_btn->description
+#, fuzzy
+msgid "Open Cinnamon Keyboard Settings to manage Workspace hotkeys"
+msgstr "Åbn Cinnamons indstillinger for at administrere arbejdsområder"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/de.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-06 09:45-0400\n"
+"POT-Creation-Date: 2024-11-20 10:20-0500\n"
 "PO-Revision-Date: 2021-03-02 22:50+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -33,22 +33,18 @@ msgid "General"
 msgstr "Allgemein"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
 msgid "Animation duration"
 msgstr "Animationsdauer"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
 msgid "Pullaway proportion from screen"
 msgstr "Wegzieh-Entfernung vom Bildschirm"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Effekte"
 
 #. 2.0->settings-schema.json->scaleEffect->description
-#. 5.4->settings-schema.json->newScaleEffect->description
 msgid "Scale effect"
 msgstr "Wegzieh-Effekt"
 
@@ -74,8 +70,46 @@ msgstr "Systemeinstellungen"
 msgid "Open Cinnamon Settings to manage Workspaces"
 msgstr "Cinnamon-Einstellungen öffnen, um Arbeitsflächen zu verwalten"
 
+#. 5.4->settings-schema.json->animationTimeSec->description
+#, fuzzy
+msgid "Animation duration (seconds)"
+msgstr "Animationsdauer"
+
+#. 5.4->settings-schema.json->pullawayPercent->description
+msgid "Cube size (percent of screen size)"
+msgstr ""
+
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Cube effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Cube effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Cube effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Cube effect is used to change the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->header2->description
+#, fuzzy
+msgid "Effect Easing"
+msgstr "Effekte"
+
+#. 5.4->settings-schema.json->newScaleEffect->description
+msgid "Scale easing"
 msgstr ""
 
 #. 5.4->settings-schema.json->newScaleEffect->options
@@ -130,5 +164,14 @@ msgstr ""
 
 #. 5.4->settings-schema.json->newRotateEffect->description
 #, fuzzy
-msgid "Rotate effect"
+msgid "Rotate easing"
 msgstr "Ende des Dreheffekts"
+
+#. 5.4->settings-schema.json->easing_btn->description
+msgid "Open easing information website"
+msgstr ""
+
+#. 5.4->settings-schema.json->hotkeys_btn->description
+#, fuzzy
+msgid "Open Cinnamon Keyboard Settings to manage Workspace hotkeys"
+msgstr "Cinnamon-Einstellungen öffnen, um Arbeitsflächen zu verwalten"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/es.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-06 09:45-0400\n"
+"POT-Creation-Date: 2024-11-20 10:20-0500\n"
 "PO-Revision-Date: 2024-08-23 21:44-0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -32,22 +32,18 @@ msgid "General"
 msgstr "General"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
 msgid "Animation duration"
 msgstr "Duración de la animación"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
 msgid "Pullaway proportion from screen"
 msgstr "Distancia de separación de la pantalla"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Efectos"
 
 #. 2.0->settings-schema.json->scaleEffect->description
-#. 5.4->settings-schema.json->newScaleEffect->description
 msgid "Scale effect"
 msgstr "Efecto de alejamiento de pantalla"
 
@@ -74,9 +70,47 @@ msgid "Open Cinnamon Settings to manage Workspaces"
 msgstr ""
 "Abrir la configuración de Cinnamon para gestionar los espacios de trabajo"
 
+#. 5.4->settings-schema.json->animationTimeSec->description
+#, fuzzy
+msgid "Animation duration (seconds)"
+msgstr "Duración de la animación"
+
+#. 5.4->settings-schema.json->pullawayPercent->description
+msgid "Cube size (percent of screen size)"
+msgstr ""
+
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
 msgstr "Incluir paneles"
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Cube effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Cube effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Cube effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Cube effect is used to change the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->header2->description
+#, fuzzy
+msgid "Effect Easing"
+msgstr "Efectos"
+
+#. 5.4->settings-schema.json->newScaleEffect->description
+msgid "Scale easing"
+msgstr ""
 
 #. 5.4->settings-schema.json->newScaleEffect->options
 #. 5.4->settings-schema.json->newRotateEffect->options
@@ -129,5 +163,16 @@ msgid "Quint"
 msgstr "Quinta"
 
 #. 5.4->settings-schema.json->newRotateEffect->description
-msgid "Rotate effect"
+#, fuzzy
+msgid "Rotate easing"
 msgstr "Efecto de rotación"
+
+#. 5.4->settings-schema.json->easing_btn->description
+msgid "Open easing information website"
+msgstr ""
+
+#. 5.4->settings-schema.json->hotkeys_btn->description
+#, fuzzy
+msgid "Open Cinnamon Keyboard Settings to manage Workspace hotkeys"
+msgstr ""
+"Abrir la configuración de Cinnamon para gestionar los espacios de trabajo"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/eu.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/eu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-06 09:45-0400\n"
+"POT-Creation-Date: 2024-11-20 10:20-0500\n"
 "PO-Revision-Date: 2024-05-30 10:18+0200\n"
 "Last-Translator: Muxutruk <muxutruk2@users.noreply.github.com>\n"
 "Language-Team: Basque <muxutruk2@users.noreply.github.com>\n"
@@ -26,42 +26,150 @@ msgstr "Mahaigaineko kuboa"
 msgid "Compiz Cube-like animation for workspace switching"
 msgstr "Compiz Cube-ren antzeko animazioa, lanerako areetatik mugitzerakoan"
 
-#. settings-schema.json->header1->description
+#. 2.0->settings-schema.json->header1->description
+#. 5.4->settings-schema.json->header1->description
 msgid "General"
 msgstr "Jenerala"
 
-#. settings-schema.json->animationTime->description
+#. 2.0->settings-schema.json->animationTime->description
 msgid "Animation duration"
 msgstr "Animazioaren iraupena"
 
-#. settings-schema.json->pullaway->description
+#. 2.0->settings-schema.json->pullaway->description
 msgid "Pullaway proportion from screen"
 msgstr "Pullaway proportzioa pantailatik"
 
-#. settings-schema.json->header2->description
+#. 2.0->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Efektua"
 
-#. settings-schema.json->scaleEffect->description
+#. 2.0->settings-schema.json->scaleEffect->description
 msgid "Scale effect"
 msgstr "Handitze-efektua"
 
-#. settings-schema.json->unscaleEffect->description
+#. 2.0->settings-schema.json->unscaleEffect->description
 msgid "Unscale effect"
 msgstr "Txikitze-efektua"
 
-#. settings-schema.json->rotateEffect->description
+#. 2.0->settings-schema.json->rotateEffect->description
 msgid "Begin rotate effect"
 msgstr "Biraketa-efektuaren hasiera"
 
-#. settings-schema.json->unrotateEffect->description
+#. 2.0->settings-schema.json->unrotateEffect->description
 msgid "End rotate effect"
 msgstr "Biraketa-efektuaren amaiera"
 
-#. settings-schema.json->header3->description
+#. 2.0->settings-schema.json->header3->description
+#. 5.4->settings-schema.json->header3->description
 msgid "System Settings"
 msgstr "Sistemaren Ezarpenak"
 
-#. settings-schema.json->workspaces_btn->description
+#. 2.0->settings-schema.json->workspaces_btn->description
+#. 5.4->settings-schema.json->workspaces_btn->description
 msgid "Open Cinnamon Settings to manage Workspaces"
+msgstr "Ireki Cinnamonen Ezarpenak laneko areak kudeatzeko"
+
+#. 5.4->settings-schema.json->animationTimeSec->description
+#, fuzzy
+msgid "Animation duration (seconds)"
+msgstr "Animazioaren iraupena"
+
+#. 5.4->settings-schema.json->pullawayPercent->description
+msgid "Cube size (percent of screen size)"
+msgstr ""
+
+#. 5.4->settings-schema.json->includePanels->description
+msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Cube effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Cube effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Cube effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Cube effect is used to change the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->header2->description
+#, fuzzy
+msgid "Effect Easing"
+msgstr "Efektua"
+
+#. 5.4->settings-schema.json->newScaleEffect->description
+msgid "Scale easing"
+msgstr ""
+
+#. 5.4->settings-schema.json->newScaleEffect->options
+#. 5.4->settings-schema.json->newRotateEffect->options
+msgid "Back"
+msgstr ""
+
+#. 5.4->settings-schema.json->newScaleEffect->options
+#. 5.4->settings-schema.json->newRotateEffect->options
+msgid "Bounce"
+msgstr ""
+
+#. 5.4->settings-schema.json->newScaleEffect->options
+#. 5.4->settings-schema.json->newRotateEffect->options
+msgid "Circ"
+msgstr ""
+
+#. 5.4->settings-schema.json->newScaleEffect->options
+#. 5.4->settings-schema.json->newRotateEffect->options
+msgid "Cubic"
+msgstr ""
+
+#. 5.4->settings-schema.json->newScaleEffect->options
+#. 5.4->settings-schema.json->newRotateEffect->options
+msgid "Elastic"
+msgstr ""
+
+#. 5.4->settings-schema.json->newScaleEffect->options
+#. 5.4->settings-schema.json->newRotateEffect->options
+msgid "Expo"
+msgstr ""
+
+#. 5.4->settings-schema.json->newScaleEffect->options
+#. 5.4->settings-schema.json->newRotateEffect->options
+msgid "Sine"
+msgstr ""
+
+#. 5.4->settings-schema.json->newScaleEffect->options
+#. 5.4->settings-schema.json->newRotateEffect->options
+msgid "Quad"
+msgstr ""
+
+#. 5.4->settings-schema.json->newScaleEffect->options
+#. 5.4->settings-schema.json->newRotateEffect->options
+msgid "Quart"
+msgstr ""
+
+#. 5.4->settings-schema.json->newScaleEffect->options
+#. 5.4->settings-schema.json->newRotateEffect->options
+msgid "Quint"
+msgstr ""
+
+#. 5.4->settings-schema.json->newRotateEffect->description
+msgid "Rotate easing"
+msgstr ""
+
+#. 5.4->settings-schema.json->easing_btn->description
+msgid "Open easing information website"
+msgstr ""
+
+#. 5.4->settings-schema.json->hotkeys_btn->description
+#, fuzzy
+msgid "Open Cinnamon Keyboard Settings to manage Workspace hotkeys"
 msgstr "Ireki Cinnamonen Ezarpenak laneko areak kudeatzeko"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/fi.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/fi.po
@@ -7,16 +7,16 @@ msgstr ""
 "Project-Id-Version: DesktopCube@yare 1.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-06 09:45-0400\n"
+"POT-Creation-Date: 2024-11-20 10:20-0500\n"
 "PO-Revision-Date: \n"
+"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
+"Language: fi\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 2.3\n"
-"Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-"Language: fi\n"
 
 #. metadata.json->name
 msgid "Desktop Cube"
@@ -24,8 +24,7 @@ msgstr "Desktop Cube"
 
 #. metadata.json->description
 msgid "Compiz Cube-like animation for workspace switching"
-msgstr ""
-"Compiz Cube kuutio animaatio työtilan vaihtamiseen ⬅ ➡ ctrl+alt"
+msgstr "Compiz Cube kuutio animaatio työtilan vaihtamiseen ⬅ ➡ ctrl+alt"
 
 #. 2.0->settings-schema.json->header1->description
 #. 5.4->settings-schema.json->header1->description
@@ -33,22 +32,18 @@ msgid "General"
 msgstr "Yleinen"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
 msgid "Animation duration"
 msgstr "Animaation kesto"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
 msgid "Pullaway proportion from screen"
 msgstr "Mitta verrattuna näytön reunasta"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Tehosteet"
 
 #. 2.0->settings-schema.json->scaleEffect->description
-#. 5.4->settings-schema.json->newScaleEffect->description
 msgid "Scale effect"
 msgstr "Skaalaustehoste"
 
@@ -74,9 +69,47 @@ msgstr "Järjestelmäasetukset"
 msgid "Open Cinnamon Settings to manage Workspaces"
 msgstr "Avaa Cinnamon työtilojen asetukset"
 
+#. 5.4->settings-schema.json->animationTimeSec->description
+#, fuzzy
+msgid "Animation duration (seconds)"
+msgstr "Animaation kesto"
+
+#. 5.4->settings-schema.json->pullawayPercent->description
+msgid "Cube size (percent of screen size)"
+msgstr ""
+
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
 msgstr "Sisältää paneelit"
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Cube effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Cube effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Cube effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Cube effect is used to change the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->header2->description
+#, fuzzy
+msgid "Effect Easing"
+msgstr "Tehosteet"
+
+#. 5.4->settings-schema.json->newScaleEffect->description
+msgid "Scale easing"
+msgstr ""
 
 #. 5.4->settings-schema.json->newScaleEffect->options
 #. 5.4->settings-schema.json->newRotateEffect->options
@@ -129,5 +162,15 @@ msgid "Quint"
 msgstr "Viisikko"
 
 #. 5.4->settings-schema.json->newRotateEffect->description
-msgid "Rotate effect"
+#, fuzzy
+msgid "Rotate easing"
 msgstr "Kääntötehoste"
+
+#. 5.4->settings-schema.json->easing_btn->description
+msgid "Open easing information website"
+msgstr ""
+
+#. 5.4->settings-schema.json->hotkeys_btn->description
+#, fuzzy
+msgid "Open Cinnamon Keyboard Settings to manage Workspace hotkeys"
+msgstr "Avaa Cinnamon työtilojen asetukset"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/fr.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-06 09:45-0400\n"
+"POT-Creation-Date: 2024-11-20 10:20-0500\n"
 "PO-Revision-Date: 2019-02-13 16:49+0100\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -33,22 +33,18 @@ msgid "General"
 msgstr "Général"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
 msgid "Animation duration"
 msgstr "Durée de l'animation"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
 msgid "Pullaway proportion from screen"
 msgstr "Proportion d'écran conservé autour de l'animation"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Effets"
 
 #. 2.0->settings-schema.json->scaleEffect->description
-#. 5.4->settings-schema.json->newScaleEffect->description
 msgid "Scale effect"
 msgstr "Effet d'éloignement"
 
@@ -74,8 +70,46 @@ msgstr ""
 msgid "Open Cinnamon Settings to manage Workspaces"
 msgstr "Ouvrir les paramètres système pour gérer les espaces de travail"
 
+#. 5.4->settings-schema.json->animationTimeSec->description
+#, fuzzy
+msgid "Animation duration (seconds)"
+msgstr "Durée de l'animation"
+
+#. 5.4->settings-schema.json->pullawayPercent->description
+msgid "Cube size (percent of screen size)"
+msgstr ""
+
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Cube effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Cube effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Cube effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Cube effect is used to change the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->header2->description
+#, fuzzy
+msgid "Effect Easing"
+msgstr "Effets"
+
+#. 5.4->settings-schema.json->newScaleEffect->description
+msgid "Scale easing"
 msgstr ""
 
 #. 5.4->settings-schema.json->newScaleEffect->options
@@ -130,5 +164,14 @@ msgstr ""
 
 #. 5.4->settings-schema.json->newRotateEffect->description
 #, fuzzy
-msgid "Rotate effect"
+msgid "Rotate easing"
 msgstr "Effet en fin de rotation"
+
+#. 5.4->settings-schema.json->easing_btn->description
+msgid "Open easing information website"
+msgstr ""
+
+#. 5.4->settings-schema.json->hotkeys_btn->description
+#, fuzzy
+msgid "Open Cinnamon Keyboard Settings to manage Workspace hotkeys"
+msgstr "Ouvrir les paramètres système pour gérer les espaces de travail"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/hr.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/hr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: DesktopCube@yare\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-06 09:45-0400\n"
+"POT-Creation-Date: 2024-11-20 10:20-0500\n"
 "PO-Revision-Date: 2017-04-30 16:57+0200\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: \n"
@@ -34,22 +34,18 @@ msgid "General"
 msgstr "Općenito"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
 msgid "Animation duration"
 msgstr "Trajanje animacije"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
 msgid "Pullaway proportion from screen"
 msgstr "Omjer udaljavanja od zaslona"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Efekti"
 
 #. 2.0->settings-schema.json->scaleEffect->description
-#. 5.4->settings-schema.json->newScaleEffect->description
 msgid "Scale effect"
 msgstr "Efekt udaljenja"
 
@@ -75,8 +71,46 @@ msgstr ""
 msgid "Open Cinnamon Settings to manage Workspaces"
 msgstr ""
 
+#. 5.4->settings-schema.json->animationTimeSec->description
+#, fuzzy
+msgid "Animation duration (seconds)"
+msgstr "Trajanje animacije"
+
+#. 5.4->settings-schema.json->pullawayPercent->description
+msgid "Cube size (percent of screen size)"
+msgstr ""
+
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Cube effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Cube effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Cube effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Cube effect is used to change the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->header2->description
+#, fuzzy
+msgid "Effect Easing"
+msgstr "Efekti"
+
+#. 5.4->settings-schema.json->newScaleEffect->description
+msgid "Scale easing"
 msgstr ""
 
 #. 5.4->settings-schema.json->newScaleEffect->options
@@ -131,5 +165,13 @@ msgstr ""
 
 #. 5.4->settings-schema.json->newRotateEffect->description
 #, fuzzy
-msgid "Rotate effect"
+msgid "Rotate easing"
 msgstr "Efekt završetka zakretanja"
+
+#. 5.4->settings-schema.json->easing_btn->description
+msgid "Open easing information website"
+msgstr ""
+
+#. 5.4->settings-schema.json->hotkeys_btn->description
+msgid "Open Cinnamon Keyboard Settings to manage Workspace hotkeys"
+msgstr ""

--- a/DesktopCube@yare/files/DesktopCube@yare/po/hu.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-06 09:45-0400\n"
+"POT-Creation-Date: 2024-11-20 10:20-0500\n"
 "PO-Revision-Date: 2024-10-02 10:21+0200\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
@@ -32,22 +32,18 @@ msgid "General"
 msgstr "Általános"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
 msgid "Animation duration"
 msgstr "Animáció időtartama"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
 msgid "Pullaway proportion from screen"
 msgstr "Képernyőről való elhúzás mértéke"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Effektusok"
 
 #. 2.0->settings-schema.json->scaleEffect->description
-#. 5.4->settings-schema.json->newScaleEffect->description
 msgid "Scale effect"
 msgstr "Eltávolodás effektus"
 
@@ -73,9 +69,47 @@ msgstr "Rendszerbeállítások"
 msgid "Open Cinnamon Settings to manage Workspaces"
 msgstr "Cinnamon beállítások megnyitása a munkaterületek kezeléséhez"
 
+#. 5.4->settings-schema.json->animationTimeSec->description
+#, fuzzy
+msgid "Animation duration (seconds)"
+msgstr "Animáció időtartama"
+
+#. 5.4->settings-schema.json->pullawayPercent->description
+msgid "Cube size (percent of screen size)"
+msgstr ""
+
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
 msgstr "Tartalmazza a paneleket"
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Cube effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Cube effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Cube effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Cube effect is used to change the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->header2->description
+#, fuzzy
+msgid "Effect Easing"
+msgstr "Effektusok"
+
+#. 5.4->settings-schema.json->newScaleEffect->description
+msgid "Scale easing"
+msgstr ""
 
 #. 5.4->settings-schema.json->newScaleEffect->options
 #. 5.4->settings-schema.json->newRotateEffect->options
@@ -128,5 +162,15 @@ msgid "Quint"
 msgstr "Quint"
 
 #. 5.4->settings-schema.json->newRotateEffect->description
-msgid "Rotate effect"
+#, fuzzy
+msgid "Rotate easing"
 msgstr "Forgás effektus"
+
+#. 5.4->settings-schema.json->easing_btn->description
+msgid "Open easing information website"
+msgstr ""
+
+#. 5.4->settings-schema.json->hotkeys_btn->description
+#, fuzzy
+msgid "Open Cinnamon Keyboard Settings to manage Workspace hotkeys"
+msgstr "Cinnamon beállítások megnyitása a munkaterületek kezeléséhez"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/it.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-06 09:45-0400\n"
+"POT-Creation-Date: 2024-11-20 10:20-0500\n"
 "PO-Revision-Date: 2022-06-03 10:52+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -34,22 +34,18 @@ msgid "General"
 msgstr "Generale"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
 msgid "Animation duration"
 msgstr "Durata animazione"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
 msgid "Pullaway proportion from screen"
 msgstr "Allontana la proporzione dallo schermo"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Effetti"
 
 #. 2.0->settings-schema.json->scaleEffect->description
-#. 5.4->settings-schema.json->newScaleEffect->description
 msgid "Scale effect"
 msgstr "Effetto scala"
 
@@ -75,8 +71,46 @@ msgstr "Impostazioni di Sistema"
 msgid "Open Cinnamon Settings to manage Workspaces"
 msgstr "Apri le Impostazioni di Cinnamon per gestire le Aree di Lavoro"
 
+#. 5.4->settings-schema.json->animationTimeSec->description
+#, fuzzy
+msgid "Animation duration (seconds)"
+msgstr "Durata animazione"
+
+#. 5.4->settings-schema.json->pullawayPercent->description
+msgid "Cube size (percent of screen size)"
+msgstr ""
+
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Cube effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Cube effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Cube effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Cube effect is used to change the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->header2->description
+#, fuzzy
+msgid "Effect Easing"
+msgstr "Effetti"
+
+#. 5.4->settings-schema.json->newScaleEffect->description
+msgid "Scale easing"
 msgstr ""
 
 #. 5.4->settings-schema.json->newScaleEffect->options
@@ -131,5 +165,14 @@ msgstr ""
 
 #. 5.4->settings-schema.json->newRotateEffect->description
 #, fuzzy
-msgid "Rotate effect"
+msgid "Rotate easing"
 msgstr "Effetto fine rotazione"
+
+#. 5.4->settings-schema.json->easing_btn->description
+msgid "Open easing information website"
+msgstr ""
+
+#. 5.4->settings-schema.json->hotkeys_btn->description
+#, fuzzy
+msgid "Open Cinnamon Keyboard Settings to manage Workspace hotkeys"
+msgstr "Apri le Impostazioni di Cinnamon per gestire le Aree di Lavoro"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/nl.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/nl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-06 09:45-0400\n"
+"POT-Creation-Date: 2024-11-20 10:20-0500\n"
 "PO-Revision-Date: 2024-09-11 11:32+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -32,22 +32,18 @@ msgid "General"
 msgstr "Algemeen"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
 msgid "Animation duration"
 msgstr "Animatieduur"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
 msgid "Pullaway proportion from screen"
 msgstr "Verhouding van het wegtrekken van het scherm"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Effecten"
 
 #. 2.0->settings-schema.json->scaleEffect->description
-#. 5.4->settings-schema.json->newScaleEffect->description
 msgid "Scale effect"
 msgstr "Vergroten effect"
 
@@ -73,9 +69,47 @@ msgstr "Systeeminstellingen"
 msgid "Open Cinnamon Settings to manage Workspaces"
 msgstr "Open Cinnamon Instellingen om Werkruimtes te beheren"
 
+#. 5.4->settings-schema.json->animationTimeSec->description
+#, fuzzy
+msgid "Animation duration (seconds)"
+msgstr "Animatieduur"
+
+#. 5.4->settings-schema.json->pullawayPercent->description
+msgid "Cube size (percent of screen size)"
+msgstr ""
+
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
 msgstr "Inclusief Panelen"
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Cube effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Cube effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Cube effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Cube effect is used to change the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->header2->description
+#, fuzzy
+msgid "Effect Easing"
+msgstr "Effecten"
+
+#. 5.4->settings-schema.json->newScaleEffect->description
+msgid "Scale easing"
+msgstr ""
 
 #. 5.4->settings-schema.json->newScaleEffect->options
 #. 5.4->settings-schema.json->newRotateEffect->options
@@ -128,5 +162,15 @@ msgid "Quint"
 msgstr "Quint"
 
 #. 5.4->settings-schema.json->newRotateEffect->description
-msgid "Rotate effect"
+#, fuzzy
+msgid "Rotate easing"
 msgstr "Draai-effect"
+
+#. 5.4->settings-schema.json->easing_btn->description
+msgid "Open easing information website"
+msgstr ""
+
+#. 5.4->settings-schema.json->hotkeys_btn->description
+#, fuzzy
+msgid "Open Cinnamon Keyboard Settings to manage Workspace hotkeys"
+msgstr "Open Cinnamon Instellingen om Werkruimtes te beheren"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/pt_BR.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/pt_BR.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-06 09:45-0400\n"
+"POT-Creation-Date: 2024-11-20 10:20-0500\n"
 "PO-Revision-Date: 2021-09-26 21:23-0300\n"
 "Last-Translator: Marcelo Aof\n"
 "Language-Team: \n"
@@ -34,22 +34,18 @@ msgid "General"
 msgstr "Visão geral"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
 msgid "Animation duration"
 msgstr "Duração da animação"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
 msgid "Pullaway proportion from screen"
 msgstr "Proporção de afastamento da tela"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Efeitos"
 
 #. 2.0->settings-schema.json->scaleEffect->description
-#. 5.4->settings-schema.json->newScaleEffect->description
 msgid "Scale effect"
 msgstr "Efeito de afastamento da tela"
 
@@ -75,8 +71,46 @@ msgstr "Configurações do sistema"
 msgid "Open Cinnamon Settings to manage Workspaces"
 msgstr "Abrir as configurações do Cinnamon para ajustar os espaços de trabalho"
 
+#. 5.4->settings-schema.json->animationTimeSec->description
+#, fuzzy
+msgid "Animation duration (seconds)"
+msgstr "Duração da animação"
+
+#. 5.4->settings-schema.json->pullawayPercent->description
+msgid "Cube size (percent of screen size)"
+msgstr ""
+
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Cube effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Cube effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Cube effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Cube effect is used to change the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->header2->description
+#, fuzzy
+msgid "Effect Easing"
+msgstr "Efeitos"
+
+#. 5.4->settings-schema.json->newScaleEffect->description
+msgid "Scale easing"
 msgstr ""
 
 #. 5.4->settings-schema.json->newScaleEffect->options
@@ -131,5 +165,14 @@ msgstr ""
 
 #. 5.4->settings-schema.json->newRotateEffect->description
 #, fuzzy
-msgid "Rotate effect"
+msgid "Rotate easing"
 msgstr "Fim do efeito de rotação"
+
+#. 5.4->settings-schema.json->easing_btn->description
+msgid "Open easing information website"
+msgstr ""
+
+#. 5.4->settings-schema.json->hotkeys_btn->description
+#, fuzzy
+msgid "Open Cinnamon Keyboard Settings to manage Workspace hotkeys"
+msgstr "Abrir as configurações do Cinnamon para ajustar os espaços de trabalho"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/ro.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/ro.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-06 09:45-0400\n"
+"POT-Creation-Date: 2024-11-20 10:20-0500\n"
 "PO-Revision-Date: 2022-08-06 01:55+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -34,22 +34,18 @@ msgid "General"
 msgstr "General"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
 msgid "Animation duration"
 msgstr "Durata animației"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
 msgid "Pullaway proportion from screen"
 msgstr "Proporția de tragere în spate de la ecran"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Efecte"
 
 #. 2.0->settings-schema.json->scaleEffect->description
-#. 5.4->settings-schema.json->newScaleEffect->description
 msgid "Scale effect"
 msgstr "Efectul de mărire"
 
@@ -75,8 +71,46 @@ msgstr "Setări de sistem"
 msgid "Open Cinnamon Settings to manage Workspaces"
 msgstr "Deschide Setări Cinnamon pentru a gestiona Spațiile de lucru"
 
+#. 5.4->settings-schema.json->animationTimeSec->description
+#, fuzzy
+msgid "Animation duration (seconds)"
+msgstr "Durata animației"
+
+#. 5.4->settings-schema.json->pullawayPercent->description
+msgid "Cube size (percent of screen size)"
+msgstr ""
+
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Cube effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Cube effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Cube effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Cube effect is used to change the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->header2->description
+#, fuzzy
+msgid "Effect Easing"
+msgstr "Efecte"
+
+#. 5.4->settings-schema.json->newScaleEffect->description
+msgid "Scale easing"
 msgstr ""
 
 #. 5.4->settings-schema.json->newScaleEffect->options
@@ -131,5 +165,14 @@ msgstr ""
 
 #. 5.4->settings-schema.json->newRotateEffect->description
 #, fuzzy
-msgid "Rotate effect"
+msgid "Rotate easing"
 msgstr "Termină efectului de rotire"
+
+#. 5.4->settings-schema.json->easing_btn->description
+msgid "Open easing information website"
+msgstr ""
+
+#. 5.4->settings-schema.json->hotkeys_btn->description
+#, fuzzy
+msgid "Open Cinnamon Keyboard Settings to manage Workspace hotkeys"
+msgstr "Deschide Setări Cinnamon pentru a gestiona Spațiile de lucru"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/ru.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/ru.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-06 09:45-0400\n"
+"POT-Creation-Date: 2024-11-20 10:20-0500\n"
 "PO-Revision-Date: 2023-12-03 14:51-0500\n"
 "Last-Translator: blogdron\n"
 "Language-Team: \n"
@@ -28,22 +28,18 @@ msgid "General"
 msgstr "Общие"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
 msgid "Animation duration"
 msgstr "Продолжительность анимации"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
 msgid "Pullaway proportion from screen"
 msgstr "Пропорции куба относительно экрана"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Эффекты"
 
 #. 2.0->settings-schema.json->scaleEffect->description
-#. 5.4->settings-schema.json->newScaleEffect->description
 msgid "Scale effect"
 msgstr "Эффект отстранения"
 
@@ -69,8 +65,46 @@ msgstr "Системные настройки"
 msgid "Open Cinnamon Settings to manage Workspaces"
 msgstr "Открыть настройки Cinnamon для управления рабочими областями"
 
+#. 5.4->settings-schema.json->animationTimeSec->description
+#, fuzzy
+msgid "Animation duration (seconds)"
+msgstr "Продолжительность анимации"
+
+#. 5.4->settings-schema.json->pullawayPercent->description
+msgid "Cube size (percent of screen size)"
+msgstr ""
+
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Cube effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Cube effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Cube effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Cube effect is used to change the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->header2->description
+#, fuzzy
+msgid "Effect Easing"
+msgstr "Эффекты"
+
+#. 5.4->settings-schema.json->newScaleEffect->description
+msgid "Scale easing"
 msgstr ""
 
 #. 5.4->settings-schema.json->newScaleEffect->options
@@ -125,5 +159,14 @@ msgstr ""
 
 #. 5.4->settings-schema.json->newRotateEffect->description
 #, fuzzy
-msgid "Rotate effect"
+msgid "Rotate easing"
 msgstr "Конец эффекта вращения"
+
+#. 5.4->settings-schema.json->easing_btn->description
+msgid "Open easing information website"
+msgstr ""
+
+#. 5.4->settings-schema.json->hotkeys_btn->description
+#, fuzzy
+msgid "Open Cinnamon Keyboard Settings to manage Workspace hotkeys"
+msgstr "Открыть настройки Cinnamon для управления рабочими областями"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/tr.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/tr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-06 09:45-0400\n"
+"POT-Creation-Date: 2024-11-20 10:20-0500\n"
 "PO-Revision-Date: 2017-09-01 18:36+0300\n"
 "Last-Translator: Gökhan Gökkaya <gokhanlnx@gmail.com>\n"
 "Language-Team: Linux Mint Türkiye\n"
@@ -33,22 +33,18 @@ msgid "General"
 msgstr "Genel"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
 msgid "Animation duration"
 msgstr "Animasyon süresi"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
 msgid "Pullaway proportion from screen"
 msgstr "Ekrandan uzaklaşma oranı"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Efektler"
 
 #. 2.0->settings-schema.json->scaleEffect->description
-#. 5.4->settings-schema.json->newScaleEffect->description
 msgid "Scale effect"
 msgstr "Ölçeklendirme efekti"
 
@@ -74,8 +70,46 @@ msgstr ""
 msgid "Open Cinnamon Settings to manage Workspaces"
 msgstr ""
 
+#. 5.4->settings-schema.json->animationTimeSec->description
+#, fuzzy
+msgid "Animation duration (seconds)"
+msgstr "Animasyon süresi"
+
+#. 5.4->settings-schema.json->pullawayPercent->description
+msgid "Cube size (percent of screen size)"
+msgstr ""
+
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Cube effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Cube effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Cube effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Cube effect is used to change the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->header2->description
+#, fuzzy
+msgid "Effect Easing"
+msgstr "Efektler"
+
+#. 5.4->settings-schema.json->newScaleEffect->description
+msgid "Scale easing"
 msgstr ""
 
 #. 5.4->settings-schema.json->newScaleEffect->options
@@ -130,5 +164,13 @@ msgstr ""
 
 #. 5.4->settings-schema.json->newRotateEffect->description
 #, fuzzy
-msgid "Rotate effect"
+msgid "Rotate easing"
 msgstr "Dönme bitiş efekti"
+
+#. 5.4->settings-schema.json->easing_btn->description
+msgid "Open easing information website"
+msgstr ""
+
+#. 5.4->settings-schema.json->hotkeys_btn->description
+msgid "Open Cinnamon Keyboard Settings to manage Workspace hotkeys"
+msgstr ""

--- a/DesktopCube@yare/files/DesktopCube@yare/po/zh_CN.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/zh_CN.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-09-06 09:45-0400\n"
+"POT-Creation-Date: 2024-11-20 10:20-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -29,22 +29,18 @@ msgid "General"
 msgstr "常规"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
 msgid "Animation duration"
 msgstr "动画时长"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
 msgid "Pullaway proportion from screen"
 msgstr "从屏幕拉出比例"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "特效"
 
 #. 2.0->settings-schema.json->scaleEffect->description
-#. 5.4->settings-schema.json->newScaleEffect->description
 msgid "Scale effect"
 msgstr "缩放特效"
 
@@ -70,8 +66,46 @@ msgstr "系统设置"
 msgid "Open Cinnamon Settings to manage Workspaces"
 msgstr "打开Cinnamon设置来管理工作区"
 
+#. 5.4->settings-schema.json->animationTimeSec->description
+#, fuzzy
+msgid "Animation duration (seconds)"
+msgstr "动画时长"
+
+#. 5.4->settings-schema.json->pullawayPercent->description
+msgid "Cube size (percent of screen size)"
+msgstr ""
+
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Cube effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Cube effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Cube effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Cube effect is used to change the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->header2->description
+#, fuzzy
+msgid "Effect Easing"
+msgstr "特效"
+
+#. 5.4->settings-schema.json->newScaleEffect->description
+msgid "Scale easing"
 msgstr ""
 
 #. 5.4->settings-schema.json->newScaleEffect->options
@@ -126,5 +160,14 @@ msgstr ""
 
 #. 5.4->settings-schema.json->newRotateEffect->description
 #, fuzzy
-msgid "Rotate effect"
+msgid "Rotate easing"
 msgstr "结尾旋转特效"
+
+#. 5.4->settings-schema.json->easing_btn->description
+msgid "Open easing information website"
+msgstr ""
+
+#. 5.4->settings-schema.json->hotkeys_btn->description
+#, fuzzy
+msgid "Open Cinnamon Keyboard Settings to manage Workspace hotkeys"
+msgstr "打开Cinnamon设置来管理工作区"


### PR DESCRIPTION
1. Added ability to use Cube effect when changing the workspace via the "Workspace Switcher" applet
2. Added ability to use Cube effect when changing the workspace by activating a window on a different workspace
3. Added ability to use Cube effect when using the workspace "Direct Navigation" hotkeys
4. Enabled showing the desktop icons during the Cube effect
5. Allow the Cube to queue up hotkey press actions rather than ignoring hotkey presses during the Cube animation
6. Changed the "Animation duration" option to be a number of seconds (0.1 to 4 seconds)
7. Changed the Pullaway setting to be a "Cube size" as a percentage of the screen size
8. Added button to the Desktop Cube setting dialog which will launch the keyboard setting dialog as a convenient access to setting workspace related hotkeys
9. The Cube rotation and the scale down to the target Cube size effects will now run in parallel, this saves animation time and makes the animation look smoother. As a side effect, the easing for the scale down action is now hard-coded to "easeNone" and the user defined "Scale effect" is used only for the "Unscale" action. This is assuming there is a need to scale at all, i.e. the cube size is not 100%, in the 'Cube size is 100%' case the easing will still apply.
10. The "Rotate easing" effect is now only applied to the ending of the rotate when there is no 2nd rotation that is need and there is no immediate unscaling needed. Likewise, easing is only applied at the start of the rotate when there is no scaling needed (i.e only when hot-keys are used a 2nd time while holding the modifier keys). This makes the whole animation smoother particularly when Bounce/Back/Elastic easing is used.
11. Added a button to the Desktop Cube setting dialog under the "Effect Easing" section which will open the easing information website