### PR TITLE
[horizontal-osd@berk-karaal] v0.0.3 - Improves compatibility with Cinnamon 6.4

### DIFF
--- a/horizontal-osd@berk-karaal/files/horizontal-osd@berk-karaal/metadata.json
+++ b/horizontal-osd@berk-karaal/files/horizontal-osd@berk-karaal/metadata.json
@@ -1,8 +1,8 @@
 {
     "uuid": "horizontal-osd@berk-karaal",
     "name": "Horizontal OSD",
-    "author": "Berk Karaal",
-    "version": "0.0.2",
+    "author": "berk-karaal",
+    "version": "0.0.3",
     "description": "Horizontal and customizable OSDs",
     "url": "https://github.com/berk-karaal/cinnamon-horizontal-osd",
     "website": "https://github.com/berk-karaal/cinnamon-horizontal-osd",


### PR DESCRIPTION
Hi @berk-karaal,

Thank you for this very useful extension!

With Cinnamon 6.4, the key "show-media-keys-osd" is no longer a string but a boolean and the " %" symbol is no longer displayed in OSD: https://github.com/linuxmint/mint22.1-beta/issues/4#issuecomment-2535973291

This PR corrects all that.

Regards.
Claudiux
