### PR TITLE
[horizontal-osd@berk-karaal] set author to none

### DIFF
--- a/horizontal-osd@berk-karaal/info.json
+++ b/horizontal-osd@berk-karaal/info.json
@@ -1,4 +1,5 @@
 {
-    "author": "berk-karaal",
+    "author": "none",
+    "original_author": "berk-karaal",
     "license": "GPL-3.0"
 }


### PR DESCRIPTION
Hi, I'm not able take care of the extension anymore. Glad that Cinnamon 6.4 features horizontal OSDs.

Linux Mint team can decide who will be next author or the status of the extension. 