### PR TITLE
[smart-panel@mohammad-sn] Use Flipper/DesktopCube in more cases

### DIFF
--- a/smart-panel@mohammad-sn/files/smart-panel@mohammad-sn/metadata.json
+++ b/smart-panel@mohammad-sn/files/smart-panel@mohammad-sn/metadata.json
@@ -23,7 +23,7 @@
   ],
   "description": "Switch between workspaces, show desktop, activate overview or expo, ... by scrolling, double click, mouse gestures etc on free space of the panel.",
   "name": "Smart Panel",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "uuid": "smart-panel@mohammad-sn",
   "url": "https://cinnamon-spices.linuxmint.com/extensions/view/80",
   "author": "mohammad-sn"


### PR DESCRIPTION
Use a new API that will be added to Flipper & DesktopCube for switching the workspace. This API will allow switching to arbitrary workspaces rather than just to workspaces that are adjacent to the current one. The change checks if the new API exists (which it does not currently, but Flipper & DesktopCube updates will follow soon) and uses the API if it exists. If the API is not found, the code will use DesktopCube/Flipper as it did before (in a slightly more limited way then what is possible using the API).