### PR TITLE
Flipper v2.0.0

### DIFF
--- a/Flipper@connerdev/CHANGELOG.md
+++ b/Flipper@connerdev/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## 2.0.0
+
+- Added ability to use Flipper effects when changing the workspace via the "Workspace Switcher" applet
+- Added ability to use Flipper effects when changing the workspace by activating a window on a different workspace
+- Added ability to use Flipper effects when using the workspace "Direct Navigation" hotkeys
+- Implement "Extension Workspace Switching API" used by smart-panel 1.4.2 to switch workspaces using the Flipper effect
+- Added a configuration option to control if the "Workspace Switcher" applet will use the Flipper effect
+- Added a configuration option to control if switching to a window on a different workspace will use the Flipper effect
+- Use independent effect settings so each effect remembers it's own settings
+- Added a "Randomized" effect option that will randomly select a effect for each workspace transition initiation
+- Added a set of configuration options that allows you to control which effects are in the Randomized set
+- Removed the "Include Background" option and hard-coded Cube effect to include a cloned background, all the other effects will see the original desktop background dimmed according to the "Background Dim Amount" setting
+
 ## 1.0.6
 
 * Fix "opacity" .xsession-errors messages when using the "Back" or "Elastic" easing options

--- a/Flipper@connerdev/README.md
+++ b/Flipper@connerdev/README.md
@@ -1,5 +1,54 @@
 # Flipper
 
-Fancy workspace switching extension with 7 different effect options
+Fancy workspace switching extension with 7 different effect animation options
 
-Using the standard workspace switching hotkeys Ctrl+Alt+Left/Right will animate the workspace change with several types of animation effects (configurable in the extension settings)
+## Requirements
+
+Version 2 requires Cinnamon 5.4 (Mint 21) or better
+
+The older Flipper version (with limited features) will be used on older Cinnamon versions.
+
+Tested on: Mint 21 / 21.1 / 21.3 / 22 and Fedora Cinnamon-Spin 40.
+
+## When is the Flipper effect used?
+
+There are a number of ways to switch the current workspace, all of following will be handled by Flipper starting with version 2:
+
+1. The "Switch to left/right workspace" hotkeys (under Keyboard settings, Shortcuts tab, Workspace category) Default hotkey: Ctrl + Alt + Left/Right_Arrow_Keys
+
+2. The "Switch to workspace 1-12" hotkeys (under Keyboard settings, Shortcuts tab, Workspace/Direct Navigation category) Default hotkey: unassigned
+
+3. Using the "Move window to the left/right workspace" hotkeys (under Keyboard settings, Shortcuts tab, Windows/Inter-workspace category) Default hotkey: Shift + Ctrl + Alt + Left/Right_Arrow_Keys
+
+4. Clicking on a workspace button in the "Workspace Switcher" applet (can be disabled in the configuration)
+
+5. When changing the focus to a window on another workspace by using the Window-List or Alt-Tab when they are configured to show windows from other workspaces. (can be disabled in the configuration)
+
+6. When using the "Smart Panel" Applet features that change the workspace (Also plan to change "Desktop Scroller" to use Flipper as well in the near future)
+
+When switching the current workspace using Expo ("workspace selection screen" Default hotkey: Ctrl + Alt + Up_Arrow_Key) the Flipper effects will not be used. This includes clicking on a workspace in the Expo or using the Left/Right arrow keys when the Expo is open.
+
+If you know of other methods of switching the workspace where the Flipper effect is not currently used, please let me know so I can see if I can find a way to enable the Flipper for that path as well.
+
+## Known Issues
+
+1. When using Flipper with two or more Monitors attached, the effects will only appear on the primary display. At some point I plan on adding options to control how Flipper works on multi-monitor setups, but it might be a while before I find the time to work on that.
+
+2. If you enable the "Include Panels" option in the Flipper configuration, the panels will disappear while the effect is in action and then reappear when it is done. This is far from ideal, so I recommend that you leave this option disabled so that the panels remain hidden, only reappearing after returning to the normal desktop.
+
+3. In the setting configure window under the "Effect Settings" tab, when changing the "Show setting for effect" drop-down to select a different effect, sometimes the contents under the "Effect Specific Settings" title will not properly update. Because of this, only a subset of the available options are visible. I believe this is a Cinnamon bug. You can force Cinnamon to properly redraw the options by selecting the "General" tab then returning to the "Effect Settings" tab again. After that, the complete set of "Effect Specific Settings" should be visible.
+
+## Installation
+
+- Right click on the cinnamon panel and click "System Settings"
+- Click on the "Extensions" icon under the "Preferences" category
+- Click the "Download" tab and then click the "Flipper" entry
+- Click the "Install" button on the right and then return to the "Manage" tab
+- Select the new "Flipper" entry and then click the "+" button at the bottom of the window
+- Use the "gears" icon next to the "Flipper" entry to open the setting window and setup your preferred behavior
+
+## Feedback
+
+Please leave a comment here on cinnamon-spices.linuxmint.com
+
+To report a bug or submit a feature request, open an issue here: [GitHub Spices Repo](https://github.com/linuxmint/cinnamon-spices-extensions/issues/new/choose)

--- a/Flipper@connerdev/files/Flipper@connerdev/5.4/settings-schema.json
+++ b/Flipper@connerdev/files/Flipper@connerdev/5.4/settings-schema.json
@@ -1,62 +1,122 @@
 {
-  "header1" : {
-    "type" : "header",
-    "description" : "General"
+  "layout" : {
+    "type" : "layout",
+    "pages" : ["general-page", "effects-page"],
+
+    "general-page" : {
+      "type" : "page",
+      "title" : "General",
+      "sections" : ["general-settings", "random-settings"]
+    },
+    "effects-page" : {
+      "type" : "page",
+      "title" : "Effect Settings",
+      "sections" : ["effect-selector-section", "effect-settings"]
+    },
+
+    "general-settings" : {
+      "type" : "section",
+      "title" : "Flipper General Settings",
+      "keys" : ["transitionEffect", "patchmoveToWorkspace", "patchActivateWindow", "includePanels"]
+    },
+    "random-settings" : {
+      "type" : "section",
+      "title" : "Effects included in the randomized set",
+      "dependency" : "transitionEffect=7",
+      "keys" : ["cube-random-include", "deck-random-include", "flip-random-include", "pop-random-include", "rolodex-random-include", "slide-random-include", "stack-random-include"]
+    },
+
+    "effect-selector-section" : {
+      "type" : "section",
+      "title" : "Effect Selector",
+      "keys" : ["effect-selector"]
+    },
+    "effect-settings" : {
+      "type" : "section",
+      "title" : "Effect Specific Settings",
+      "keys" : ["cube-animationTime", "cube-pullaway", "cube-fade", "cube-dim-factor", "cube-rotateEffect",
+                "deck-animationTime", "deck-pullaway", "deck-fade", "deck-dim-factor", "deck-rotateEffect",
+                "flip-animationTime", "flip-pullaway", "flip-fade", "flip-dim-factor", "flip-rotateEffect",
+                "pop-animationTime", "pop-pullaway", "pop-fade", "pop-dim-factor", "pop-rotateEffect",
+                "rolodex-animationTime", "rolodex-pullaway", "rolodex-fade", "rolodex-dim-factor", "rolodex-rotateEffect",
+                "slide-animationTime", "slide-pullaway", "slide-fade", "slide-dim-factor", "slide-rotateEffect",
+                "stack-animationTime", "stack-pullaway", "stack-fade", "stack-dim-factor", "stack-rotateEffect"]
+    }
   },
-  "animationTime" : {
+
+  "cube-random-include": {
+    "type" : "checkbox",
+    "description" : "Cube",
+    "default": true
+  },
+  "deck-random-include": {
+    "type" : "checkbox",
+    "description" : "Deck",
+    "default": true
+  },
+  "flip-random-include": {
+    "type" : "checkbox",
+    "description" : "Flip",
+    "default": true
+  },
+  "pop-random-include": {
+    "type" : "checkbox",
+    "description" : "Pop",
+    "default": true
+  },
+  "rolodex-random-include": {
+    "type" : "checkbox",
+    "description" : "Rolodex",
+    "default": true
+  },
+  "slide-random-include": {
+    "type" : "checkbox",
+    "description" : "Slide",
+    "default": true
+  },
+  "stack-random-include": {
+    "type" : "checkbox",
+    "description" : "Stack",
+    "default": true
+  },
+
+  "cube-animationTime" : {
     "type" : "scale",
     "description" : "Animation duration",
     "min" : 0,
     "max" : 1500,
     "default": 500,
-    "step" : 50
+    "step" : 50,
+    "dependency" : "effect-selector=0"
   },
-  "pullaway" : {
+  "cube-pullaway" : {
     "type" : "scale",
     "description" : "Zoom Amount",
     "min" : 0.00,
     "max" : 1.0,
     "default" : 1.0,
-    "step" : 0.05
+    "step" : 0.05,
+    "dependency" : "effect-selector=0"
   },
-  "fade" : {
+  "cube-fade" : {
     "type" : "scale",
     "description" : "Fade Transition",
     "min" : 0.00,
     "max" : 1.0,
     "default" : 0.0,
-    "step" : 0.05
+    "step" : 0.05,
+    "dependency" : "effect-selector=0"
   },
-  "dim_factor" : {
+  "cube-dim-factor" : {
     "type" : "scale",
     "description" : "Background Dim Amount",
     "min" : 0.0,
     "max" : 1.0,
     "default" : 0.2,
-    "step" : 0.05
+    "step" : 0.05,
+    "dependency" : "effect-selector=0"
   },
-  "sep1": {
-    "type": "separator"
-  },
-  "header2" : {
-    "type" : "header",
-    "description" : "Effects"
-  },
-  "transitionEffect": {
-    "type": "combobox",
-    "description": "Transition Effect",
-    "default": "Stack",
-    "options": {
-      "Cube": "Cube",
-      "Deck": "Deck",
-      "Flip": "Flip",
-      "Pop": "Pop",
-      "Rolodex": "Rolodex",
-      "Slide": "Slide",
-      "Stack" : "Stack"
-    }
-  },
-  "rotateEffect": {
+  "cube-rotateEffect": {
     "type": "combobox",
     "description": "Transition Easing",
     "default": "Expo",
@@ -74,16 +134,405 @@
       "Quad": "Quad",
       "Quart": "Quart",
       "Quint": "Quint"
+    },
+    "dependency" : "effect-selector=0"
+  },
+
+
+  "deck-animationTime" : {
+    "type" : "scale",
+    "description" : "Animation duration",
+    "min" : 0,
+    "max" : 1500,
+    "default": 500,
+    "step" : 50,
+    "dependency" : "effect-selector=1"
+  },
+  "deck-pullaway" : {
+    "type" : "scale",
+    "description" : "Zoom Amount",
+    "min" : 0.00,
+    "max" : 1.0,
+    "default" : 1.0,
+    "step" : 0.05,
+    "dependency" : "effect-selector=1"
+  },
+  "deck-fade" : {
+    "type" : "scale",
+    "description" : "Fade Transition",
+    "min" : 0.00,
+    "max" : 1.0,
+    "default" : 0.0,
+    "step" : 0.05,
+    "dependency" : "effect-selector=1"
+  },
+  "deck-dim-factor" : {
+    "type" : "scale",
+    "description" : "Background Dim Amount",
+    "min" : 0.0,
+    "max" : 1.0,
+    "default" : 0.2,
+    "step" : 0.05,
+    "dependency" : "effect-selector=1"
+  },
+  "deck-rotateEffect": {
+    "type": "combobox",
+    "description": "Transition Easing",
+    "default": "Expo",
+    "options": {
+      "Back": "Back",
+      "Bounce": "Bounce",
+      "Circ": "Circ",
+      "Cubic": "Cubic",
+      "Cubic-Back": "EndBack",
+      "Cubic-Bounce": "EndBounce",
+      "Cubic-Elastic": "EndElastic",
+      "Elastic": "Elastic",
+      "Expo": "Expo",
+      "Sine": "Sine",
+      "Quad": "Quad",
+      "Quart": "Quart",
+      "Quint": "Quint"
+    },
+    "dependency" : "effect-selector=1"
+  },
+
+  "flip-animationTime" : {
+    "type" : "scale",
+    "description" : "Animation duration",
+    "min" : 0,
+    "max" : 1500,
+    "default": 500,
+    "step" : 50,
+    "dependency" : "effect-selector=2"
+  },
+  "flip-pullaway" : {
+    "type" : "scale",
+    "description" : "Zoom Amount",
+    "min" : 0.00,
+    "max" : 1.0,
+    "default" : 1.0,
+    "step" : 0.05,
+    "dependency" : "effect-selector=2"
+  },
+  "flip-fade" : {
+    "type" : "scale",
+    "description" : "Fade Transition",
+    "min" : 0.00,
+    "max" : 1.0,
+    "default" : 0.0,
+    "step" : 0.05,
+    "dependency" : "effect-selector=2"
+  },
+  "flip-dim-factor" : {
+    "type" : "scale",
+    "description" : "Background Dim Amount",
+    "min" : 0.0,
+    "max" : 1.0,
+    "default" : 0.2,
+    "step" : 0.05,
+    "dependency" : "effect-selector=2"
+  },
+  "flip-rotateEffect": {
+    "type": "combobox",
+    "description": "Transition Easing",
+    "default": "Expo",
+    "options": {
+      "Back": "Back",
+      "Bounce": "Bounce",
+      "Circ": "Circ",
+      "Cubic": "Cubic",
+      "Cubic-Back": "EndBack",
+      "Cubic-Bounce": "EndBounce",
+      "Cubic-Elastic": "EndElastic",
+      "Elastic": "Elastic",
+      "Expo": "Expo",
+      "Sine": "Sine",
+      "Quad": "Quad",
+      "Quart": "Quart",
+      "Quint": "Quint"
+    },
+    "dependency" : "effect-selector=2"
+  },
+
+  "pop-animationTime" : {
+    "type" : "scale",
+    "description" : "Animation duration",
+    "min" : 0,
+    "max" : 1500,
+    "default": 500,
+    "step" : 50,
+    "dependency" : "effect-selector=3"
+  },
+  "pop-pullaway" : {
+    "type" : "scale",
+    "description" : "Zoom Amount",
+    "min" : 0.00,
+    "max" : 1.0,
+    "default" : 1.0,
+    "step" : 0.05,
+    "dependency" : "effect-selector=3"
+  },
+  "pop-fade" : {
+    "type" : "scale",
+    "description" : "Fade Transition",
+    "min" : 0.00,
+    "max" : 1.0,
+    "default" : 0.0,
+    "step" : 0.05,
+    "dependency" : "effect-selector=3"
+  },
+  "pop-dim-factor" : {
+    "type" : "scale",
+    "description" : "Background Dim Amount",
+    "min" : 0.0,
+    "max" : 1.0,
+    "default" : 0.2,
+    "step" : 0.05,
+    "dependency" : "effect-selector=3"
+  },
+  "pop-rotateEffect": {
+    "type": "combobox",
+    "description": "Transition Easing",
+    "default": "Expo",
+    "options": {
+      "Back": "Back",
+      "Bounce": "Bounce",
+      "Circ": "Circ",
+      "Cubic": "Cubic",
+      "Cubic-Back": "EndBack",
+      "Cubic-Bounce": "EndBounce",
+      "Cubic-Elastic": "EndElastic",
+      "Elastic": "Elastic",
+      "Expo": "Expo",
+      "Sine": "Sine",
+      "Quad": "Quad",
+      "Quart": "Quart",
+      "Quint": "Quint"
+    },
+    "dependency" : "effect-selector=3"
+  },
+
+  "rolodex-animationTime" : {
+    "type" : "scale",
+    "description" : "Animation duration",
+    "min" : 0,
+    "max" : 1500,
+    "default": 500,
+    "step" : 50,
+    "dependency" : "effect-selector=4"
+  },
+  "rolodex-pullaway" : {
+    "type" : "scale",
+    "description" : "Zoom Amount",
+    "min" : 0.00,
+    "max" : 1.0,
+    "default" : 1.0,
+    "step" : 0.05,
+    "dependency" : "effect-selector=4"
+  },
+  "rolodex-fade" : {
+    "type" : "scale",
+    "description" : "Fade Transition",
+    "min" : 0.00,
+    "max" : 1.0,
+    "default" : 0.0,
+    "step" : 0.05,
+    "dependency" : "effect-selector=4"
+  },
+  "rolodex-dim-factor" : {
+    "type" : "scale",
+    "description" : "Background Dim Amount",
+    "min" : 0.0,
+    "max" : 1.0,
+    "default" : 0.2,
+    "step" : 0.05,
+    "dependency" : "effect-selector=4"
+  },
+  "rolodex-rotateEffect": {
+    "type": "combobox",
+    "description": "Transition Easing",
+    "default": "Expo",
+    "options": {
+      "Back": "Back",
+      "Bounce": "Bounce",
+      "Circ": "Circ",
+      "Cubic": "Cubic",
+      "Cubic-Back": "EndBack",
+      "Cubic-Bounce": "EndBounce",
+      "Cubic-Elastic": "EndElastic",
+      "Elastic": "Elastic",
+      "Expo": "Expo",
+      "Sine": "Sine",
+      "Quad": "Quad",
+      "Quart": "Quart",
+      "Quint": "Quint"
+    },
+    "dependency" : "effect-selector=4"
+  },
+
+  "slide-animationTime" : {
+    "type" : "scale",
+    "description" : "Animation duration",
+    "min" : 0,
+    "max" : 1500,
+    "default": 500,
+    "step" : 50,
+    "dependency" : "effect-selector=5"
+  },
+  "slide-pullaway" : {
+    "type" : "scale",
+    "description" : "Zoom Amount",
+    "min" : 0.00,
+    "max" : 1.0,
+    "default" : 1.0,
+    "step" : 0.05,
+    "dependency" : "effect-selector=5"
+  },
+  "slide-fade" : {
+    "type" : "scale",
+    "description" : "Fade Transition",
+    "min" : 0.00,
+    "max" : 1.0,
+    "default" : 0.0,
+    "step" : 0.05,
+    "dependency" : "effect-selector=5"
+  },
+  "slide-dim-factor" : {
+    "type" : "scale",
+    "description" : "Background Dim Amount",
+    "min" : 0.0,
+    "max" : 1.0,
+    "default" : 0.2,
+    "step" : 0.05,
+    "dependency" : "effect-selector=5"
+  },
+  "slide-rotateEffect": {
+    "type": "combobox",
+    "description": "Transition Easing",
+    "default": "Expo",
+    "options": {
+      "Back": "Back",
+      "Bounce": "Bounce",
+      "Circ": "Circ",
+      "Cubic": "Cubic",
+      "Cubic-Back": "EndBack",
+      "Cubic-Bounce": "EndBounce",
+      "Cubic-Elastic": "EndElastic",
+      "Elastic": "Elastic",
+      "Expo": "Expo",
+      "Sine": "Sine",
+      "Quad": "Quad",
+      "Quart": "Quart",
+      "Quint": "Quint"
+    },
+    "dependency" : "effect-selector=5"
+  },
+
+  "stack-animationTime" : {
+    "type" : "scale",
+    "description" : "Animation duration",
+    "min" : 0,
+    "max" : 1500,
+    "default": 500,
+    "step" : 50,
+    "dependency" : "effect-selector=6"
+  },
+  "stack-pullaway" : {
+    "type" : "scale",
+    "description" : "Zoom Amount",
+    "min" : 0.00,
+    "max" : 1.0,
+    "default" : 1.0,
+    "step" : 0.05,
+    "dependency" : "effect-selector=6"
+  },
+  "stack-fade" : {
+    "type" : "scale",
+    "description" : "Fade Transition",
+    "min" : 0.00,
+    "max" : 1.0,
+    "default" : 0.0,
+    "step" : 0.05,
+    "dependency" : "effect-selector=6"
+  },
+  "stack-dim-factor" : {
+    "type" : "scale",
+    "description" : "Background Dim Amount",
+    "min" : 0.0,
+    "max" : 1.0,
+    "default" : 0.2,
+    "step" : 0.05,
+    "dependency" : "effect-selector=6"
+  },
+  "stack-rotateEffect": {
+    "type": "combobox",
+    "description": "Transition Easing",
+    "default": "Expo",
+    "options": {
+      "Back": "Back",
+      "Bounce": "Bounce",
+      "Circ": "Circ",
+      "Cubic": "Cubic",
+      "Cubic-Back": "EndBack",
+      "Cubic-Bounce": "EndBounce",
+      "Cubic-Elastic": "EndElastic",
+      "Elastic": "Elastic",
+      "Expo": "Expo",
+      "Sine": "Sine",
+      "Quad": "Quad",
+      "Quart": "Quart",
+      "Quint": "Quint"
+    },
+    "dependency" : "effect-selector=6"
+  },
+
+  "transitionEffect": {
+    "type": "combobox",
+    "description": "Workspace Transition Effect",
+    "default": "Stack",
+    "options": {
+      "Cube": 0,
+      "Deck": 1,
+      "Flip": 2,
+      "Pop": 3,
+      "Rolodex": 4,
+      "Slide": 5,
+      "Stack" : 6,
+      "Randomized" : 7
     }
   },
-  "includeBackground" : {
-    "type" : "checkbox",
-    "description" : "Include Background",
-    "default" : true
+  "patchmoveToWorkspace": {
+    "type": "checkbox",
+    "description": "Use Flipper effect with the Workspace Switcher applet",
+    "tooltip": "Override the moveToWorkspace() API so that the Flipper effect is used by the Workspace Switcher Applet when changing the current workspace",
+    "default": true
+  },
+  "patchActivateWindow": {
+    "type": "checkbox",
+    "description": "Use Flipper effect when changing focus causes a workspace switch",
+    "tooltip": "Override the activateWindow() API so that when a window on another workspace is given the focus, the Flipper effect is used to change the current workspace",
+    "default": true
   },
   "includePanels" : {
     "type" : "checkbox",
     "description" : "Include Panels",
+     "tooltip": "Exclude the panels while animating. In most cases the panels are not properly painted or completely invisible anyhow, so it's best to leave this disabled",
     "default" : false
+  },
+
+  "effect-selector": {
+    "type": "combobox",
+    "default": 0,
+    "options": {
+      "Cube": 0,
+      "Deck": 1,
+      "Flip": 2,
+      "Pop": 3,
+      "Rolodex": 4,
+      "Slide": 5,
+      "Stack" : 6
+    },
+    "description": "Show settings for effect:"
   }
 }

--- a/Flipper@connerdev/files/Flipper@connerdev/metadata.json
+++ b/Flipper@connerdev/files/Flipper@connerdev/metadata.json
@@ -20,7 +20,7 @@
         "5.0",
         "5.4"
     ],
-    "version": "1.0.6",
+    "version": "2.0.0",
     "url": "https://github.com/ConnerHansen/Flipper",
     "uuid": "Flipper@connerdev",
     "name": "Flipper",

--- a/Flipper@connerdev/files/Flipper@connerdev/po/Flipper@connerdev.pot
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/Flipper@connerdev.pot
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Flipper@connerdev 1.0.6\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-28 23:14-0500\n"
+"POT-Creation-Date: 2024-12-21 11:12-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -26,150 +26,329 @@ msgid "Fancy workspace switching extension"
 msgstr ""
 
 #. 2.0->settings-schema.json->header1->description
-#. 5.4->settings-schema.json->header1->description
+#. 5.4->settings-schema.json->general-page->title
 msgid "General"
 msgstr ""
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
+#. 5.4->settings-schema.json->cube-animationTime->description
+#. 5.4->settings-schema.json->deck-animationTime->description
+#. 5.4->settings-schema.json->flip-animationTime->description
+#. 5.4->settings-schema.json->pop-animationTime->description
+#. 5.4->settings-schema.json->rolodex-animationTime->description
+#. 5.4->settings-schema.json->slide-animationTime->description
+#. 5.4->settings-schema.json->stack-animationTime->description
 msgid "Animation duration"
 msgstr ""
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
+#. 5.4->settings-schema.json->cube-pullaway->description
+#. 5.4->settings-schema.json->deck-pullaway->description
+#. 5.4->settings-schema.json->flip-pullaway->description
+#. 5.4->settings-schema.json->pop-pullaway->description
+#. 5.4->settings-schema.json->rolodex-pullaway->description
+#. 5.4->settings-schema.json->slide-pullaway->description
+#. 5.4->settings-schema.json->stack-pullaway->description
 msgid "Zoom Amount"
 msgstr ""
 
 #. 2.0->settings-schema.json->fade->description
-#. 5.4->settings-schema.json->fade->description
+#. 5.4->settings-schema.json->cube-fade->description
+#. 5.4->settings-schema.json->deck-fade->description
+#. 5.4->settings-schema.json->flip-fade->description
+#. 5.4->settings-schema.json->pop-fade->description
+#. 5.4->settings-schema.json->rolodex-fade->description
+#. 5.4->settings-schema.json->slide-fade->description
+#. 5.4->settings-schema.json->stack-fade->description
 msgid "Fade Transition"
 msgstr ""
 
 #. 2.0->settings-schema.json->dim_factor->description
-#. 5.4->settings-schema.json->dim_factor->description
+#. 5.4->settings-schema.json->cube-dim-factor->description
+#. 5.4->settings-schema.json->deck-dim-factor->description
+#. 5.4->settings-schema.json->flip-dim-factor->description
+#. 5.4->settings-schema.json->pop-dim-factor->description
+#. 5.4->settings-schema.json->rolodex-dim-factor->description
+#. 5.4->settings-schema.json->slide-dim-factor->description
+#. 5.4->settings-schema.json->stack-dim-factor->description
 msgid "Background Dim Amount"
 msgstr ""
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr ""
 
 #. 2.0->settings-schema.json->transitionEffect->description
-#. 5.4->settings-schema.json->transitionEffect->description
 msgid "Transition Effect"
 msgstr ""
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->cube-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Cube"
 msgstr ""
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->deck-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Deck"
 msgstr ""
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->flip-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Flip"
 msgstr ""
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->pop-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Pop"
 msgstr ""
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->rolodex-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Rolodex"
 msgstr ""
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->slide-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Slide"
 msgstr ""
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->stack-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Stack"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->description
-#. 5.4->settings-schema.json->rotateEffect->description
+#. 5.4->settings-schema.json->cube-rotateEffect->description
+#. 5.4->settings-schema.json->deck-rotateEffect->description
+#. 5.4->settings-schema.json->flip-rotateEffect->description
+#. 5.4->settings-schema.json->pop-rotateEffect->description
+#. 5.4->settings-schema.json->rolodex-rotateEffect->description
+#. 5.4->settings-schema.json->slide-rotateEffect->description
+#. 5.4->settings-schema.json->stack-rotateEffect->description
 msgid "Transition Easing"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Back"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Bounce"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Circ"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Back"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Bounce"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Elastic"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Elastic"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Expo"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Sine"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quad"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quart"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quint"
 msgstr ""
 
 #. 2.0->settings-schema.json->includeBackground->description
-#. 5.4->settings-schema.json->includeBackground->description
 msgid "Include Background"
+msgstr ""
+
+#. 5.4->settings-schema.json->effects-page->title
+msgid "Effect Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->general-settings->title
+msgid "Flipper General Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->random-settings->title
+msgid "Effects included in the randomized set"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector-section->title
+msgid "Effect Selector"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-settings->title
+msgid "Effect Specific Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->description
+msgid "Workspace Transition Effect"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Flipper effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Flipper effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Flipper effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Flipper effect is used to change the current "
+"workspace"
 msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Exclude the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector->description
+msgid "Show settings for effect:"
 msgstr ""

--- a/Flipper@connerdev/files/Flipper@connerdev/po/ca.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/ca.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-28 23:14-0500\n"
+"POT-Creation-Date: 2024-12-21 11:12-0500\n"
 "PO-Revision-Date: 2024-08-22 01:52+0200\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -28,150 +28,331 @@ msgid "Fancy workspace switching extension"
 msgstr "Extensió per canviar d'espai de treball"
 
 #. 2.0->settings-schema.json->header1->description
-#. 5.4->settings-schema.json->header1->description
+#. 5.4->settings-schema.json->general-page->title
 msgid "General"
 msgstr "General"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
+#. 5.4->settings-schema.json->cube-animationTime->description
+#. 5.4->settings-schema.json->deck-animationTime->description
+#. 5.4->settings-schema.json->flip-animationTime->description
+#. 5.4->settings-schema.json->pop-animationTime->description
+#. 5.4->settings-schema.json->rolodex-animationTime->description
+#. 5.4->settings-schema.json->slide-animationTime->description
+#. 5.4->settings-schema.json->stack-animationTime->description
 msgid "Animation duration"
 msgstr "Duració de l'animació"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
+#. 5.4->settings-schema.json->cube-pullaway->description
+#. 5.4->settings-schema.json->deck-pullaway->description
+#. 5.4->settings-schema.json->flip-pullaway->description
+#. 5.4->settings-schema.json->pop-pullaway->description
+#. 5.4->settings-schema.json->rolodex-pullaway->description
+#. 5.4->settings-schema.json->slide-pullaway->description
+#. 5.4->settings-schema.json->stack-pullaway->description
 msgid "Zoom Amount"
 msgstr "Quantitat de zoom"
 
 #. 2.0->settings-schema.json->fade->description
-#. 5.4->settings-schema.json->fade->description
+#. 5.4->settings-schema.json->cube-fade->description
+#. 5.4->settings-schema.json->deck-fade->description
+#. 5.4->settings-schema.json->flip-fade->description
+#. 5.4->settings-schema.json->pop-fade->description
+#. 5.4->settings-schema.json->rolodex-fade->description
+#. 5.4->settings-schema.json->slide-fade->description
+#. 5.4->settings-schema.json->stack-fade->description
 msgid "Fade Transition"
 msgstr "Transició de desaparició"
 
 #. 2.0->settings-schema.json->dim_factor->description
-#. 5.4->settings-schema.json->dim_factor->description
+#. 5.4->settings-schema.json->cube-dim-factor->description
+#. 5.4->settings-schema.json->deck-dim-factor->description
+#. 5.4->settings-schema.json->flip-dim-factor->description
+#. 5.4->settings-schema.json->pop-dim-factor->description
+#. 5.4->settings-schema.json->rolodex-dim-factor->description
+#. 5.4->settings-schema.json->slide-dim-factor->description
+#. 5.4->settings-schema.json->stack-dim-factor->description
 msgid "Background Dim Amount"
 msgstr "Quantitat de foscor del fons"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Efectes"
 
 #. 2.0->settings-schema.json->transitionEffect->description
-#. 5.4->settings-schema.json->transitionEffect->description
 msgid "Transition Effect"
 msgstr "Efecte de transició"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->cube-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Cube"
 msgstr "Cub"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->deck-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Deck"
 msgstr "Cartes"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->flip-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Flip"
 msgstr "Voltejar"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->pop-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Pop"
 msgstr "Pop"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->rolodex-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Rolodex"
 msgstr "Rolodex"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->slide-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Slide"
 msgstr "Relliscar"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->stack-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Stack"
 msgstr "Apilar"
 
 #. 2.0->settings-schema.json->rotateEffect->description
-#. 5.4->settings-schema.json->rotateEffect->description
+#. 5.4->settings-schema.json->cube-rotateEffect->description
+#. 5.4->settings-schema.json->deck-rotateEffect->description
+#. 5.4->settings-schema.json->flip-rotateEffect->description
+#. 5.4->settings-schema.json->pop-rotateEffect->description
+#. 5.4->settings-schema.json->rolodex-rotateEffect->description
+#. 5.4->settings-schema.json->slide-rotateEffect->description
+#. 5.4->settings-schema.json->stack-rotateEffect->description
 msgid "Transition Easing"
 msgstr "Mode de transició d'acceleració i des-acceleració"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Back"
 msgstr "Tornar"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Bounce"
 msgstr "Rebotar"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Circ"
 msgstr "Cercle"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic"
 msgstr "Cúbic"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Back"
 msgstr "Cúbic-Tornar"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Bounce"
 msgstr "Cúbic-Rebotar"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Elastic"
 msgstr "Cúbic-Elàstic"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Elastic"
 msgstr "Elàstic"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Expo"
 msgstr "Expo"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Sine"
 msgstr "Sinus"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quad"
 msgstr "Quadrat"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quart"
 msgstr "Quart"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quint"
 msgstr "Quint"
 
 #. 2.0->settings-schema.json->includeBackground->description
-#. 5.4->settings-schema.json->includeBackground->description
 msgid "Include Background"
 msgstr "Incloure el fons"
+
+#. 5.4->settings-schema.json->effects-page->title
+#, fuzzy
+msgid "Effect Settings"
+msgstr "Efectes"
+
+#. 5.4->settings-schema.json->general-settings->title
+msgid "Flipper General Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->random-settings->title
+msgid "Effects included in the randomized set"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector-section->title
+msgid "Effect Selector"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-settings->title
+msgid "Effect Specific Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->description
+#, fuzzy
+msgid "Workspace Transition Effect"
+msgstr "Efecte de transició"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Flipper effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Flipper effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Flipper effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Flipper effect is used to change the current "
+"workspace"
+msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
 msgstr "Incloure els taulers"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Exclude the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector->description
+msgid "Show settings for effect:"
+msgstr ""

--- a/Flipper@connerdev/files/Flipper@connerdev/po/da.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-28 23:14-0500\n"
+"POT-Creation-Date: 2024-12-21 11:12-0500\n"
 "PO-Revision-Date: 2017-06-10 17:39+0200\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -28,151 +28,332 @@ msgid "Fancy workspace switching extension"
 msgstr "Smart udvidelse til skift af arbejdsområde"
 
 #. 2.0->settings-schema.json->header1->description
-#. 5.4->settings-schema.json->header1->description
+#. 5.4->settings-schema.json->general-page->title
 msgid "General"
 msgstr "Generelt"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
+#. 5.4->settings-schema.json->cube-animationTime->description
+#. 5.4->settings-schema.json->deck-animationTime->description
+#. 5.4->settings-schema.json->flip-animationTime->description
+#. 5.4->settings-schema.json->pop-animationTime->description
+#. 5.4->settings-schema.json->rolodex-animationTime->description
+#. 5.4->settings-schema.json->slide-animationTime->description
+#. 5.4->settings-schema.json->stack-animationTime->description
 msgid "Animation duration"
 msgstr "Animationens varighed"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
+#. 5.4->settings-schema.json->cube-pullaway->description
+#. 5.4->settings-schema.json->deck-pullaway->description
+#. 5.4->settings-schema.json->flip-pullaway->description
+#. 5.4->settings-schema.json->pop-pullaway->description
+#. 5.4->settings-schema.json->rolodex-pullaway->description
+#. 5.4->settings-schema.json->slide-pullaway->description
+#. 5.4->settings-schema.json->stack-pullaway->description
 msgid "Zoom Amount"
 msgstr "Zoomniveau"
 
 #. 2.0->settings-schema.json->fade->description
-#. 5.4->settings-schema.json->fade->description
+#. 5.4->settings-schema.json->cube-fade->description
+#. 5.4->settings-schema.json->deck-fade->description
+#. 5.4->settings-schema.json->flip-fade->description
+#. 5.4->settings-schema.json->pop-fade->description
+#. 5.4->settings-schema.json->rolodex-fade->description
+#. 5.4->settings-schema.json->slide-fade->description
+#. 5.4->settings-schema.json->stack-fade->description
 msgid "Fade Transition"
 msgstr "Udtoning af overgang"
 
 #. 2.0->settings-schema.json->dim_factor->description
-#. 5.4->settings-schema.json->dim_factor->description
+#. 5.4->settings-schema.json->cube-dim-factor->description
+#. 5.4->settings-schema.json->deck-dim-factor->description
+#. 5.4->settings-schema.json->flip-dim-factor->description
+#. 5.4->settings-schema.json->pop-dim-factor->description
+#. 5.4->settings-schema.json->rolodex-dim-factor->description
+#. 5.4->settings-schema.json->slide-dim-factor->description
+#. 5.4->settings-schema.json->stack-dim-factor->description
 msgid "Background Dim Amount"
 msgstr "Dæmpning af baggrund"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Effekter"
 
 #. 2.0->settings-schema.json->transitionEffect->description
-#. 5.4->settings-schema.json->transitionEffect->description
 msgid "Transition Effect"
 msgstr "Overgangseffekt"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->cube-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Cube"
 msgstr "Terning"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->deck-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Deck"
 msgstr "Kortbunke"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->flip-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Flip"
 msgstr "Vendning"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->pop-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Pop"
 msgstr "Pop"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->rolodex-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Rolodex"
 msgstr "Rolodex"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->slide-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Slide"
 msgstr "Glidende"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->stack-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Stack"
 msgstr "Stabel"
 
 #. 2.0->settings-schema.json->rotateEffect->description
-#. 5.4->settings-schema.json->rotateEffect->description
+#. 5.4->settings-schema.json->cube-rotateEffect->description
+#. 5.4->settings-schema.json->deck-rotateEffect->description
+#. 5.4->settings-schema.json->flip-rotateEffect->description
+#. 5.4->settings-schema.json->pop-rotateEffect->description
+#. 5.4->settings-schema.json->rolodex-rotateEffect->description
+#. 5.4->settings-schema.json->slide-rotateEffect->description
+#. 5.4->settings-schema.json->stack-rotateEffect->description
 msgid "Transition Easing"
 msgstr "Modificering af overgang"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Back"
 msgstr "Tilbage"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Bounce"
 msgstr "Hoppe"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Circ"
 msgstr "Cirkulær"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic"
 msgstr "Kubisk"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Back"
 msgstr "Kubisk-tilbage"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Bounce"
 msgstr "Kubisk-hoppe"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Elastic"
 msgstr "Kubisk-elastisk"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Elastic"
 msgstr "Elastisk"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Expo"
 msgstr "Expo"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Sine"
 msgstr "Sinus"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quad"
 msgstr "Kvadratisk"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quart"
 msgstr "Fjerde"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quint"
 msgstr "Femte"
 
 #. 2.0->settings-schema.json->includeBackground->description
-#. 5.4->settings-schema.json->includeBackground->description
 msgid "Include Background"
 msgstr "Inkludér baggrund"
+
+#. 5.4->settings-schema.json->effects-page->title
+#, fuzzy
+msgid "Effect Settings"
+msgstr "Effekter"
+
+#. 5.4->settings-schema.json->general-settings->title
+msgid "Flipper General Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->random-settings->title
+msgid "Effects included in the randomized set"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector-section->title
+msgid "Effect Selector"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-settings->title
+msgid "Effect Specific Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->description
+#, fuzzy
+msgid "Workspace Transition Effect"
+msgstr "Overgangseffekt"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Flipper effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Flipper effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Flipper effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Flipper effect is used to change the current "
+"workspace"
+msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 #, fuzzy
 msgid "Include Panels"
 msgstr "Inkludér baggrund"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Exclude the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector->description
+msgid "Show settings for effect:"
+msgstr ""

--- a/Flipper@connerdev/files/Flipper@connerdev/po/de.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-28 23:14-0500\n"
+"POT-Creation-Date: 2024-12-21 11:12-0500\n"
 "PO-Revision-Date: 2021-03-02 21:09+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -28,151 +28,332 @@ msgid "Fancy workspace switching extension"
 msgstr "Erweiterung für ausgefallene Arbeitsflächenwechsel"
 
 #. 2.0->settings-schema.json->header1->description
-#. 5.4->settings-schema.json->header1->description
+#. 5.4->settings-schema.json->general-page->title
 msgid "General"
 msgstr "Allgemein"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
+#. 5.4->settings-schema.json->cube-animationTime->description
+#. 5.4->settings-schema.json->deck-animationTime->description
+#. 5.4->settings-schema.json->flip-animationTime->description
+#. 5.4->settings-schema.json->pop-animationTime->description
+#. 5.4->settings-schema.json->rolodex-animationTime->description
+#. 5.4->settings-schema.json->slide-animationTime->description
+#. 5.4->settings-schema.json->stack-animationTime->description
 msgid "Animation duration"
 msgstr "Animationsdauer"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
+#. 5.4->settings-schema.json->cube-pullaway->description
+#. 5.4->settings-schema.json->deck-pullaway->description
+#. 5.4->settings-schema.json->flip-pullaway->description
+#. 5.4->settings-schema.json->pop-pullaway->description
+#. 5.4->settings-schema.json->rolodex-pullaway->description
+#. 5.4->settings-schema.json->slide-pullaway->description
+#. 5.4->settings-schema.json->stack-pullaway->description
 msgid "Zoom Amount"
 msgstr "Zoomstufe"
 
 #. 2.0->settings-schema.json->fade->description
-#. 5.4->settings-schema.json->fade->description
+#. 5.4->settings-schema.json->cube-fade->description
+#. 5.4->settings-schema.json->deck-fade->description
+#. 5.4->settings-schema.json->flip-fade->description
+#. 5.4->settings-schema.json->pop-fade->description
+#. 5.4->settings-schema.json->rolodex-fade->description
+#. 5.4->settings-schema.json->slide-fade->description
+#. 5.4->settings-schema.json->stack-fade->description
 msgid "Fade Transition"
 msgstr "Verblassen beim Übergang"
 
 #. 2.0->settings-schema.json->dim_factor->description
-#. 5.4->settings-schema.json->dim_factor->description
+#. 5.4->settings-schema.json->cube-dim-factor->description
+#. 5.4->settings-schema.json->deck-dim-factor->description
+#. 5.4->settings-schema.json->flip-dim-factor->description
+#. 5.4->settings-schema.json->pop-dim-factor->description
+#. 5.4->settings-schema.json->rolodex-dim-factor->description
+#. 5.4->settings-schema.json->slide-dim-factor->description
+#. 5.4->settings-schema.json->stack-dim-factor->description
 msgid "Background Dim Amount"
 msgstr "Dimmstufe des Hintergrunds"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Effekte"
 
 #. 2.0->settings-schema.json->transitionEffect->description
-#. 5.4->settings-schema.json->transitionEffect->description
 msgid "Transition Effect"
 msgstr "Übergangseffekt"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->cube-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Cube"
 msgstr "Würfel"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->deck-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Deck"
 msgstr "Umblättern"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->flip-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Flip"
 msgstr "Umdrehen"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->pop-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Pop"
 msgstr "Pop"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->rolodex-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Rolodex"
 msgstr "Rolodex"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->slide-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Slide"
 msgstr "Gleiten"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->stack-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Stack"
 msgstr "Stapeln"
 
 #. 2.0->settings-schema.json->rotateEffect->description
-#. 5.4->settings-schema.json->rotateEffect->description
+#. 5.4->settings-schema.json->cube-rotateEffect->description
+#. 5.4->settings-schema.json->deck-rotateEffect->description
+#. 5.4->settings-schema.json->flip-rotateEffect->description
+#. 5.4->settings-schema.json->pop-rotateEffect->description
+#. 5.4->settings-schema.json->rolodex-rotateEffect->description
+#. 5.4->settings-schema.json->slide-rotateEffect->description
+#. 5.4->settings-schema.json->stack-rotateEffect->description
 msgid "Transition Easing"
 msgstr "Leichtigkeit des Übergangs"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Back"
 msgstr "Zurück"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Bounce"
 msgstr "Hüpfen"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Circ"
 msgstr "Kreisen"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic"
 msgstr "Kubisch"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Back"
 msgstr "Kubisch-Zurück"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Bounce"
 msgstr "Kubisch-Hüpfen"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Elastic"
 msgstr "Kubisch-Elastisch"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Elastic"
 msgstr "Elastisch"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Expo"
 msgstr "Expo"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Sine"
 msgstr "Sinus"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quad"
 msgstr "Quadratisch"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quart"
 msgstr "Quartisch"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quint"
 msgstr "Quintisch"
 
 #. 2.0->settings-schema.json->includeBackground->description
-#. 5.4->settings-schema.json->includeBackground->description
 msgid "Include Background"
 msgstr "Hintergrund mit einbeziehen"
+
+#. 5.4->settings-schema.json->effects-page->title
+#, fuzzy
+msgid "Effect Settings"
+msgstr "Effekte"
+
+#. 5.4->settings-schema.json->general-settings->title
+msgid "Flipper General Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->random-settings->title
+msgid "Effects included in the randomized set"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector-section->title
+msgid "Effect Selector"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-settings->title
+msgid "Effect Specific Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->description
+#, fuzzy
+msgid "Workspace Transition Effect"
+msgstr "Übergangseffekt"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Flipper effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Flipper effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Flipper effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Flipper effect is used to change the current "
+"workspace"
+msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 #, fuzzy
 msgid "Include Panels"
 msgstr "Hintergrund mit einbeziehen"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Exclude the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector->description
+msgid "Show settings for effect:"
+msgstr ""

--- a/Flipper@connerdev/files/Flipper@connerdev/po/es.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-28 23:14-0500\n"
+"POT-Creation-Date: 2024-12-21 11:12-0500\n"
 "PO-Revision-Date: 2024-08-21 14:49-0400\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -27,150 +27,331 @@ msgid "Fancy workspace switching extension"
 msgstr "Extensión para cambiar de espacio de trabajo"
 
 #. 2.0->settings-schema.json->header1->description
-#. 5.4->settings-schema.json->header1->description
+#. 5.4->settings-schema.json->general-page->title
 msgid "General"
 msgstr "General"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
+#. 5.4->settings-schema.json->cube-animationTime->description
+#. 5.4->settings-schema.json->deck-animationTime->description
+#. 5.4->settings-schema.json->flip-animationTime->description
+#. 5.4->settings-schema.json->pop-animationTime->description
+#. 5.4->settings-schema.json->rolodex-animationTime->description
+#. 5.4->settings-schema.json->slide-animationTime->description
+#. 5.4->settings-schema.json->stack-animationTime->description
 msgid "Animation duration"
 msgstr "Duración de la animación"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
+#. 5.4->settings-schema.json->cube-pullaway->description
+#. 5.4->settings-schema.json->deck-pullaway->description
+#. 5.4->settings-schema.json->flip-pullaway->description
+#. 5.4->settings-schema.json->pop-pullaway->description
+#. 5.4->settings-schema.json->rolodex-pullaway->description
+#. 5.4->settings-schema.json->slide-pullaway->description
+#. 5.4->settings-schema.json->stack-pullaway->description
 msgid "Zoom Amount"
 msgstr "Cantidad de zoom"
 
 #. 2.0->settings-schema.json->fade->description
-#. 5.4->settings-schema.json->fade->description
+#. 5.4->settings-schema.json->cube-fade->description
+#. 5.4->settings-schema.json->deck-fade->description
+#. 5.4->settings-schema.json->flip-fade->description
+#. 5.4->settings-schema.json->pop-fade->description
+#. 5.4->settings-schema.json->rolodex-fade->description
+#. 5.4->settings-schema.json->slide-fade->description
+#. 5.4->settings-schema.json->stack-fade->description
 msgid "Fade Transition"
 msgstr "Transición de desvanecimiento"
 
 #. 2.0->settings-schema.json->dim_factor->description
-#. 5.4->settings-schema.json->dim_factor->description
+#. 5.4->settings-schema.json->cube-dim-factor->description
+#. 5.4->settings-schema.json->deck-dim-factor->description
+#. 5.4->settings-schema.json->flip-dim-factor->description
+#. 5.4->settings-schema.json->pop-dim-factor->description
+#. 5.4->settings-schema.json->rolodex-dim-factor->description
+#. 5.4->settings-schema.json->slide-dim-factor->description
+#. 5.4->settings-schema.json->stack-dim-factor->description
 msgid "Background Dim Amount"
 msgstr "Cantidad de oscurecimiento del fondo"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Efectos"
 
 #. 2.0->settings-schema.json->transitionEffect->description
-#. 5.4->settings-schema.json->transitionEffect->description
 msgid "Transition Effect"
 msgstr "Efecto de transición"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->cube-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Cube"
 msgstr "Cubo"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->deck-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Deck"
 msgstr "Cartas"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->flip-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Flip"
 msgstr "Voltear"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->pop-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Pop"
 msgstr "Pop"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->rolodex-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Rolodex"
 msgstr "Rolodex"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->slide-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Slide"
 msgstr "Deslizar"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->stack-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Stack"
 msgstr "Apilar"
 
 #. 2.0->settings-schema.json->rotateEffect->description
-#. 5.4->settings-schema.json->rotateEffect->description
+#. 5.4->settings-schema.json->cube-rotateEffect->description
+#. 5.4->settings-schema.json->deck-rotateEffect->description
+#. 5.4->settings-schema.json->flip-rotateEffect->description
+#. 5.4->settings-schema.json->pop-rotateEffect->description
+#. 5.4->settings-schema.json->rolodex-rotateEffect->description
+#. 5.4->settings-schema.json->slide-rotateEffect->description
+#. 5.4->settings-schema.json->stack-rotateEffect->description
 msgid "Transition Easing"
 msgstr "Modo de transición de aceleración y desaceleración"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Back"
 msgstr "Volver"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Bounce"
 msgstr "Rebotar"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Circ"
 msgstr "Círculo"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic"
 msgstr "Cúbico"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Back"
 msgstr "Cúbico-Volver"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Bounce"
 msgstr "Cúbico-Rebotar"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Elastic"
 msgstr "Cúbico-Elástico"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Elastic"
 msgstr "Elástico"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Expo"
 msgstr "Expo"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Sine"
 msgstr "Seno"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quad"
 msgstr "Cuadrado"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quart"
 msgstr "Quart"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quint"
 msgstr "Quint"
 
 #. 2.0->settings-schema.json->includeBackground->description
-#. 5.4->settings-schema.json->includeBackground->description
 msgid "Include Background"
 msgstr "Incluir fondo"
+
+#. 5.4->settings-schema.json->effects-page->title
+#, fuzzy
+msgid "Effect Settings"
+msgstr "Efectos"
+
+#. 5.4->settings-schema.json->general-settings->title
+msgid "Flipper General Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->random-settings->title
+msgid "Effects included in the randomized set"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector-section->title
+msgid "Effect Selector"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-settings->title
+msgid "Effect Specific Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->description
+#, fuzzy
+msgid "Workspace Transition Effect"
+msgstr "Efecto de transición"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Flipper effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Flipper effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Flipper effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Flipper effect is used to change the current "
+"workspace"
+msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
 msgstr "Incluir paneles"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Exclude the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector->description
+msgid "Show settings for effect:"
+msgstr ""

--- a/Flipper@connerdev/files/Flipper@connerdev/po/eu.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/eu.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-28 23:14-0500\n"
+"POT-Creation-Date: 2024-12-21 11:12-0500\n"
 "PO-Revision-Date: 2024-05-30 9:50+1\n"
 "Last-Translator: Muxutruk <muxutruk2@users.noreply.github.com>\n"
 "Language-Team: Basque <muxutruk2@users.noreply.github.com>\n"
@@ -27,151 +27,332 @@ msgid "Fancy workspace switching extension"
 msgstr "Lan areen tartean aldatzeko luxuzko hedapena"
 
 #. 2.0->settings-schema.json->header1->description
-#. 5.4->settings-schema.json->header1->description
+#. 5.4->settings-schema.json->general-page->title
 msgid "General"
 msgstr "Orokorra"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
+#. 5.4->settings-schema.json->cube-animationTime->description
+#. 5.4->settings-schema.json->deck-animationTime->description
+#. 5.4->settings-schema.json->flip-animationTime->description
+#. 5.4->settings-schema.json->pop-animationTime->description
+#. 5.4->settings-schema.json->rolodex-animationTime->description
+#. 5.4->settings-schema.json->slide-animationTime->description
+#. 5.4->settings-schema.json->stack-animationTime->description
 msgid "Animation duration"
 msgstr "Animazioaren iraupena"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
+#. 5.4->settings-schema.json->cube-pullaway->description
+#. 5.4->settings-schema.json->deck-pullaway->description
+#. 5.4->settings-schema.json->flip-pullaway->description
+#. 5.4->settings-schema.json->pop-pullaway->description
+#. 5.4->settings-schema.json->rolodex-pullaway->description
+#. 5.4->settings-schema.json->slide-pullaway->description
+#. 5.4->settings-schema.json->stack-pullaway->description
 msgid "Zoom Amount"
 msgstr "Zoom Kantitatea"
 
 #. 2.0->settings-schema.json->fade->description
-#. 5.4->settings-schema.json->fade->description
+#. 5.4->settings-schema.json->cube-fade->description
+#. 5.4->settings-schema.json->deck-fade->description
+#. 5.4->settings-schema.json->flip-fade->description
+#. 5.4->settings-schema.json->pop-fade->description
+#. 5.4->settings-schema.json->rolodex-fade->description
+#. 5.4->settings-schema.json->slide-fade->description
+#. 5.4->settings-schema.json->stack-fade->description
 msgid "Fade Transition"
 msgstr "Desagertze Trantsizioa"
 
 #. 2.0->settings-schema.json->dim_factor->description
-#. 5.4->settings-schema.json->dim_factor->description
+#. 5.4->settings-schema.json->cube-dim-factor->description
+#. 5.4->settings-schema.json->deck-dim-factor->description
+#. 5.4->settings-schema.json->flip-dim-factor->description
+#. 5.4->settings-schema.json->pop-dim-factor->description
+#. 5.4->settings-schema.json->rolodex-dim-factor->description
+#. 5.4->settings-schema.json->slide-dim-factor->description
+#. 5.4->settings-schema.json->stack-dim-factor->description
 msgid "Background Dim Amount"
 msgstr "Atzekaldearen Ahultze Kantitatea"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Efektuak"
 
 #. 2.0->settings-schema.json->transitionEffect->description
-#. 5.4->settings-schema.json->transitionEffect->description
 msgid "Transition Effect"
 msgstr "Trantsizio-efektua"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->cube-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Cube"
 msgstr "Kuboa"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->deck-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Deck"
 msgstr "Kartak"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->flip-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Flip"
 msgstr "Irauli"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->pop-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Pop"
 msgstr "Lehertzea"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->rolodex-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Rolodex"
 msgstr "Rolodex"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->slide-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Slide"
 msgstr "Diapositiba"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->stack-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Stack"
 msgstr "Pilaketa"
 
 #. 2.0->settings-schema.json->rotateEffect->description
-#. 5.4->settings-schema.json->rotateEffect->description
+#. 5.4->settings-schema.json->cube-rotateEffect->description
+#. 5.4->settings-schema.json->deck-rotateEffect->description
+#. 5.4->settings-schema.json->flip-rotateEffect->description
+#. 5.4->settings-schema.json->pop-rotateEffect->description
+#. 5.4->settings-schema.json->rolodex-rotateEffect->description
+#. 5.4->settings-schema.json->slide-rotateEffect->description
+#. 5.4->settings-schema.json->stack-rotateEffect->description
 msgid "Transition Easing"
 msgstr "Trantsizioaren Lasaitzea"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Back"
 msgstr "Itzuli"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Bounce"
 msgstr "Errebotea"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Circ"
 msgstr "Circ"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic"
 msgstr "Kubikoa"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Back"
 msgstr "Kubikoa atzerantz."
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Bounce"
 msgstr "Errebote kubikoa"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Elastic"
 msgstr "Kubiko elsatikoa"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Elastic"
 msgstr "Elastikoa"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Expo"
 msgstr "Exponentziala"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Sine"
 msgstr "Sinu"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quad"
 msgstr "Koadratikoa"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quart"
 msgstr "Koatrikoa"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quint"
 msgstr "Kintikoa"
 
 #. 2.0->settings-schema.json->includeBackground->description
-#. 5.4->settings-schema.json->includeBackground->description
 msgid "Include Background"
 msgstr "Atzekaldea Erantzi"
+
+#. 5.4->settings-schema.json->effects-page->title
+#, fuzzy
+msgid "Effect Settings"
+msgstr "Efektuak"
+
+#. 5.4->settings-schema.json->general-settings->title
+msgid "Flipper General Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->random-settings->title
+msgid "Effects included in the randomized set"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector-section->title
+msgid "Effect Selector"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-settings->title
+msgid "Effect Specific Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->description
+#, fuzzy
+msgid "Workspace Transition Effect"
+msgstr "Trantsizio-efektua"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Flipper effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Flipper effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Flipper effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Flipper effect is used to change the current "
+"workspace"
+msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 #, fuzzy
 msgid "Include Panels"
 msgstr "Atzekaldea Erantzi"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Exclude the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector->description
+msgid "Show settings for effect:"
+msgstr ""

--- a/Flipper@connerdev/files/Flipper@connerdev/po/fi.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/fi.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Flipper@connerdev 1.0.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-28 23:14-0500\n"
+"POT-Creation-Date: 2024-12-21 11:12-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -28,150 +28,331 @@ msgstr ""
 "Animaatiot työtilojen vaihdon yhteydessä käyttäen ⬅ ➡ ctrl+alt näppäimiä"
 
 #. 2.0->settings-schema.json->header1->description
-#. 5.4->settings-schema.json->header1->description
+#. 5.4->settings-schema.json->general-page->title
 msgid "General"
 msgstr "Yleinen"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
+#. 5.4->settings-schema.json->cube-animationTime->description
+#. 5.4->settings-schema.json->deck-animationTime->description
+#. 5.4->settings-schema.json->flip-animationTime->description
+#. 5.4->settings-schema.json->pop-animationTime->description
+#. 5.4->settings-schema.json->rolodex-animationTime->description
+#. 5.4->settings-schema.json->slide-animationTime->description
+#. 5.4->settings-schema.json->stack-animationTime->description
 msgid "Animation duration"
 msgstr "Animaation kesto"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
+#. 5.4->settings-schema.json->cube-pullaway->description
+#. 5.4->settings-schema.json->deck-pullaway->description
+#. 5.4->settings-schema.json->flip-pullaway->description
+#. 5.4->settings-schema.json->pop-pullaway->description
+#. 5.4->settings-schema.json->rolodex-pullaway->description
+#. 5.4->settings-schema.json->slide-pullaway->description
+#. 5.4->settings-schema.json->stack-pullaway->description
 msgid "Zoom Amount"
 msgstr "Mittakaava"
 
 #. 2.0->settings-schema.json->fade->description
-#. 5.4->settings-schema.json->fade->description
+#. 5.4->settings-schema.json->cube-fade->description
+#. 5.4->settings-schema.json->deck-fade->description
+#. 5.4->settings-schema.json->flip-fade->description
+#. 5.4->settings-schema.json->pop-fade->description
+#. 5.4->settings-schema.json->rolodex-fade->description
+#. 5.4->settings-schema.json->slide-fade->description
+#. 5.4->settings-schema.json->stack-fade->description
 msgid "Fade Transition"
 msgstr "Siirtymän häivytys"
 
 #. 2.0->settings-schema.json->dim_factor->description
-#. 5.4->settings-schema.json->dim_factor->description
+#. 5.4->settings-schema.json->cube-dim-factor->description
+#. 5.4->settings-schema.json->deck-dim-factor->description
+#. 5.4->settings-schema.json->flip-dim-factor->description
+#. 5.4->settings-schema.json->pop-dim-factor->description
+#. 5.4->settings-schema.json->rolodex-dim-factor->description
+#. 5.4->settings-schema.json->slide-dim-factor->description
+#. 5.4->settings-schema.json->stack-dim-factor->description
 msgid "Background Dim Amount"
 msgstr "Taustan himmennys"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Tehosteet"
 
 #. 2.0->settings-schema.json->transitionEffect->description
-#. 5.4->settings-schema.json->transitionEffect->description
 msgid "Transition Effect"
 msgstr "Siirtymän tehoste"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->cube-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Cube"
 msgstr "Kuutio"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->deck-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Deck"
 msgstr "Kansi"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->flip-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Flip"
 msgstr "Käännä"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->pop-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Pop"
 msgstr "Ponnahdus"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->rolodex-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Rolodex"
 msgstr "Kohti"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->slide-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Slide"
 msgstr "Liuku"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->stack-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Stack"
 msgstr "Ladonta"
 
 #. 2.0->settings-schema.json->rotateEffect->description
-#. 5.4->settings-schema.json->rotateEffect->description
+#. 5.4->settings-schema.json->cube-rotateEffect->description
+#. 5.4->settings-schema.json->deck-rotateEffect->description
+#. 5.4->settings-schema.json->flip-rotateEffect->description
+#. 5.4->settings-schema.json->pop-rotateEffect->description
+#. 5.4->settings-schema.json->rolodex-rotateEffect->description
+#. 5.4->settings-schema.json->slide-rotateEffect->description
+#. 5.4->settings-schema.json->stack-rotateEffect->description
 msgid "Transition Easing"
 msgstr "Lisäominaisuus"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Back"
 msgstr "Takaisku"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Bounce"
 msgstr "Pomppu"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Circ"
 msgstr "Piiri"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic"
 msgstr "Kuutio"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Back"
 msgstr "Kuutio-Takaisku"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Bounce"
 msgstr "Kuutio-Pomppu"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Elastic"
 msgstr "Kuutio-Jousto"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Elastic"
 msgstr "Jousto"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Expo"
 msgstr "Alue"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Sine"
 msgstr "Kaari"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quad"
 msgstr "Neliö"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quart"
 msgstr "Kvartti"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quint"
 msgstr "Viisikko"
 
 #. 2.0->settings-schema.json->includeBackground->description
-#. 5.4->settings-schema.json->includeBackground->description
 msgid "Include Background"
 msgstr "Sisältää taustakuvan"
+
+#. 5.4->settings-schema.json->effects-page->title
+#, fuzzy
+msgid "Effect Settings"
+msgstr "Tehosteet"
+
+#. 5.4->settings-schema.json->general-settings->title
+msgid "Flipper General Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->random-settings->title
+msgid "Effects included in the randomized set"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector-section->title
+msgid "Effect Selector"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-settings->title
+msgid "Effect Specific Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->description
+#, fuzzy
+msgid "Workspace Transition Effect"
+msgstr "Siirtymän tehoste"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Flipper effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Flipper effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Flipper effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Flipper effect is used to change the current "
+"workspace"
+msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
 msgstr "Sisältää paneelit"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Exclude the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector->description
+msgid "Show settings for effect:"
+msgstr ""

--- a/Flipper@connerdev/files/Flipper@connerdev/po/hu.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-28 23:14-0500\n"
+"POT-Creation-Date: 2024-12-21 11:12-0500\n"
 "PO-Revision-Date: 2024-10-02 10:07+0200\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
@@ -27,150 +27,331 @@ msgid "Fancy workspace switching extension"
 msgstr "Egy különleges munkaterület váltó bővítmény"
 
 #. 2.0->settings-schema.json->header1->description
-#. 5.4->settings-schema.json->header1->description
+#. 5.4->settings-schema.json->general-page->title
 msgid "General"
 msgstr "Általános"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
+#. 5.4->settings-schema.json->cube-animationTime->description
+#. 5.4->settings-schema.json->deck-animationTime->description
+#. 5.4->settings-schema.json->flip-animationTime->description
+#. 5.4->settings-schema.json->pop-animationTime->description
+#. 5.4->settings-schema.json->rolodex-animationTime->description
+#. 5.4->settings-schema.json->slide-animationTime->description
+#. 5.4->settings-schema.json->stack-animationTime->description
 msgid "Animation duration"
 msgstr "Animáció időtartama"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
+#. 5.4->settings-schema.json->cube-pullaway->description
+#. 5.4->settings-schema.json->deck-pullaway->description
+#. 5.4->settings-schema.json->flip-pullaway->description
+#. 5.4->settings-schema.json->pop-pullaway->description
+#. 5.4->settings-schema.json->rolodex-pullaway->description
+#. 5.4->settings-schema.json->slide-pullaway->description
+#. 5.4->settings-schema.json->stack-pullaway->description
 msgid "Zoom Amount"
 msgstr "Nagyítás mértéke"
 
 #. 2.0->settings-schema.json->fade->description
-#. 5.4->settings-schema.json->fade->description
+#. 5.4->settings-schema.json->cube-fade->description
+#. 5.4->settings-schema.json->deck-fade->description
+#. 5.4->settings-schema.json->flip-fade->description
+#. 5.4->settings-schema.json->pop-fade->description
+#. 5.4->settings-schema.json->rolodex-fade->description
+#. 5.4->settings-schema.json->slide-fade->description
+#. 5.4->settings-schema.json->stack-fade->description
 msgid "Fade Transition"
 msgstr "Átmenet elmosódása"
 
 #. 2.0->settings-schema.json->dim_factor->description
-#. 5.4->settings-schema.json->dim_factor->description
+#. 5.4->settings-schema.json->cube-dim-factor->description
+#. 5.4->settings-schema.json->deck-dim-factor->description
+#. 5.4->settings-schema.json->flip-dim-factor->description
+#. 5.4->settings-schema.json->pop-dim-factor->description
+#. 5.4->settings-schema.json->rolodex-dim-factor->description
+#. 5.4->settings-schema.json->slide-dim-factor->description
+#. 5.4->settings-schema.json->stack-dim-factor->description
 msgid "Background Dim Amount"
 msgstr "Háttér homályosításának mértéke"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Effektusok"
 
 #. 2.0->settings-schema.json->transitionEffect->description
-#. 5.4->settings-schema.json->transitionEffect->description
 msgid "Transition Effect"
 msgstr "Átmeneti effektus"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->cube-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Cube"
 msgstr "Kocka"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->deck-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Deck"
 msgstr "Pakli"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->flip-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Flip"
 msgstr "Fordítás"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->pop-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Pop"
 msgstr "Felugró"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->rolodex-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Rolodex"
 msgstr "Rolodex"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->slide-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Slide"
 msgstr "Dia"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->stack-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Stack"
 msgstr "Tömb"
 
 #. 2.0->settings-schema.json->rotateEffect->description
-#. 5.4->settings-schema.json->rotateEffect->description
+#. 5.4->settings-schema.json->cube-rotateEffect->description
+#. 5.4->settings-schema.json->deck-rotateEffect->description
+#. 5.4->settings-schema.json->flip-rotateEffect->description
+#. 5.4->settings-schema.json->pop-rotateEffect->description
+#. 5.4->settings-schema.json->rolodex-rotateEffect->description
+#. 5.4->settings-schema.json->slide-rotateEffect->description
+#. 5.4->settings-schema.json->stack-rotateEffect->description
 msgid "Transition Easing"
 msgstr "Átmenet finomítása"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Back"
 msgstr "Vissza"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Bounce"
 msgstr "Visszaugró"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Circ"
 msgstr "Cric"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic"
 msgstr "Kocka"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Back"
 msgstr "Kocka - vissza"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Bounce"
 msgstr "Kocka - visszaugró"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Elastic"
 msgstr "Kocka - ruganyos"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Elastic"
 msgstr "Ruganyos"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Expo"
 msgstr "Expo"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Sine"
 msgstr "Szinusz"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quad"
 msgstr "Quad"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quart"
 msgstr "Quart"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quint"
 msgstr "Quint"
 
 #. 2.0->settings-schema.json->includeBackground->description
-#. 5.4->settings-schema.json->includeBackground->description
 msgid "Include Background"
 msgstr "Háttérrel együtt"
+
+#. 5.4->settings-schema.json->effects-page->title
+#, fuzzy
+msgid "Effect Settings"
+msgstr "Effektusok"
+
+#. 5.4->settings-schema.json->general-settings->title
+msgid "Flipper General Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->random-settings->title
+msgid "Effects included in the randomized set"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector-section->title
+msgid "Effect Selector"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-settings->title
+msgid "Effect Specific Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->description
+#, fuzzy
+msgid "Workspace Transition Effect"
+msgstr "Átmeneti effektus"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Flipper effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Flipper effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Flipper effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Flipper effect is used to change the current "
+"workspace"
+msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
 msgstr "Panelekkel együtt"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Exclude the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector->description
+msgid "Show settings for effect:"
+msgstr ""

--- a/Flipper@connerdev/files/Flipper@connerdev/po/it.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-28 23:14-0500\n"
+"POT-Creation-Date: 2024-12-21 11:12-0500\n"
 "PO-Revision-Date: 2022-06-03 11:05+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -28,151 +28,332 @@ msgid "Fancy workspace switching extension"
 msgstr "Estensione di commutazione di area di lavoro elaborata"
 
 #. 2.0->settings-schema.json->header1->description
-#. 5.4->settings-schema.json->header1->description
+#. 5.4->settings-schema.json->general-page->title
 msgid "General"
 msgstr "Generale"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
+#. 5.4->settings-schema.json->cube-animationTime->description
+#. 5.4->settings-schema.json->deck-animationTime->description
+#. 5.4->settings-schema.json->flip-animationTime->description
+#. 5.4->settings-schema.json->pop-animationTime->description
+#. 5.4->settings-schema.json->rolodex-animationTime->description
+#. 5.4->settings-schema.json->slide-animationTime->description
+#. 5.4->settings-schema.json->stack-animationTime->description
 msgid "Animation duration"
 msgstr "Durata animazione"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
+#. 5.4->settings-schema.json->cube-pullaway->description
+#. 5.4->settings-schema.json->deck-pullaway->description
+#. 5.4->settings-schema.json->flip-pullaway->description
+#. 5.4->settings-schema.json->pop-pullaway->description
+#. 5.4->settings-schema.json->rolodex-pullaway->description
+#. 5.4->settings-schema.json->slide-pullaway->description
+#. 5.4->settings-schema.json->stack-pullaway->description
 msgid "Zoom Amount"
 msgstr "Quantità di Zoom"
 
 #. 2.0->settings-schema.json->fade->description
-#. 5.4->settings-schema.json->fade->description
+#. 5.4->settings-schema.json->cube-fade->description
+#. 5.4->settings-schema.json->deck-fade->description
+#. 5.4->settings-schema.json->flip-fade->description
+#. 5.4->settings-schema.json->pop-fade->description
+#. 5.4->settings-schema.json->rolodex-fade->description
+#. 5.4->settings-schema.json->slide-fade->description
+#. 5.4->settings-schema.json->stack-fade->description
 msgid "Fade Transition"
 msgstr "Dissolvenza Transizione"
 
 #. 2.0->settings-schema.json->dim_factor->description
-#. 5.4->settings-schema.json->dim_factor->description
+#. 5.4->settings-schema.json->cube-dim-factor->description
+#. 5.4->settings-schema.json->deck-dim-factor->description
+#. 5.4->settings-schema.json->flip-dim-factor->description
+#. 5.4->settings-schema.json->pop-dim-factor->description
+#. 5.4->settings-schema.json->rolodex-dim-factor->description
+#. 5.4->settings-schema.json->slide-dim-factor->description
+#. 5.4->settings-schema.json->stack-dim-factor->description
 msgid "Background Dim Amount"
 msgstr "Quantità Dimensione Sfondo"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Effetti"
 
 #. 2.0->settings-schema.json->transitionEffect->description
-#. 5.4->settings-schema.json->transitionEffect->description
 msgid "Transition Effect"
 msgstr "Effetto Transizione"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->cube-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Cube"
 msgstr "Cubo"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->deck-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Deck"
 msgstr "Deck"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->flip-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Flip"
 msgstr "Capovolgi"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->pop-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Pop"
 msgstr "Pop"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->rolodex-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Rolodex"
 msgstr "Rolodex"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->slide-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Slide"
 msgstr "Slide"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->stack-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Stack"
 msgstr "Stack"
 
 #. 2.0->settings-schema.json->rotateEffect->description
-#. 5.4->settings-schema.json->rotateEffect->description
+#. 5.4->settings-schema.json->cube-rotateEffect->description
+#. 5.4->settings-schema.json->deck-rotateEffect->description
+#. 5.4->settings-schema.json->flip-rotateEffect->description
+#. 5.4->settings-schema.json->pop-rotateEffect->description
+#. 5.4->settings-schema.json->rolodex-rotateEffect->description
+#. 5.4->settings-schema.json->slide-rotateEffect->description
+#. 5.4->settings-schema.json->stack-rotateEffect->description
 msgid "Transition Easing"
 msgstr "Agevolazione della Transizione"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Back"
 msgstr "Indietro"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Bounce"
 msgstr "Rimbalzo"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Circ"
 msgstr "Circ"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic"
 msgstr "Cubic"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Back"
 msgstr "Cubic-Back"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Bounce"
 msgstr "Cubic-Bounce"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Elastic"
 msgstr "Cubic-Elastic"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Elastic"
 msgstr "Elastico"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Expo"
 msgstr "Expo"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Sine"
 msgstr "Sine"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quad"
 msgstr "Quad"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quart"
 msgstr "Quart"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quint"
 msgstr "Quint"
 
 #. 2.0->settings-schema.json->includeBackground->description
-#. 5.4->settings-schema.json->includeBackground->description
 msgid "Include Background"
 msgstr "Includi Sfondo"
+
+#. 5.4->settings-schema.json->effects-page->title
+#, fuzzy
+msgid "Effect Settings"
+msgstr "Effetti"
+
+#. 5.4->settings-schema.json->general-settings->title
+msgid "Flipper General Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->random-settings->title
+msgid "Effects included in the randomized set"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector-section->title
+msgid "Effect Selector"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-settings->title
+msgid "Effect Specific Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->description
+#, fuzzy
+msgid "Workspace Transition Effect"
+msgstr "Effetto Transizione"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Flipper effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Flipper effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Flipper effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Flipper effect is used to change the current "
+"workspace"
+msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 #, fuzzy
 msgid "Include Panels"
 msgstr "Includi Sfondo"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Exclude the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector->description
+msgid "Show settings for effect:"
+msgstr ""

--- a/Flipper@connerdev/files/Flipper@connerdev/po/nl.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/nl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-28 23:14-0500\n"
+"POT-Creation-Date: 2024-12-21 11:12-0500\n"
 "PO-Revision-Date: 2024-09-11 11:33+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -26,150 +26,331 @@ msgid "Fancy workspace switching extension"
 msgstr "Stijlvolle extensie om van werkruimte te wisselen"
 
 #. 2.0->settings-schema.json->header1->description
-#. 5.4->settings-schema.json->header1->description
+#. 5.4->settings-schema.json->general-page->title
 msgid "General"
 msgstr "Algemeen"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
+#. 5.4->settings-schema.json->cube-animationTime->description
+#. 5.4->settings-schema.json->deck-animationTime->description
+#. 5.4->settings-schema.json->flip-animationTime->description
+#. 5.4->settings-schema.json->pop-animationTime->description
+#. 5.4->settings-schema.json->rolodex-animationTime->description
+#. 5.4->settings-schema.json->slide-animationTime->description
+#. 5.4->settings-schema.json->stack-animationTime->description
 msgid "Animation duration"
 msgstr "Animatieduur"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
+#. 5.4->settings-schema.json->cube-pullaway->description
+#. 5.4->settings-schema.json->deck-pullaway->description
+#. 5.4->settings-schema.json->flip-pullaway->description
+#. 5.4->settings-schema.json->pop-pullaway->description
+#. 5.4->settings-schema.json->rolodex-pullaway->description
+#. 5.4->settings-schema.json->slide-pullaway->description
+#. 5.4->settings-schema.json->stack-pullaway->description
 msgid "Zoom Amount"
 msgstr "Zoomhoeveelheid"
 
 #. 2.0->settings-schema.json->fade->description
-#. 5.4->settings-schema.json->fade->description
+#. 5.4->settings-schema.json->cube-fade->description
+#. 5.4->settings-schema.json->deck-fade->description
+#. 5.4->settings-schema.json->flip-fade->description
+#. 5.4->settings-schema.json->pop-fade->description
+#. 5.4->settings-schema.json->rolodex-fade->description
+#. 5.4->settings-schema.json->slide-fade->description
+#. 5.4->settings-schema.json->stack-fade->description
 msgid "Fade Transition"
 msgstr "Vervagingsovergang"
 
 #. 2.0->settings-schema.json->dim_factor->description
-#. 5.4->settings-schema.json->dim_factor->description
+#. 5.4->settings-schema.json->cube-dim-factor->description
+#. 5.4->settings-schema.json->deck-dim-factor->description
+#. 5.4->settings-schema.json->flip-dim-factor->description
+#. 5.4->settings-schema.json->pop-dim-factor->description
+#. 5.4->settings-schema.json->rolodex-dim-factor->description
+#. 5.4->settings-schema.json->slide-dim-factor->description
+#. 5.4->settings-schema.json->stack-dim-factor->description
 msgid "Background Dim Amount"
 msgstr "Achtergrond dim hoeveelheid"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Effecten"
 
 #. 2.0->settings-schema.json->transitionEffect->description
-#. 5.4->settings-schema.json->transitionEffect->description
 msgid "Transition Effect"
 msgstr "Overgangseffect"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->cube-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Cube"
 msgstr "Kubus"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->deck-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Deck"
 msgstr "Dek"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->flip-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Flip"
 msgstr "Omkeren"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->pop-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Pop"
 msgstr "Pop"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->rolodex-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Rolodex"
 msgstr "Rolodex"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->slide-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Slide"
 msgstr "Schuiven"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->stack-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Stack"
 msgstr "Stapelen"
 
 #. 2.0->settings-schema.json->rotateEffect->description
-#. 5.4->settings-schema.json->rotateEffect->description
+#. 5.4->settings-schema.json->cube-rotateEffect->description
+#. 5.4->settings-schema.json->deck-rotateEffect->description
+#. 5.4->settings-schema.json->flip-rotateEffect->description
+#. 5.4->settings-schema.json->pop-rotateEffect->description
+#. 5.4->settings-schema.json->rolodex-rotateEffect->description
+#. 5.4->settings-schema.json->slide-rotateEffect->description
+#. 5.4->settings-schema.json->stack-rotateEffect->description
 msgid "Transition Easing"
 msgstr "Overgangs easing"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Back"
 msgstr "Achteruit"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Bounce"
 msgstr "Stuiter"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Circ"
 msgstr "Cirkel"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic"
 msgstr "Kubisch"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Back"
 msgstr "Kubisch-achteruit"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Bounce"
 msgstr "Kubisch-stuiter"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Elastic"
 msgstr "Kubisch-elastisch"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Elastic"
 msgstr "Elastisch"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Expo"
 msgstr "Exponentieel"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Sine"
 msgstr "Sinus"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quad"
 msgstr "Vierkant"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quart"
 msgstr "Kwadratisch"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quint"
 msgstr "Kwint"
 
 #. 2.0->settings-schema.json->includeBackground->description
-#. 5.4->settings-schema.json->includeBackground->description
 msgid "Include Background"
 msgstr "Inclusief Achtergrond"
+
+#. 5.4->settings-schema.json->effects-page->title
+#, fuzzy
+msgid "Effect Settings"
+msgstr "Effecten"
+
+#. 5.4->settings-schema.json->general-settings->title
+msgid "Flipper General Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->random-settings->title
+msgid "Effects included in the randomized set"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector-section->title
+msgid "Effect Selector"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-settings->title
+msgid "Effect Specific Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->description
+#, fuzzy
+msgid "Workspace Transition Effect"
+msgstr "Overgangseffect"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Flipper effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Flipper effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Flipper effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Flipper effect is used to change the current "
+"workspace"
+msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
 msgstr "Inclusief Panelen"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Exclude the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector->description
+msgid "Show settings for effect:"
+msgstr ""

--- a/Flipper@connerdev/files/Flipper@connerdev/po/pt_BR.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/pt_BR.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-28 23:14-0500\n"
+"POT-Creation-Date: 2024-12-21 11:12-0500\n"
 "PO-Revision-Date: 2021-09-26 21:23-0300\n"
 "Last-Translator: Marcelo Aof\n"
 "Language-Team: \n"
@@ -28,151 +28,332 @@ msgid "Fancy workspace switching extension"
 msgstr "Escolha um efeito para a mudança de áreas de trabalho"
 
 #. 2.0->settings-schema.json->header1->description
-#. 5.4->settings-schema.json->header1->description
+#. 5.4->settings-schema.json->general-page->title
 msgid "General"
 msgstr "Visão geral"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
+#. 5.4->settings-schema.json->cube-animationTime->description
+#. 5.4->settings-schema.json->deck-animationTime->description
+#. 5.4->settings-schema.json->flip-animationTime->description
+#. 5.4->settings-schema.json->pop-animationTime->description
+#. 5.4->settings-schema.json->rolodex-animationTime->description
+#. 5.4->settings-schema.json->slide-animationTime->description
+#. 5.4->settings-schema.json->stack-animationTime->description
 msgid "Animation duration"
 msgstr "Duração da animação"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
+#. 5.4->settings-schema.json->cube-pullaway->description
+#. 5.4->settings-schema.json->deck-pullaway->description
+#. 5.4->settings-schema.json->flip-pullaway->description
+#. 5.4->settings-schema.json->pop-pullaway->description
+#. 5.4->settings-schema.json->rolodex-pullaway->description
+#. 5.4->settings-schema.json->slide-pullaway->description
+#. 5.4->settings-schema.json->stack-pullaway->description
 msgid "Zoom Amount"
 msgstr "Quantidade de zoom"
 
 #. 2.0->settings-schema.json->fade->description
-#. 5.4->settings-schema.json->fade->description
+#. 5.4->settings-schema.json->cube-fade->description
+#. 5.4->settings-schema.json->deck-fade->description
+#. 5.4->settings-schema.json->flip-fade->description
+#. 5.4->settings-schema.json->pop-fade->description
+#. 5.4->settings-schema.json->rolodex-fade->description
+#. 5.4->settings-schema.json->slide-fade->description
+#. 5.4->settings-schema.json->stack-fade->description
 msgid "Fade Transition"
 msgstr "Suavidade da transição"
 
 #. 2.0->settings-schema.json->dim_factor->description
-#. 5.4->settings-schema.json->dim_factor->description
+#. 5.4->settings-schema.json->cube-dim-factor->description
+#. 5.4->settings-schema.json->deck-dim-factor->description
+#. 5.4->settings-schema.json->flip-dim-factor->description
+#. 5.4->settings-schema.json->pop-dim-factor->description
+#. 5.4->settings-schema.json->rolodex-dim-factor->description
+#. 5.4->settings-schema.json->slide-dim-factor->description
+#. 5.4->settings-schema.json->stack-dim-factor->description
 msgid "Background Dim Amount"
 msgstr "Quantidade de escurecimento do plano de fundo"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Efeitos"
 
 #. 2.0->settings-schema.json->transitionEffect->description
-#. 5.4->settings-schema.json->transitionEffect->description
 msgid "Transition Effect"
 msgstr "Efeito de transição"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->cube-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Cube"
 msgstr "Cubo"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->deck-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Deck"
 msgstr "Baralho"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->flip-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Flip"
 msgstr "Virar"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->pop-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Pop"
 msgstr "Pop"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->rolodex-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Rolodex"
 msgstr "Rolodex"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->slide-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Slide"
 msgstr "Deslizar"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->stack-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Stack"
 msgstr "Empilhar"
 
 #. 2.0->settings-schema.json->rotateEffect->description
-#. 5.4->settings-schema.json->rotateEffect->description
+#. 5.4->settings-schema.json->cube-rotateEffect->description
+#. 5.4->settings-schema.json->deck-rotateEffect->description
+#. 5.4->settings-schema.json->flip-rotateEffect->description
+#. 5.4->settings-schema.json->pop-rotateEffect->description
+#. 5.4->settings-schema.json->rolodex-rotateEffect->description
+#. 5.4->settings-schema.json->slide-rotateEffect->description
+#. 5.4->settings-schema.json->stack-rotateEffect->description
 msgid "Transition Easing"
 msgstr "Modo de aceleração e desaceleração da transição"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Back"
 msgstr "Voltar"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Bounce"
 msgstr "Quicar"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Circ"
 msgstr "Círculo"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic"
 msgstr "Cúbico"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Back"
 msgstr "Cúbico-Voltar"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Bounce"
 msgstr "Cúbico-Quicar"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Elastic"
 msgstr "Cúbico-Elástico"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Elastic"
 msgstr "Elástico"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Expo"
 msgstr "Expo"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Sine"
 msgstr "Seno"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quad"
 msgstr "Quadrado"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quart"
 msgstr "Quart"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quint"
 msgstr "Quint"
 
 #. 2.0->settings-schema.json->includeBackground->description
-#. 5.4->settings-schema.json->includeBackground->description
 msgid "Include Background"
 msgstr "Incluir o plano de fundo"
+
+#. 5.4->settings-schema.json->effects-page->title
+#, fuzzy
+msgid "Effect Settings"
+msgstr "Efeitos"
+
+#. 5.4->settings-schema.json->general-settings->title
+msgid "Flipper General Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->random-settings->title
+msgid "Effects included in the randomized set"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector-section->title
+msgid "Effect Selector"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-settings->title
+msgid "Effect Specific Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->description
+#, fuzzy
+msgid "Workspace Transition Effect"
+msgstr "Efeito de transição"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Flipper effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Flipper effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Flipper effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Flipper effect is used to change the current "
+"workspace"
+msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 #, fuzzy
 msgid "Include Panels"
 msgstr "Incluir o plano de fundo"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Exclude the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector->description
+msgid "Show settings for effect:"
+msgstr ""

--- a/Flipper@connerdev/files/Flipper@connerdev/po/ro.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/ro.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-28 23:14-0500\n"
+"POT-Creation-Date: 2024-12-21 11:12-0500\n"
 "PO-Revision-Date: 2022-08-06 01:55+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -29,151 +29,332 @@ msgid "Fancy workspace switching extension"
 msgstr "Extensie extravagantă de comutare a spațiului de lucru"
 
 #. 2.0->settings-schema.json->header1->description
-#. 5.4->settings-schema.json->header1->description
+#. 5.4->settings-schema.json->general-page->title
 msgid "General"
 msgstr "General"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
+#. 5.4->settings-schema.json->cube-animationTime->description
+#. 5.4->settings-schema.json->deck-animationTime->description
+#. 5.4->settings-schema.json->flip-animationTime->description
+#. 5.4->settings-schema.json->pop-animationTime->description
+#. 5.4->settings-schema.json->rolodex-animationTime->description
+#. 5.4->settings-schema.json->slide-animationTime->description
+#. 5.4->settings-schema.json->stack-animationTime->description
 msgid "Animation duration"
 msgstr "Durata animației"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
+#. 5.4->settings-schema.json->cube-pullaway->description
+#. 5.4->settings-schema.json->deck-pullaway->description
+#. 5.4->settings-schema.json->flip-pullaway->description
+#. 5.4->settings-schema.json->pop-pullaway->description
+#. 5.4->settings-schema.json->rolodex-pullaway->description
+#. 5.4->settings-schema.json->slide-pullaway->description
+#. 5.4->settings-schema.json->stack-pullaway->description
 msgid "Zoom Amount"
 msgstr "Cantitate de zoom"
 
 #. 2.0->settings-schema.json->fade->description
-#. 5.4->settings-schema.json->fade->description
+#. 5.4->settings-schema.json->cube-fade->description
+#. 5.4->settings-schema.json->deck-fade->description
+#. 5.4->settings-schema.json->flip-fade->description
+#. 5.4->settings-schema.json->pop-fade->description
+#. 5.4->settings-schema.json->rolodex-fade->description
+#. 5.4->settings-schema.json->slide-fade->description
+#. 5.4->settings-schema.json->stack-fade->description
 msgid "Fade Transition"
 msgstr "Tranziție estompare"
 
 #. 2.0->settings-schema.json->dim_factor->description
-#. 5.4->settings-schema.json->dim_factor->description
+#. 5.4->settings-schema.json->cube-dim-factor->description
+#. 5.4->settings-schema.json->deck-dim-factor->description
+#. 5.4->settings-schema.json->flip-dim-factor->description
+#. 5.4->settings-schema.json->pop-dim-factor->description
+#. 5.4->settings-schema.json->rolodex-dim-factor->description
+#. 5.4->settings-schema.json->slide-dim-factor->description
+#. 5.4->settings-schema.json->stack-dim-factor->description
 msgid "Background Dim Amount"
 msgstr "Atenuarea fundalului"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Efecte"
 
 #. 2.0->settings-schema.json->transitionEffect->description
-#. 5.4->settings-schema.json->transitionEffect->description
 msgid "Transition Effect"
 msgstr "Efectul de tranziție"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->cube-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Cube"
 msgstr "Cub"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->deck-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Deck"
 msgstr "Punte"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->flip-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Flip"
 msgstr "Răsturnare"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->pop-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Pop"
 msgstr "Plesnire"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->rolodex-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Rolodex"
 msgstr "Rolodex"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->slide-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Slide"
 msgstr "Alunecare"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->stack-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Stack"
 msgstr "Stivă"
 
 #. 2.0->settings-schema.json->rotateEffect->description
-#. 5.4->settings-schema.json->rotateEffect->description
+#. 5.4->settings-schema.json->cube-rotateEffect->description
+#. 5.4->settings-schema.json->deck-rotateEffect->description
+#. 5.4->settings-schema.json->flip-rotateEffect->description
+#. 5.4->settings-schema.json->pop-rotateEffect->description
+#. 5.4->settings-schema.json->rolodex-rotateEffect->description
+#. 5.4->settings-schema.json->slide-rotateEffect->description
+#. 5.4->settings-schema.json->stack-rotateEffect->description
 msgid "Transition Easing"
 msgstr "Temperarea tranziției"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Back"
 msgstr "Înapoi"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Bounce"
 msgstr "Săritură"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Circ"
 msgstr "Circ"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic"
 msgstr "Cubic"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Back"
 msgstr "Cubic-Back"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Bounce"
 msgstr "Cubic-Săritură"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Elastic"
 msgstr "Cubic-Elastic"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Elastic"
 msgstr "Elastic"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Expo"
 msgstr "Expo"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Sine"
 msgstr "Sinus"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quad"
 msgstr "Quad"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quart"
 msgstr "Quart"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quint"
 msgstr "Quint"
 
 #. 2.0->settings-schema.json->includeBackground->description
-#. 5.4->settings-schema.json->includeBackground->description
 msgid "Include Background"
 msgstr "Include fundal"
+
+#. 5.4->settings-schema.json->effects-page->title
+#, fuzzy
+msgid "Effect Settings"
+msgstr "Efecte"
+
+#. 5.4->settings-schema.json->general-settings->title
+msgid "Flipper General Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->random-settings->title
+msgid "Effects included in the randomized set"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector-section->title
+msgid "Effect Selector"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-settings->title
+msgid "Effect Specific Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->description
+#, fuzzy
+msgid "Workspace Transition Effect"
+msgstr "Efectul de tranziție"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Flipper effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Flipper effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Flipper effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Flipper effect is used to change the current "
+"workspace"
+msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 #, fuzzy
 msgid "Include Panels"
 msgstr "Include fundal"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Exclude the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector->description
+msgid "Show settings for effect:"
+msgstr ""

--- a/Flipper@connerdev/files/Flipper@connerdev/po/ru.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/ru.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-28 23:14-0500\n"
+"POT-Creation-Date: 2024-12-21 11:12-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: blogdron\n"
 "Language-Team: \n"
@@ -23,151 +23,332 @@ msgid "Fancy workspace switching extension"
 msgstr "Прикольное переключение рабочих столов"
 
 #. 2.0->settings-schema.json->header1->description
-#. 5.4->settings-schema.json->header1->description
+#. 5.4->settings-schema.json->general-page->title
 msgid "General"
 msgstr "Общие"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
+#. 5.4->settings-schema.json->cube-animationTime->description
+#. 5.4->settings-schema.json->deck-animationTime->description
+#. 5.4->settings-schema.json->flip-animationTime->description
+#. 5.4->settings-schema.json->pop-animationTime->description
+#. 5.4->settings-schema.json->rolodex-animationTime->description
+#. 5.4->settings-schema.json->slide-animationTime->description
+#. 5.4->settings-schema.json->stack-animationTime->description
 msgid "Animation duration"
 msgstr "Продолжительность Анимации"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
+#. 5.4->settings-schema.json->cube-pullaway->description
+#. 5.4->settings-schema.json->deck-pullaway->description
+#. 5.4->settings-schema.json->flip-pullaway->description
+#. 5.4->settings-schema.json->pop-pullaway->description
+#. 5.4->settings-schema.json->rolodex-pullaway->description
+#. 5.4->settings-schema.json->slide-pullaway->description
+#. 5.4->settings-schema.json->stack-pullaway->description
 msgid "Zoom Amount"
 msgstr "Величина Масштабирования"
 
 #. 2.0->settings-schema.json->fade->description
-#. 5.4->settings-schema.json->fade->description
+#. 5.4->settings-schema.json->cube-fade->description
+#. 5.4->settings-schema.json->deck-fade->description
+#. 5.4->settings-schema.json->flip-fade->description
+#. 5.4->settings-schema.json->pop-fade->description
+#. 5.4->settings-schema.json->rolodex-fade->description
+#. 5.4->settings-schema.json->slide-fade->description
+#. 5.4->settings-schema.json->stack-fade->description
 msgid "Fade Transition"
 msgstr "Затухание"
 
 #. 2.0->settings-schema.json->dim_factor->description
-#. 5.4->settings-schema.json->dim_factor->description
+#. 5.4->settings-schema.json->cube-dim-factor->description
+#. 5.4->settings-schema.json->deck-dim-factor->description
+#. 5.4->settings-schema.json->flip-dim-factor->description
+#. 5.4->settings-schema.json->pop-dim-factor->description
+#. 5.4->settings-schema.json->rolodex-dim-factor->description
+#. 5.4->settings-schema.json->slide-dim-factor->description
+#. 5.4->settings-schema.json->stack-dim-factor->description
 msgid "Background Dim Amount"
 msgstr "Значение Тусклости Фона"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Эффекты"
 
 #. 2.0->settings-schema.json->transitionEffect->description
-#. 5.4->settings-schema.json->transitionEffect->description
 msgid "Transition Effect"
 msgstr "Эффект Перехода"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->cube-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Cube"
 msgstr ""
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->deck-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Deck"
 msgstr ""
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->flip-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Flip"
 msgstr ""
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->pop-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Pop"
 msgstr ""
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->rolodex-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Rolodex"
 msgstr ""
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->slide-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Slide"
 msgstr ""
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->stack-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Stack"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->description
-#. 5.4->settings-schema.json->rotateEffect->description
+#. 5.4->settings-schema.json->cube-rotateEffect->description
+#. 5.4->settings-schema.json->deck-rotateEffect->description
+#. 5.4->settings-schema.json->flip-rotateEffect->description
+#. 5.4->settings-schema.json->pop-rotateEffect->description
+#. 5.4->settings-schema.json->rolodex-rotateEffect->description
+#. 5.4->settings-schema.json->slide-rotateEffect->description
+#. 5.4->settings-schema.json->stack-rotateEffect->description
 msgid "Transition Easing"
 msgstr "Плавность Перехода"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Back"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Bounce"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Circ"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Back"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Bounce"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Elastic"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Elastic"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Expo"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Sine"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quad"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quart"
 msgstr ""
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quint"
 msgstr ""
 
 #. 2.0->settings-schema.json->includeBackground->description
-#. 5.4->settings-schema.json->includeBackground->description
 msgid "Include Background"
 msgstr "Задействовать Фон"
+
+#. 5.4->settings-schema.json->effects-page->title
+#, fuzzy
+msgid "Effect Settings"
+msgstr "Эффекты"
+
+#. 5.4->settings-schema.json->general-settings->title
+msgid "Flipper General Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->random-settings->title
+msgid "Effects included in the randomized set"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector-section->title
+msgid "Effect Selector"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-settings->title
+msgid "Effect Specific Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->description
+#, fuzzy
+msgid "Workspace Transition Effect"
+msgstr "Эффект Перехода"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Flipper effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Flipper effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Flipper effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Flipper effect is used to change the current "
+"workspace"
+msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 #, fuzzy
 msgid "Include Panels"
 msgstr "Задействовать Фон"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Exclude the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector->description
+msgid "Show settings for effect:"
+msgstr ""

--- a/Flipper@connerdev/files/Flipper@connerdev/po/tr.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/tr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-28 23:14-0500\n"
+"POT-Creation-Date: 2024-12-21 11:12-0500\n"
 "PO-Revision-Date: 2021-03-15 20:55+0300\n"
 "Last-Translator: Gökhan Gökkaya <gokhanlnx@gmail.com>\n"
 "Language-Team: \n"
@@ -28,151 +28,332 @@ msgid "Fancy workspace switching extension"
 msgstr "Çalışma alanı değiştirmek için hoş bir eklenti"
 
 #. 2.0->settings-schema.json->header1->description
-#. 5.4->settings-schema.json->header1->description
+#. 5.4->settings-schema.json->general-page->title
 msgid "General"
 msgstr "Genel"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
+#. 5.4->settings-schema.json->cube-animationTime->description
+#. 5.4->settings-schema.json->deck-animationTime->description
+#. 5.4->settings-schema.json->flip-animationTime->description
+#. 5.4->settings-schema.json->pop-animationTime->description
+#. 5.4->settings-schema.json->rolodex-animationTime->description
+#. 5.4->settings-schema.json->slide-animationTime->description
+#. 5.4->settings-schema.json->stack-animationTime->description
 msgid "Animation duration"
 msgstr "Animasyon süresi"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
+#. 5.4->settings-schema.json->cube-pullaway->description
+#. 5.4->settings-schema.json->deck-pullaway->description
+#. 5.4->settings-schema.json->flip-pullaway->description
+#. 5.4->settings-schema.json->pop-pullaway->description
+#. 5.4->settings-schema.json->rolodex-pullaway->description
+#. 5.4->settings-schema.json->slide-pullaway->description
+#. 5.4->settings-schema.json->stack-pullaway->description
 msgid "Zoom Amount"
 msgstr "Yakınlaştırma Miktarı"
 
 #. 2.0->settings-schema.json->fade->description
-#. 5.4->settings-schema.json->fade->description
+#. 5.4->settings-schema.json->cube-fade->description
+#. 5.4->settings-schema.json->deck-fade->description
+#. 5.4->settings-schema.json->flip-fade->description
+#. 5.4->settings-schema.json->pop-fade->description
+#. 5.4->settings-schema.json->rolodex-fade->description
+#. 5.4->settings-schema.json->slide-fade->description
+#. 5.4->settings-schema.json->stack-fade->description
 msgid "Fade Transition"
 msgstr "Kaybolma Geçişi"
 
 #. 2.0->settings-schema.json->dim_factor->description
-#. 5.4->settings-schema.json->dim_factor->description
+#. 5.4->settings-schema.json->cube-dim-factor->description
+#. 5.4->settings-schema.json->deck-dim-factor->description
+#. 5.4->settings-schema.json->flip-dim-factor->description
+#. 5.4->settings-schema.json->pop-dim-factor->description
+#. 5.4->settings-schema.json->rolodex-dim-factor->description
+#. 5.4->settings-schema.json->slide-dim-factor->description
+#. 5.4->settings-schema.json->stack-dim-factor->description
 msgid "Background Dim Amount"
 msgstr "Arkaplan Donuklaşma Miktarı"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "Efektler"
 
 #. 2.0->settings-schema.json->transitionEffect->description
-#. 5.4->settings-schema.json->transitionEffect->description
 msgid "Transition Effect"
 msgstr "Kaybolma Efekti"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->cube-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Cube"
 msgstr "Küp"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->deck-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Deck"
 msgstr "Deste"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->flip-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Flip"
 msgstr "Çevir"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->pop-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Pop"
 msgstr "Patlama"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->rolodex-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Rolodex"
 msgstr "Döndür"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->slide-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Slide"
 msgstr "Kaydır"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->stack-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Stack"
 msgstr "Yığma"
 
 #. 2.0->settings-schema.json->rotateEffect->description
-#. 5.4->settings-schema.json->rotateEffect->description
+#. 5.4->settings-schema.json->cube-rotateEffect->description
+#. 5.4->settings-schema.json->deck-rotateEffect->description
+#. 5.4->settings-schema.json->flip-rotateEffect->description
+#. 5.4->settings-schema.json->pop-rotateEffect->description
+#. 5.4->settings-schema.json->rolodex-rotateEffect->description
+#. 5.4->settings-schema.json->slide-rotateEffect->description
+#. 5.4->settings-schema.json->stack-rotateEffect->description
 msgid "Transition Easing"
 msgstr "Geçiş Yardımcısı"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Back"
 msgstr "Geri"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Bounce"
 msgstr "Titreme"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Circ"
 msgstr "Daire"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic"
 msgstr "Küpsel"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Back"
 msgstr "Küpsel-Geri"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Bounce"
 msgstr "Küpsel-Titreme"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Elastic"
 msgstr "Küpsel-Esnek"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Elastic"
 msgstr "Esnek"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Expo"
 msgstr "Sergi"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Sine"
 msgstr "Eğrisel"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quad"
 msgstr "Dörtlü"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quart"
 msgstr "Çeyrek"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quint"
 msgstr "Art arda"
 
 #. 2.0->settings-schema.json->includeBackground->description
-#. 5.4->settings-schema.json->includeBackground->description
 msgid "Include Background"
 msgstr "Arkaplan Dahil"
+
+#. 5.4->settings-schema.json->effects-page->title
+#, fuzzy
+msgid "Effect Settings"
+msgstr "Efektler"
+
+#. 5.4->settings-schema.json->general-settings->title
+msgid "Flipper General Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->random-settings->title
+msgid "Effects included in the randomized set"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector-section->title
+msgid "Effect Selector"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-settings->title
+msgid "Effect Specific Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->description
+#, fuzzy
+msgid "Workspace Transition Effect"
+msgstr "Kaybolma Efekti"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Flipper effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Flipper effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Flipper effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Flipper effect is used to change the current "
+"workspace"
+msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 #, fuzzy
 msgid "Include Panels"
 msgstr "Arkaplan Dahil"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Exclude the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector->description
+msgid "Show settings for effect:"
+msgstr ""

--- a/Flipper@connerdev/files/Flipper@connerdev/po/zh_CN.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/zh_CN.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-28 23:14-0500\n"
+"POT-Creation-Date: 2024-12-21 11:12-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -24,151 +24,332 @@ msgid "Fancy workspace switching extension"
 msgstr "绚丽的工作区切换扩展"
 
 #. 2.0->settings-schema.json->header1->description
-#. 5.4->settings-schema.json->header1->description
+#. 5.4->settings-schema.json->general-page->title
 msgid "General"
 msgstr "常规"
 
 #. 2.0->settings-schema.json->animationTime->description
-#. 5.4->settings-schema.json->animationTime->description
+#. 5.4->settings-schema.json->cube-animationTime->description
+#. 5.4->settings-schema.json->deck-animationTime->description
+#. 5.4->settings-schema.json->flip-animationTime->description
+#. 5.4->settings-schema.json->pop-animationTime->description
+#. 5.4->settings-schema.json->rolodex-animationTime->description
+#. 5.4->settings-schema.json->slide-animationTime->description
+#. 5.4->settings-schema.json->stack-animationTime->description
 msgid "Animation duration"
 msgstr "动画时长"
 
 #. 2.0->settings-schema.json->pullaway->description
-#. 5.4->settings-schema.json->pullaway->description
+#. 5.4->settings-schema.json->cube-pullaway->description
+#. 5.4->settings-schema.json->deck-pullaway->description
+#. 5.4->settings-schema.json->flip-pullaway->description
+#. 5.4->settings-schema.json->pop-pullaway->description
+#. 5.4->settings-schema.json->rolodex-pullaway->description
+#. 5.4->settings-schema.json->slide-pullaway->description
+#. 5.4->settings-schema.json->stack-pullaway->description
 msgid "Zoom Amount"
 msgstr "缩放量"
 
 #. 2.0->settings-schema.json->fade->description
-#. 5.4->settings-schema.json->fade->description
+#. 5.4->settings-schema.json->cube-fade->description
+#. 5.4->settings-schema.json->deck-fade->description
+#. 5.4->settings-schema.json->flip-fade->description
+#. 5.4->settings-schema.json->pop-fade->description
+#. 5.4->settings-schema.json->rolodex-fade->description
+#. 5.4->settings-schema.json->slide-fade->description
+#. 5.4->settings-schema.json->stack-fade->description
 msgid "Fade Transition"
 msgstr "淡出过渡"
 
 #. 2.0->settings-schema.json->dim_factor->description
-#. 5.4->settings-schema.json->dim_factor->description
+#. 5.4->settings-schema.json->cube-dim-factor->description
+#. 5.4->settings-schema.json->deck-dim-factor->description
+#. 5.4->settings-schema.json->flip-dim-factor->description
+#. 5.4->settings-schema.json->pop-dim-factor->description
+#. 5.4->settings-schema.json->rolodex-dim-factor->description
+#. 5.4->settings-schema.json->slide-dim-factor->description
+#. 5.4->settings-schema.json->stack-dim-factor->description
 msgid "Background Dim Amount"
 msgstr "背景昏暗量"
 
 #. 2.0->settings-schema.json->header2->description
-#. 5.4->settings-schema.json->header2->description
 msgid "Effects"
 msgstr "特效"
 
 #. 2.0->settings-schema.json->transitionEffect->description
-#. 5.4->settings-schema.json->transitionEffect->description
 msgid "Transition Effect"
 msgstr "过渡特效"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->cube-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Cube"
 msgstr "立方体"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->deck-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Deck"
 msgstr "铺面"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->flip-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Flip"
 msgstr "翻转"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->pop-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Pop"
 msgstr "流行"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->rolodex-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Rolodex"
 msgstr "旋转夹"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->slide-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Slide"
 msgstr "滑动"
 
 #. 2.0->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->stack-random-include->description
 #. 5.4->settings-schema.json->transitionEffect->options
+#. 5.4->settings-schema.json->effect-selector->options
 msgid "Stack"
 msgstr "堆叠"
 
 #. 2.0->settings-schema.json->rotateEffect->description
-#. 5.4->settings-schema.json->rotateEffect->description
+#. 5.4->settings-schema.json->cube-rotateEffect->description
+#. 5.4->settings-schema.json->deck-rotateEffect->description
+#. 5.4->settings-schema.json->flip-rotateEffect->description
+#. 5.4->settings-schema.json->pop-rotateEffect->description
+#. 5.4->settings-schema.json->rolodex-rotateEffect->description
+#. 5.4->settings-schema.json->slide-rotateEffect->description
+#. 5.4->settings-schema.json->stack-rotateEffect->description
 msgid "Transition Easing"
 msgstr "过渡缓动"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Back"
 msgstr "回退"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Bounce"
 msgstr "弹跳"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Circ"
 msgstr "环形"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic"
 msgstr "立方体"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Back"
 msgstr "立方体-回退"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Bounce"
 msgstr "立方体-弹跳"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Cubic-Elastic"
 msgstr "立方体-弹性"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Elastic"
 msgstr "弹性"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Expo"
 msgstr "展览"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Sine"
 msgstr "正弦"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quad"
 msgstr "四宫格"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quart"
 msgstr "四分之一"
 
 #. 2.0->settings-schema.json->rotateEffect->options
-#. 5.4->settings-schema.json->rotateEffect->options
+#. 5.4->settings-schema.json->cube-rotateEffect->options
+#. 5.4->settings-schema.json->deck-rotateEffect->options
+#. 5.4->settings-schema.json->flip-rotateEffect->options
+#. 5.4->settings-schema.json->pop-rotateEffect->options
+#. 5.4->settings-schema.json->rolodex-rotateEffect->options
+#. 5.4->settings-schema.json->slide-rotateEffect->options
+#. 5.4->settings-schema.json->stack-rotateEffect->options
 msgid "Quint"
 msgstr "五分之一"
 
 #. 2.0->settings-schema.json->includeBackground->description
-#. 5.4->settings-schema.json->includeBackground->description
 msgid "Include Background"
 msgstr "包含背景"
+
+#. 5.4->settings-schema.json->effects-page->title
+#, fuzzy
+msgid "Effect Settings"
+msgstr "特效"
+
+#. 5.4->settings-schema.json->general-settings->title
+msgid "Flipper General Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->random-settings->title
+msgid "Effects included in the randomized set"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector-section->title
+msgid "Effect Selector"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-settings->title
+msgid "Effect Specific Settings"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->description
+#, fuzzy
+msgid "Workspace Transition Effect"
+msgstr "过渡特效"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->description
+msgid "Use Flipper effect with the Workspace Switcher applet"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchmoveToWorkspace->tooltip
+msgid ""
+"Override the moveToWorkspace() API so that the Flipper effect is used by the "
+"Workspace Switcher Applet when changing the current workspace"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->description
+msgid "Use Flipper effect when changing focus causes a workspace switch"
+msgstr ""
+
+#. 5.4->settings-schema.json->patchActivateWindow->tooltip
+msgid ""
+"Override the activateWindow() API so that when a window on another workspace "
+"is given the focus, the Flipper effect is used to change the current "
+"workspace"
+msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 #, fuzzy
 msgid "Include Panels"
 msgstr "包含背景"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Exclude the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
+
+#. 5.4->settings-schema.json->effect-selector->description
+msgid "Show settings for effect:"
+msgstr ""

--- a/smart-panel@mohammad-sn/files/smart-panel@mohammad-sn/metadata.json
+++ b/smart-panel@mohammad-sn/files/smart-panel@mohammad-sn/metadata.json
@@ -23,7 +23,7 @@
   ],
   "description": "Switch between workspaces, show desktop, activate overview or expo, ... by scrolling, double click, mouse gestures etc on free space of the panel.",
   "name": "Smart Panel",
-  "version": "1.4.1",
+  "version": "1.4.2",
   "uuid": "smart-panel@mohammad-sn",
   "url": "https://cinnamon-spices.linuxmint.com/extensions/view/80",
   "author": "mohammad-sn"


### PR DESCRIPTION
- Added ability to use Flipper effects when changing the workspace via the "Workspace Switcher" applet
- Added ability to use Flipper effects when changing the workspace by activating a window on a different workspace
- Added ability to use Flipper effects when using the workspace "Direct Navigation" hotkeys
- Implement "Extension Workspace Switching API" used by smart-panel 1.4.2 to switch workspaces using the Flipper effect
- Added a configuration option to control if the "Workspace Switcher" applet will use the Flipper effect
- Added a configuration option to control if switching to a window on a different workspace will use the Flipper effect
- Use independent effect settings so each effect remembers it's own settings
- Added a "Randomized" effect option that will randomly select a effect for each workspace transition initiation
- Added a set of configuration options that allows you to control which effects are in the Randomized set
- Removed the "Include Background" option and hard-coded Cube effect to include a cloned background, all the other effects will see the original desktop background dimmed according to the "Background Dim Amount" setting