### PR TITLE
[DesktopCube@yare] Version 2.0.2

### DIFF
--- a/DesktopCube@yare/CHANGELOG.md
+++ b/DesktopCube@yare/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 2.0.2
+
+- Added APIs used by the "Smart Panel" applet so it can use Desktop Cube in more cases
+- Fixed a case where the Cube was used under the Expo (using the Left/Right arrow keys when the Expo was open). Using the Cube in this case was visually awkward and unnecessary so I disabled using Cube for this scenario
+- Fixes issues when attempting to move a window to an adjacent workspace (Shift+Ctrl+Alt+Left/Right) for a window that is visible on all workspaces
+
+## 2.0.1
+
+- Allow Desktop Cube to work with the "Smart Panel" applet
+
 ## 2.0.0
 
 * Added ability to use Cube effect when changing the workspace via the "Workspace Switcher" applet

--- a/DesktopCube@yare/CHANGELOG.md
+++ b/DesktopCube@yare/CHANGELOG.md
@@ -33,7 +33,7 @@
 ## 1.0.2
 
 * Added an option to remove the panels from the animation effect
-* Fix the Effect Setting options that were broken when the "tween" option widget was removed starting with cinnamon 5.4 
+* Fix the Effect Setting options that were broken when the "tween" option widget was removed starting with cinnamon 5.4
 * Allow Cinnamon to play the workspace switch sound if it is enabled
 * Note: All changed from here on will only be for the Cinnamon 5.4+ version
 * Change info.json author to me, since there is currently no maintainer

--- a/DesktopCube@yare/README.md
+++ b/DesktopCube@yare/README.md
@@ -37,7 +37,7 @@ If you know of other methods of switching the workspace where the Desktop Cube e
 ## Known Issues
 
 1. When using Desktop Cube with two or more Monitors attached, the Cube will be placed in the middle of the overall desktop which will likely appear spit between the monitors, kind of ruining the effect.
-   
+
    At some point I plan on adding options to control how the Cube is displayed on multi-monitor setups, but it might be a while before I find the time to work on that.
 
 2. If you enable the "Include Panels" option in the Desktop Cube configuration, the panels will disappear while the cube is turning and then reappear when it is done. This is far from ideal, so I recommend that you leave this option disabled so that the panels remain hidden, only reappearing after returning to the normal desktop.

--- a/DesktopCube@yare/README.md
+++ b/DesktopCube@yare/README.md
@@ -28,6 +28,8 @@ There are a number of ways to switch the current workspace, all of following wil
 
 5. When changing the focus to a window on another workspace by using the Window-List or Alt-Tab when they are configured to show windows from other workspaces. (can be disabled in the configuration)
 
+6. When using the "Smart Panel" Applet features that change the workspace (Also plan to change "Desktop Scroller" to use Flipper as well in the near future)
+
 When switching the current workspace using Expo ("workspace selection screen" Default hotkey: Ctrl + Alt + Up_Arrow_Key) by clicking on a different workspace, the Desktop Cube effect will not be used. Since the Expo is not really a "face" on the cube it would break the Cube concept a bit, therefore I left it as is since I felt it was more logical that way.
 
 If you know of other methods of switching the workspace where the Desktop Cube effect is not currently used, please let me know so I can see if I can find a way to enable the Desktop Cube for that path as well.
@@ -35,7 +37,7 @@ If you know of other methods of switching the workspace where the Desktop Cube e
 ## Known Issues
 
 1. When using Desktop Cube with two or more Monitors attached, the Cube will be placed in the middle of the overall desktop which will likely appear spit between the monitors, kind of ruining the effect.
-
+   
    At some point I plan on adding options to control how the Cube is displayed on multi-monitor setups, but it might be a while before I find the time to work on that.
 
 2. If you enable the "Include Panels" option in the Desktop Cube configuration, the panels will disappear while the cube is turning and then reappear when it is done. This is far from ideal, so I recommend that you leave this option disabled so that the panels remain hidden, only reappearing after returning to the normal desktop.

--- a/DesktopCube@yare/files/DesktopCube@yare/5.4/settings-schema.json
+++ b/DesktopCube@yare/files/DesktopCube@yare/5.4/settings-schema.json
@@ -22,6 +22,7 @@
     "includePanels": {
         "type": "checkbox",
         "description": "Include Panels",
+        "tooltip": "Include the panels while animating. In most cases the panels are not properly painted or completely invisible anyhow, so it's best to leave this disabled",
         "default": false
     },
     "patchmoveToWorkspace": {

--- a/DesktopCube@yare/files/DesktopCube@yare/metadata.json
+++ b/DesktopCube@yare/files/DesktopCube@yare/metadata.json
@@ -16,7 +16,7 @@
     "4.6",
     "5.4"
   ],
-  "version": "2.0.1",
+  "version": "2.0.2",
   "uuid": "DesktopCube@yare",
   "name": "Desktop Cube",
   "description": "Compiz Cube-like animation for workspace switching",

--- a/DesktopCube@yare/files/DesktopCube@yare/po/DesktopCube@yare.pot
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/DesktopCube@yare.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: DesktopCube@yare 2.0.0\n"
+"Project-Id-Version: DesktopCube@yare 2.0.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-20 10:20-0500\n"
+"POT-Creation-Date: 2024-12-21 14:16-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -78,6 +78,13 @@ msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Include the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/DesktopCube@yare/files/DesktopCube@yare/po/ca.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/ca.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-20 10:20-0500\n"
+"POT-Creation-Date: 2024-12-21 14:16-0500\n"
 "PO-Revision-Date: 2024-08-25 22:27+0200\n"
 "Last-Translator: \n"
 "Language-Team: Odyssey <odysseyhyd@gmail.com>\n"
@@ -82,6 +82,13 @@ msgstr ""
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
 msgstr "Incloure els taulers"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Include the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description
 msgid "Use Cube effect with the Workspace Switcher applet"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/da.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-20 10:20-0500\n"
+"POT-Creation-Date: 2024-12-21 14:16-0500\n"
 "PO-Revision-Date: 2022-08-07 15:06+0200\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -81,6 +81,13 @@ msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Include the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/DesktopCube@yare/files/DesktopCube@yare/po/de.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-20 10:20-0500\n"
+"POT-Creation-Date: 2024-12-21 14:16-0500\n"
 "PO-Revision-Date: 2021-03-02 22:50+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -81,6 +81,13 @@ msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Include the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/DesktopCube@yare/files/DesktopCube@yare/po/es.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-20 10:20-0500\n"
+"POT-Creation-Date: 2024-12-21 14:16-0500\n"
 "PO-Revision-Date: 2024-11-20 18:29-0300\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -81,6 +81,13 @@ msgstr "Tamaño del cubo (porcentaje del tamaño de la pantalla)"
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
 msgstr "Incluir paneles"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Include the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description
 msgid "Use Cube effect with the Workspace Switcher applet"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/eu.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/eu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-20 10:20-0500\n"
+"POT-Creation-Date: 2024-12-21 14:16-0500\n"
 "PO-Revision-Date: 2024-05-30 10:18+0200\n"
 "Last-Translator: Muxutruk <muxutruk2@users.noreply.github.com>\n"
 "Language-Team: Basque <muxutruk2@users.noreply.github.com>\n"
@@ -80,6 +80,13 @@ msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Include the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/DesktopCube@yare/files/DesktopCube@yare/po/fi.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/fi.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: DesktopCube@yare 1.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-20 10:20-0500\n"
+"POT-Creation-Date: 2024-12-21 14:16-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -81,6 +81,13 @@ msgstr ""
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
 msgstr "Sisältää paneelit"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Include the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description
 msgid "Use Cube effect with the Workspace Switcher applet"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/fr.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-20 10:20-0500\n"
+"POT-Creation-Date: 2024-12-21 14:16-0500\n"
 "PO-Revision-Date: 2019-02-13 16:49+0100\n"
 "Last-Translator: Claudiux <claude.clerc@gmail.com>\n"
 "Language-Team: \n"
@@ -81,6 +81,13 @@ msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Include the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/DesktopCube@yare/files/DesktopCube@yare/po/hr.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/hr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: DesktopCube@yare\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-20 10:20-0500\n"
+"POT-Creation-Date: 2024-12-21 14:16-0500\n"
 "PO-Revision-Date: 2017-04-30 16:57+0200\n"
 "Last-Translator: gogo <trebelnik2@gmail.com>\n"
 "Language-Team: \n"
@@ -82,6 +82,13 @@ msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Include the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/DesktopCube@yare/files/DesktopCube@yare/po/hu.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-20 10:20-0500\n"
+"POT-Creation-Date: 2024-12-21 14:16-0500\n"
 "PO-Revision-Date: 2024-11-25 13:45+0100\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
@@ -80,6 +80,13 @@ msgstr "Kocka mérete (a képernyő méretének százalékában)"
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
 msgstr "Tartalmazza a paneleket"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Include the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description
 msgid "Use Cube effect with the Workspace Switcher applet"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/it.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-20 10:20-0500\n"
+"POT-Creation-Date: 2024-12-21 14:16-0500\n"
 "PO-Revision-Date: 2022-06-03 10:52+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -82,6 +82,13 @@ msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Include the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/DesktopCube@yare/files/DesktopCube@yare/po/nl.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/nl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-20 10:20-0500\n"
+"POT-Creation-Date: 2024-12-21 14:16-0500\n"
 "PO-Revision-Date: 2024-11-27 11:29+0100\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -80,6 +80,13 @@ msgstr "Kubusgrootte (percentage van het schermformaat)"
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
 msgstr "Inclusief Panelen"
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Include the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
+msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description
 msgid "Use Cube effect with the Workspace Switcher applet"

--- a/DesktopCube@yare/files/DesktopCube@yare/po/pt_BR.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/pt_BR.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-20 10:20-0500\n"
+"POT-Creation-Date: 2024-12-21 14:16-0500\n"
 "PO-Revision-Date: 2021-09-26 21:23-0300\n"
 "Last-Translator: Marcelo Aof\n"
 "Language-Team: \n"
@@ -82,6 +82,13 @@ msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Include the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/DesktopCube@yare/files/DesktopCube@yare/po/ro.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/ro.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-20 10:20-0500\n"
+"POT-Creation-Date: 2024-12-21 14:16-0500\n"
 "PO-Revision-Date: 2022-08-06 01:55+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -82,6 +82,13 @@ msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Include the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/DesktopCube@yare/files/DesktopCube@yare/po/ru.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/ru.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-20 10:20-0500\n"
+"POT-Creation-Date: 2024-12-21 14:16-0500\n"
 "PO-Revision-Date: 2023-12-03 14:51-0500\n"
 "Last-Translator: blogdron\n"
 "Language-Team: \n"
@@ -76,6 +76,13 @@ msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Include the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/DesktopCube@yare/files/DesktopCube@yare/po/tr.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/tr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-20 10:20-0500\n"
+"POT-Creation-Date: 2024-12-21 14:16-0500\n"
 "PO-Revision-Date: 2017-09-01 18:36+0300\n"
 "Last-Translator: Gökhan Gökkaya <gokhanlnx@gmail.com>\n"
 "Language-Team: Linux Mint Türkiye\n"
@@ -81,6 +81,13 @@ msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Include the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/DesktopCube@yare/files/DesktopCube@yare/po/zh_CN.po
+++ b/DesktopCube@yare/files/DesktopCube@yare/po/zh_CN.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2024-11-20 10:20-0500\n"
+"POT-Creation-Date: 2024-12-21 14:16-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -77,6 +77,13 @@ msgstr ""
 
 #. 5.4->settings-schema.json->includePanels->description
 msgid "Include Panels"
+msgstr ""
+
+#. 5.4->settings-schema.json->includePanels->tooltip
+msgid ""
+"Include the panels while animating. In most cases the panels are not "
+"properly painted or completely invisible anyhow, so it's best to leave this "
+"disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description


### PR DESCRIPTION
- Added APIs used by the "Smart Panel" applet so it can use Desktop Cube in more cases
- Fixed a case where the Cube was used under the Expo (using the Left/Right arrow keys when the Expo was open). Using the Cube in this case was visually awkward and unnecessary so I disabled using Cube for this scenario
- Fixes issues when attempting to move a window to an adjacent workspace (Shift+Ctrl+Alt+Left/Right) for a window that is visible on all workspaces