### PR TITLE
Extensions: Fix critical errors

### DIFF
--- a/DesktopCube@yare/files/DesktopCube@yare/5.4/extension.js
+++ b/DesktopCube@yare/files/DesktopCube@yare/5.4/extension.js
@@ -637,6 +637,7 @@ Cube.prototype = {
     },
 
     _keyPressEvent: function(actor, event) {
+        if (!enabled) return Clutter.EVENT_PROPAGATE;
         let workspace;
         let windows;
         let window;
@@ -755,7 +756,8 @@ Cube.prototype = {
         }
     },
 
-    _keyReleaseEvent: function() {
+    _keyReleaseEvent: function(actor, event) {
+        if (!enabled) return Clutter.EVENT_PROPAGATE;
         let [x, y, mods] = global.get_pointer();
         let state = mods & this._modifierMask;
 

--- a/DesktopCube@yare/files/DesktopCube@yare/metadata.json
+++ b/DesktopCube@yare/files/DesktopCube@yare/metadata.json
@@ -16,7 +16,7 @@
     "4.6",
     "5.4"
   ],
-  "version": "2.0.2",
+  "version": "2.0.3",
   "uuid": "DesktopCube@yare",
   "name": "Desktop Cube",
   "description": "Compiz Cube-like animation for workspace switching",

--- a/smart-panel@mohammad-sn/files/smart-panel@mohammad-sn/extension.js
+++ b/smart-panel@mohammad-sn/files/smart-panel@mohammad-sn/extension.js
@@ -98,15 +98,18 @@ SmartPanelExt.prototype = {
     },
 
     disable: function() {
-        this._panel.disconnect(this.sr);
-        this._panel.disconnect(this.en);
-        this._panel.disconnect(this.lv);
-        this._panel.disconnect(this.bp);
-        this._panel.disconnect(this.br);
+        this.is_disabled = true;
+        // FIXME: These lines make Cinnamon unstable!
+        //~ if (this.sr != null) this._panel.disconnect(this.sr);
+        //~ if (this.en != null) this._panel.disconnect(this.en);
+        //~ if (this.lv != null) this._panel.disconnect(this.lv);
+        //~ if (this.bp != null) this._panel.disconnect(this.bp);
+        //~ if (this.br != null) this._panel.disconnect(this.br);
     },
 
     enable: function() {
         this._panel.reactive = true;
+        this.is_disabled = false;
         this.sr = this._panel.connect('scroll-event'        , Lang.bind(this, this._onScroll));
         this.en = this._panel.connect('enter-event'         , Lang.bind(this, this._onEntered));
         this.lv = this._panel.connect('leave-event'         , Lang.bind(this, this._onLeave));
@@ -115,13 +118,13 @@ SmartPanelExt.prototype = {
     },
 
     _onEntered : function(actor, event) {
-        if (this.checkEventSource(actor, event)) return Clutter.EVENT_PROPAGATE;
+        if (this.is_disabled || this.checkEventSource(actor, event)) return Clutter.EVENT_PROPAGATE;
         this.p = false
         return;
     },
 
     _onLeave : function(actor, event) {
-        if (this.checkEventSource(actor, event)) return Clutter.EVENT_PROPAGATE;
+        if (this.is_disabled || this.checkEventSource(actor, event)) return Clutter.EVENT_PROPAGATE;
         if (this.p && this.use_gestures) {
             let v = Math.abs(global.get_pointer()[0] - this.ppos[0]) < 33;
             let e = Math.abs(global.get_pointer()[1] - this.ppos[1]) > this._panel.get_height() - 2;
@@ -132,7 +135,7 @@ SmartPanelExt.prototype = {
     },
 
     _onButtonPress : function(actor, event) {
-        if (this.checkEventSource(actor, event)) return Clutter.EVENT_PROPAGATE;
+        if (this.is_disabled || this.checkEventSource(actor, event)) return Clutter.EVENT_PROPAGATE;
         let button = event.get_button();
         if (button == 1) {
             this.p = true;
@@ -153,7 +156,7 @@ SmartPanelExt.prototype = {
     },
 
     _onButtonRelease : function(actor, event) {
-        if (this.checkEventSource(actor, event)) return Clutter.EVENT_PROPAGATE;
+        if (this.is_disabled || this.checkEventSource(actor, event)) return Clutter.EVENT_PROPAGATE;
         if (this.p && this.use_gestures) {
             let v = global.get_pointer()[0] - this.ppos[0];
             if (v > 22) this.Do(this.to_right);
@@ -164,7 +167,7 @@ SmartPanelExt.prototype = {
     },
 
     _onScroll : function(actor, event) {
-        if (this.checkEventSource(actor, event)) return Clutter.EVENT_PROPAGATE;
+        if (this.is_disabled || this.checkEventSource(actor, event)) return Clutter.EVENT_PROPAGATE;
         let currentTime = Date.now();
         let direction = event.get_scroll_direction();
 
@@ -377,7 +380,7 @@ SmartPanelExt.prototype = {
            if (this.workspaceSwitcherExt) {
               this.workspaceSwitcherExt.ExtSwitchToWorkspace(reqWs);
            } else {
-              reqWs.activate(global.get_current_time()); 
+              reqWs.activate(global.get_current_time());
               this.showWorkspaceOSD();
            }
         }

--- a/smart-panel@mohammad-sn/files/smart-panel@mohammad-sn/metadata.json
+++ b/smart-panel@mohammad-sn/files/smart-panel@mohammad-sn/metadata.json
@@ -23,7 +23,7 @@
   ],
   "description": "Switch between workspaces, show desktop, activate overview or expo, ... by scrolling, double click, mouse gestures etc on free space of the panel.",
   "name": "Smart Panel",
-  "version": "1.4.2",
+  "version": "1.4.3",
   "uuid": "smart-panel@mohammad-sn",
   "url": "https://cinnamon-spices.linuxmint.com/extensions/view/80",
   "author": "mohammad-sn"


### PR DESCRIPTION
Concerned extensions:

- smart-panel@mohammad-sn @mohammad-sn 
- DesktopCube@yare @klangman 

This PR prevents Cinnamon 6.4 from being frozen by critical errors whose messages flood `~/.xsession-errors`.
These errors can occur when Cinnamon starts up, but especially when it is restarted.
