### PR TITLE
[BlurCinnamon@klangman] V1.1.0 Unique panel effects / fixes

### DIFF
--- a/BlurCinnamon@klangman/CHANGELOG.md
+++ b/BlurCinnamon@klangman/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.1.0
+
+- Added the ability to apply different effects for every panel (or disable effects for some panels) based on the panel location and the monitor it is on
+- Fixed the blur overlay animation for showing/hiding a panel when the panel is not set to "Always show panel"
+- Simplify the settings: always show the dimming color but default to black giving a traditional dimming effect
+- Added an option to prevent the extension from modifying the panel setting, so it it will only add a blur effect under the panel. This is useful when using a theme that is already transparent and you want the themes settings to remain
+
 ## 1.0.0
 
 * Initial version committed to cinnamon spices

--- a/BlurCinnamon@klangman/README.md
+++ b/BlurCinnamon@klangman/README.md
@@ -7,9 +7,10 @@ A Cinnamon extension to Dim, Blur and Colorize parts of the Cinnamon Desktop.
 1. Gaussian blur algorithm (borrowed from the Gnome extension Blur-my-Shell) with a user configurable intensity
 2. Dimming overlay with user configurable color and intensity (0-100%, transparent to a solid color)
 3. Simple blur algorithm (the Cinnamon built-in algorithm) which I would only recommend for very old computers
-4. Makes the Panels and the Expo transparent so that the desktop background image effects are visible
+4. Makes the Panels and the Expo transparent so that the desktop background image blur effects are visible
 5. Applies blurring, colorization and dimming effects to all Panels, the Overview and the Expo
 6. You can use general settings for Panels/Overview/Expo or use unique settings for each Cinnamon component
+7. Allows unique settings for each panel based on it's location and the monitor is is on
 
 ## Requirements
 

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/extension.js
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/extension.js
@@ -34,6 +34,7 @@ const Mainloop      = imports.mainloop;
 const GaussianBlur = require("./gaussian_blur");
 
 const ANIMATION_TIME = 0.25;
+const AUTOHIDE_ANIMATION_TIME = 0.2;  // This is a copy of "Panel.AUTOHIDE_ANIMATION_TIME", we can't legally access it since it's a const and EC6 does not allow it
 
 let originalAnimateOverview;
 let originalAnimateExpo;
@@ -49,6 +50,17 @@ const BlurType = {
    Gaussian: 2
 }
 
+const PanelLoc = {
+   All: 0,
+   Top: 1,
+   Bottom: 2,
+   Left: 3,
+   Right: 4
+}
+
+const PanelMonitor = {
+   All: 100
+}
 
 function _animateVisibleOverview() {
    if (this.visible || this.animationInProgress)
@@ -60,7 +72,6 @@ function _animateVisibleOverview() {
 
    let blurType = (settings.overviewOverride) ? settings.overviewBlurType : settings.blurType;
    let radius = (settings.overviewOverride) ? settings.overviewRadius : settings.radius;
-   let colorBlend = (settings.overviewOverride) ? settings.overviewColorBlend : settings.colorBlend;
    let blendColor = (settings.overviewOverride) ? settings.overviewBlendColor : settings.blendColor;
    let opacity = (settings.overviewOverride) ? settings.overviewOpacity : settings.opacity;
 
@@ -77,7 +88,7 @@ function _animateVisibleOverview() {
    }
    // Get the overview's backgroundShade child and set it's color to see-through solid black/"Color blend" color
    let backgroundShade = children[1];
-   let [ret,color] = Clutter.Color.from_string( (colorBlend) ? blendColor : "rgba(0,0,0,1)" );
+   let [ret,color] = Clutter.Color.from_string( blendColor );
    backgroundShade.set_opacity(0);
    backgroundShade.set_background_color(color);
 
@@ -95,7 +106,6 @@ function _animateVisibleExpo() {
 
    let blurType = (settings.expoOverride) ? settings.expoBlurType : settings.blurType;
    let radius = (settings.expoOverride) ? settings.expoRadius : settings.radius;
-   let colorBlend = (settings.expoOverride) ? settings.expoColorBlend : settings.colorBlend;
    let blendColor = (settings.expoOverride) ? settings.expoBlendColor : settings.blendColor;
    let opacity = (settings.expoOverride) ? settings.expoOpacity : settings.opacity;
    if (blurType > BlurType.None) {
@@ -114,7 +124,7 @@ function _animateVisibleExpo() {
    this._backgroundShade = backgroundShade;
    backgroundShade.set_size(global.screen_width, global.screen_height);
    this._background.add_actor(backgroundShade);
-   let [ret,color] = Clutter.Color.from_string( (colorBlend) ? blendColor : "rgba(0,0,0,1)" );
+   let [ret,color] = Clutter.Color.from_string( blendColor );
    backgroundShade.set_opacity(0);
    backgroundShade.set_background_color(color);
    // Dim the backgroundShade by making the black/"Color blend" color less see-through by the configured percentage
@@ -168,33 +178,11 @@ class BlurPanels {
          if (panel && panel.__blurredPanel && panel.__blurredPanel.background && !panel._hidden) {
             background = panel.__blurredPanel.background;
             if (global.display.get_monitor_in_fullscreen(panel.monitorIndex)) {
-               background.set_opacity(0);
                background.hide();
             } else {
-               background.set_opacity(255);
                background.show();
             }
          }
-      }
-   }
-
-   // Set the portion of the panel background that is visible to match the size of the panel
-   // When a panel is hidden, the panel exists just off the screen, so we need to adjust the clip for this.
-   _setBackgroundClip(panel, background) {
-      let actor = panel.actor;
-      let monitor = panel.monitor
-      if (panel._hidden) {
-         if (panel.panelPosition === Panel.PanelLoc.top) {
-            background.set_clip( actor.x, monitor.y, actor.width, actor.height );
-         } else if (panel.panelPosition == Panel.PanelLoc.bottom) {
-            background.set_clip( actor.x, monitor.height-actor.height, actor.width, actor.height );
-         } else if (panel.panelPosition == Panel.PanelLoc.left) {
-            background.set_clip( monitor.x, actor.y, actor.width, actor.height );
-         } else {
-            background.set_clip( monitor.width-actor.width, actor.y, actor.width, actor.height );
-         }
-      } else {
-         background.set_clip( actor.x, actor.y, actor.width, actor.height );
       }
    }
 
@@ -208,7 +196,7 @@ class BlurPanels {
             if (blurredPanel) {
                // The panel height might have changed
                let actor = panel.actor;
-               this._setBackgroundClip( panel, blurredPanel.background );
+               blurredPanel.background.set_clip( actor.x, actor.y, actor.width, actor.height );
             } else {
                // A new panel was added, so we need to apply the effects to it
                this._blurPanel( panel, i );
@@ -230,19 +218,17 @@ class BlurPanels {
 
       for ( let i=0 ; i < panels.length ; i++ ) {
          if (panels[i]) {
-            let panel = panels[i];
-            this._blurPanel( panel, i );
+            this._blurPanel(  panels[i], i );
          }
       }
    }
 
    // Create a new blur effect for the panel argument.
    _blurPanel(panel, index) {
-      let blurType = (settings.panelsOverride) ? settings.panelsBlurType : settings.blurType;
-      let radius = (settings.panelsOverride) ? settings.panelsRadius : settings.radius;
-      let colorBlend = (settings.panelsOverride) ? settings.panelsColorBlend : settings.colorBlend;
-      let blendColor = (settings.panelsOverride) ? settings.panelsBlendColor : settings.blendColor;
-      let opacity = (settings.panelsOverride) ? settings.panelsOpacity : settings.opacity;
+      let panelSettings = this._getPanelSettings(panel, index);
+      if (!panelSettings ) return;
+      let [opacity, blendColor, blurType, radius] = panelSettings;
+
       let actor = panel.actor;
       let blurredPanel = panel.__blurredPanel;
 
@@ -261,15 +247,17 @@ class BlurPanels {
          panel.__blurredPanel = blurredPanel;
          this._blurredPanels[index] = blurredPanel;
       }
-      // Set the panels color
-      let [ret,color] = Clutter.Color.from_string( (colorBlend) ? blendColor : "rgba(0,0,0,0)" );
-      color.alpha = opacity*2.55;
-      actor.set_background_color(color);
-      // Make the panel transparent
-      actor.set_style( "border-image: none;  border-color: transparent;  box-shadow: 0 0 transparent; " +
-                       "background-gradient-direction: vertical; background-gradient-start: transparent; " +
-                       "background-gradient-end: transparent;    background: transparent;" );
-
+      if (settings.allowTransparentColorPanels) {
+         // Set the panels color
+         let [ret,color] = Clutter.Color.from_string( blendColor );
+         if (!ret) { [ret,color] = Clutter.Color.from_string( "rgba(0,0,0,0)" ); }
+         color.alpha = opacity*2.55;
+         actor.set_background_color(color);
+         // Make the panel transparent
+         actor.set_style( "border-image: none;  border-color: transparent;  box-shadow: 0 0 transparent; " +
+                          "background-gradient-direction: vertical; background-gradient-start: transparent; " +
+                          "background-gradient-end: transparent;    background: transparent;" );
+      }
       // If blurring is required, create a background, create effect, clip background to cover the panel only
       if (blurType > BlurType.None) {
          let fx;
@@ -281,9 +269,8 @@ class BlurPanels {
             fx = new GaussianBlur.GaussianBlurEffect( {radius: radius, brightness: 1 , width: 0, height: 0} );
          }
          background.add_effect_with_name( "blur", fx );
-         this._setBackgroundClip( panel, background );
+         background.set_clip( panel.actor.x, panel.actor.y, panel.actor.width, panel.actor.height );
          if (panel._hidden || global.display.get_monitor_in_fullscreen(panel.monitorIndex)) {
-            background.set_opacity(0);
             background.hide();
          }
          blurredPanel.effect = fx;
@@ -298,26 +285,8 @@ class BlurPanels {
       this._signalManager.disconnectAllSignals();
 
       // Restore the panels to their original state
-      for ( let i=0 ; i < this._blurredPanels.length ; i++ ) {
-         if (panels[i] && this._blurredPanels[i]) {
-            let panel = panels[i];
-            let actor = panel.actor;
-            let blurredPanel = this._blurredPanels[i];
-
-            actor.set_background_color(blurredPanel.original_color);
-            actor.set_style(blurredPanel.original_style);
-            actor.set_style_class_name(blurredPanel.original_class);
-            actor.set_style_pseudo_class(blurredPanel.original_pseudo_class);
-            if (blurredPanel.background) {
-               blurredPanel.background.remove_effect(blurredPanel.effect);
-               blurredPanel.background.destroy();
-            }
-            this._blurredPanels[i] = null;
-            delete panel.__blurredPanel;
-            if (this.added_panelHasOpenMenus) {
-               delete panel._panelHasOpenMenus;
-            }
-         }
+      for ( let i=0 ; i < panels.length ; i++ ) {
+         this._unblurPanel(panels[i], i);
       }
 
       // Restore the original functions that we monkey patched
@@ -327,49 +296,125 @@ class BlurPanels {
       Panel.Panel.prototype._hidePanel = this._originalPanelHidePanel;
    }
 
+   _unblurPanel(panel, index) {
+      if (panel && this._blurredPanels[index]) {
+         let actor = panel.actor;
+         let blurredPanel = this._blurredPanels[index];
+
+         actor.set_background_color(blurredPanel.original_color);
+         actor.set_style(blurredPanel.original_style);
+         actor.set_style_class_name(blurredPanel.original_class);
+         actor.set_style_pseudo_class(blurredPanel.original_pseudo_class);
+         if (blurredPanel.background) {
+            blurredPanel.background.remove_effect(blurredPanel.effect);
+            blurredPanel.background.destroy();
+         }
+         this._blurredPanels[index] = null;
+         delete panel.__blurredPanel;
+         if (this.added_panelHasOpenMenus) {
+            delete panel._panelHasOpenMenus;
+         }
+      }
+   }
+
    // An extension setting controlling how the dim overlay was modified
    updateColor() {
       let panels = Main.getPanels();
-      let opacity    = (settings.panelsOverride) ? settings.panelsOpacity    : settings.opacity;
-      let colorBlend = (settings.panelsOverride) ? settings.panelsColorBlend : settings.colorBlend;
-      let blendColor = (settings.panelsOverride) ? settings.panelsBlendColor : settings.blendColor;
       for ( let i=0 ; i < this._blurredPanels.length ; i++ ) {
          if (panels[i] && this._blurredPanels[i]) {
-            let [ret,color] = Clutter.Color.from_string( (colorBlend) ? blendColor : "rgba(0,0,0,0)" );
-            color.alpha = opacity*2.55;
-            panels[i].actor.set_background_color(color);
+            let panelSettings = this._getPanelSettings(panels[i], i);
+            if (panelSettings) {
+               let actor = panels[i].actor;
+               let [opacity, blendColor, blurType, radius] = panelSettings;
+               if (settings.allowTransparentColorPanels) {
+                  let [ret,color] = Clutter.Color.from_string( blendColor );
+                  if (!ret) { [ret,color] = Clutter.Color.from_string( "rgba(0,0,0,0)" ); }
+                  color.alpha = opacity*2.55;
+                  actor.set_background_color(color);
+                  // Make the panel transparent
+                  actor.set_style( "border-image: none;  border-color: transparent;  box-shadow: 0 0 transparent; " +
+                                   "background-gradient-direction: vertical; background-gradient-start: transparent; " +
+                                   "background-gradient-end: transparent;    background: transparent;" );
+               } else {
+                  let blurredPanel = this._blurredPanels[i]
+                  actor.set_background_color(blurredPanel.original_color);
+                  actor.set_style(blurredPanel.original_style);
+                  actor.set_style_class_name(blurredPanel.original_class);
+                  actor.set_style_pseudo_class(blurredPanel.original_pseudo_class);
+               }
+            }
          }
       }
    }
 
    // An extension setting controlling how to blur is handled was modified
    updateBlur() {
-      let blurType = (settings.panelsOverride) ? settings.panelsBlurType : settings.blurType;
-      let radius = (settings.panelsOverride)   ? settings.panelsRadius   : settings.radius;
       let panels = Main.getPanels();
       for ( let i=0 ; i < panels.length ; i++ ) {
          if (panels[i]) {
-            let blurredPanel = panels[i].__blurredPanel;
-            if (blurredPanel) {
-               if (blurType !== BlurType.None && !blurredPanel.background) {
+            let panelSettings = this._getPanelSettings(panels[i], i);
+            if (panelSettings) {
+               let [opacity, blendColor, blurType, radius] = panelSettings;
+               let blurredPanel = panels[i].__blurredPanel;
+               if (blurredPanel) {
+                  if (blurType !== BlurType.None && !blurredPanel.background) {
+                     this._blurPanel(panels[i], i);
+                  } else if (blurType === BlurType.None && blurredPanel.background) {
+                     blurredPanel.background.remove_effect(blurredPanel.effect);
+                     blurredPanel.background.destroy();
+                     blurredPanel.background = null;
+                  } else if (blurType === BlurType.Simple && blurredPanel.effect instanceof GaussianBlur.GaussianBlurEffect) {
+                     blurredPanel.background.remove_effect(blurredPanel.effect);
+                     blurredPanel.effect =  new Clutter.BlurEffect();
+                     blurredPanel.background.add_effect_with_name( "blur", blurredPanel.effect );
+                  } else if (blurType === BlurType.Gaussian && blurredPanel.effect instanceof Clutter.BlurEffect) {
+                     blurredPanel.background.remove_effect(blurredPanel.effect);
+                     blurredPanel.effect = new GaussianBlur.GaussianBlurEffect( {radius: radius, brightness: 1, width: 0, height: 0} );
+                     blurredPanel.background.add_effect_with_name( "blur", blurredPanel.effect );
+                  } else if (blurType === BlurType.Gaussian && blurredPanel.radius !== radius) {
+                     blurredPanel.effect.radius = radius;
+                  }
+               } else {
                   this._blurPanel(panels[i], i);
-               } else if (blurType === BlurType.None && blurredPanel.background) {
-                  blurredPanel.background.remove_effect(blurredPanel.effect);
-                  blurredPanel.background.destroy();
-                  blurredPanel.background = null;
-               } else if (blurType === BlurType.Simple && blurredPanel.effect instanceof GaussianBlur.GaussianBlurEffect) {
-                  blurredPanel.background.remove_effect(blurredPanel.effect);
-                  blurredPanel.effect =  new Clutter.BlurEffect();
-                  blurredPanel.background.add_effect_with_name( "blur", blurredPanel.effect );
-               } else if (blurType === BlurType.Gaussian && blurredPanel.effect instanceof Clutter.BlurEffect) {
-                  blurredPanel.background.remove_effect(blurredPanel.effect);
-                  blurredPanel.effect = new GaussianBlur.GaussianBlurEffect( {radius: radius, brightness: 1, width: 0, height: 0} );
-                  blurredPanel.background.add_effect_with_name( "blur", blurredPanel.effect );
-               } else if (blurType === BlurType.Gaussian && blurredPanel.radius !== radius) {
-                  blurredPanel.effect.radius = radius;
                }
+            } else {
+               // No settings found to apply to this panel, so remove all effects for this panel
+               this._unblurPanel(panels[i], i)
             }
          }
+      }
+   }
+
+   // Determine the settings that should apply for the panel argument panel
+   _getPanelSettings(panel, index) {
+      if (settings.panelsOverride && settings.enablePanelUniqueSettings) {
+         for( let i=0 ; i < settings.panelUniqueSettings.length ; i++ ) {
+            let uniqueSetting = settings.panelUniqueSettings[i];
+            if (uniqueSetting.enabled) {
+               if (uniqueSetting.panels !== PanelLoc.All) {
+                  if ( (panel.panelPosition === Panel.PanelLoc.top && uniqueSetting.panels !== PanelLoc.Top) ||
+                       (panel.panelPosition === Panel.PanelLoc.bottom && uniqueSetting.panels !== PanelLoc.Bottom) ||
+                       (panel.panelPosition === Panel.PanelLoc.left && uniqueSetting.panels !== PanelLoc.Left) ||
+                       (panel.panelPosition === Panel.PanelLoc.right && uniqueSetting.panels !== PanelLoc.Right) )
+                  {
+                     continue;
+                  }
+               }
+               if (uniqueSetting.monitors !== PanelMonitor.All) {
+                  if (panel.monitorIndex !== uniqueSetting.monitors) {
+                     continue;
+                  }
+               }
+               return [uniqueSetting.opacity, uniqueSetting.color, uniqueSetting.blurtype, uniqueSetting.radius];
+            }
+         }
+         return null;
+      } else {
+         let radius = (settings.panelsOverride) ? settings.panelsRadius : settings.radius;
+         let blurType = (settings.panelsOverride) ? settings.panelsBlurType : settings.blurType;
+         let blendColor = (settings.panelsOverride) ? settings.panelsBlendColor : settings.blendColor;
+         let opacity = (settings.panelsOverride) ? settings.panelsOpacity : settings.opacity;
+         return [opacity, blendColor, blurType, radius];
       }
    }
 
@@ -379,7 +424,7 @@ class BlurPanels {
          if (this.__blurredPanel && this.__blurredPanel.background && !global.display.get_monitor_in_fullscreen(this.monitorIndex) && !this._hidden) {
             this.__blurredPanel.background.show();
             this.__blurredPanel.background.ease(
-               {opacity: 255, duration: Panel.Panel.AUTOHIDE_ANIMATION_TIME * 1000, mode: Clutter.AnimationMode.EASE_OUT_QUAD } );
+               {opacity: 255, duration: AUTOHIDE_ANIMATION_TIME * 1000, mode: Clutter.AnimationMode.EASE_OUT_QUAD } );
          }
       } catch (e) {}
       blurExtensionThis._originalPanelEnable.apply(this, params);
@@ -389,7 +434,7 @@ class BlurPanels {
       try {
          if (this.__blurredPanel && this. __blurredPanel.background && !this._hidden) {
             this.__blurredPanel.background.ease(
-               {opacity: 0, duration: Panel.Panel.AUTOHIDE_ANIMATION_TIME * 1000, mode: Clutter.AnimationMode.EASE_OUT_QUAD,
+               {opacity: 0, duration: AUTOHIDE_ANIMATION_TIME * 1000, mode: Clutter.AnimationMode.EASE_OUT_QUAD,
                   onComplete: () => { this.__blurredPanel.background.hide(); } });
          }
       } catch (e) {}
@@ -399,8 +444,11 @@ class BlurPanels {
    blurShowPanel(...params) {
       try {
          if (!this._disabled && this._hidden) {
+            let background = this.__blurredPanel.background;
             this.__blurredPanel.background.show();
-            Tweener.addTween(this.__blurredPanel.background, {opacity: 255, time: Panel.Panel.AUTOHIDE_ANIMATION_TIME} );
+            Tweener.addTween(this.__blurredPanel.background, {time: AUTOHIDE_ANIMATION_TIME, onUpdateScope: this, onUpdate: () => {
+               this.__blurredPanel.background.set_clip( this.actor.x, this.actor.y, this.actor.width, this.actor.height );
+            } } );
          }
       } catch (e) {}
       blurExtensionThis._originalPanelShowPanel.apply(this, params);
@@ -410,7 +458,9 @@ class BlurPanels {
       try {
          let background = this.__blurredPanel.background;
          if (background && background.is_visible() && !this._destroyed && (!this._shouldShow || force) && !this._panelHasOpenMenus()) {
-            Tweener.addTween(background, {opacity: 0, time: Panel.Panel.AUTOHIDE_ANIMATION_TIME, onComplete: () => { background.hide(); } } );
+            Tweener.addTween(background, {time: AUTOHIDE_ANIMATION_TIME, onUpdateScope: this, onUpdate: () => { 
+               this.__blurredPanel.background.set_clip( this.actor.x, this.actor.y, this.actor.width, this.actor.height ); 
+            }, onComplete: () => { background.hide(); } } );
          }
       } catch (e) {}
       blurExtensionThis._originalPanelHidePanel.apply(this, force);
@@ -423,34 +473,34 @@ class BlurSettings {
       this.settings.bind('opacity',    'opacity',    colorChanged);
       this.settings.bind('blurType',   'blurType',   blurChanged);
       this.settings.bind('radius',     'radius',     blurChanged);
-      this.settings.bind('colorBlend', 'colorBlend', colorChanged);
       this.settings.bind('blendColor', 'blendColor', colorChanged);
 
       this.settings.bind('overview-opacity',    'overviewOpacity');
       this.settings.bind('overview-blurType',   'overviewBlurType');
       this.settings.bind('overview-radius',     'overviewRadius');
-      this.settings.bind('overview-colorBlend', 'overviewColorBlend');
       this.settings.bind('overview-blendColor', 'overviewBlendColor');
 
       this.settings.bind('expo-opacity',    'expoOpacity');
       this.settings.bind('expo-blurType',   'expoBlurType');
       this.settings.bind('expo-radius',     'expoRadius');
-      this.settings.bind('expo-colorBlend', 'expoColorBlend');
       this.settings.bind('expo-blendColor', 'expoBlendColor');
 
       this.settings.bind('panels-opacity',    'panelsOpacity',    colorChanged);
       this.settings.bind('panels-blurType',   'panelsBlurType',   blurChanged);
       this.settings.bind('panels-radius',     'panelsRadius',     blurChanged);
-      this.settings.bind('panels-colorBlend', 'panelsColorBlend', colorChanged);
       this.settings.bind('panels-blendColor', 'panelsBlendColor', colorChanged);
 
       this.settings.bind('enable-overview-override', 'overviewOverride');
       this.settings.bind('enable-expo-override',     'expoOverride');
-      this.settings.bind('enable-panels-override',   'panelsOverride', panelsOverrideChangled);
+      this.settings.bind('enable-panels-override',   'panelsOverride', panelsSettingsChangled);
 
       this.settings.bind('enable-overview-effects', 'enableOverviewEffects', enableOverviewChanged);
       this.settings.bind('enable-expo-effects',     'enableExpoEffects',     enableExpoChanged);
       this.settings.bind('enable-panels-effects',   'enablePanelsEffects',   enablePanelsChanged);
+
+      this.settings.bind('enable-panel-unique-settings', 'enablePanelUniqueSettings');
+      this.settings.bind('panel-unique-settings', 'panelUniqueSettings', panelsSettingsChangled);
+      this.settings.bind('allow-transparent-color-panels', 'allowTransparentColorPanels', colorChanged);
    }
 }
 
@@ -466,7 +516,7 @@ function blurChanged() {
    }
 }
 
-function panelsOverrideChangled() {
+function panelsSettingsChangled() {
    if (blurPanels) {
       blurPanels.updateBlur();
       blurPanels.updateColor();

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/settings-schema.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/settings-schema.json
@@ -32,7 +32,7 @@
       "generic-effect-settings" : {
          "type" : "section",
          "title" : "Generic effect settings",
-         "keys" : ["opacity", "colorBlend", "blendColor", "blurType", "radius"]
+         "keys" : ["opacity", "blendColor", "blurType", "radius"]
       },
 
       "overview-override" : {
@@ -44,7 +44,7 @@
          "type" : "section",
          "title" : "Overview effect settings",
          "dependency" : "enable-overview-override=1",
-         "keys" : ["overview-opacity", "overview-colorBlend", "overview-blendColor", "overview-blurType", "overview-radius"]
+         "keys" : ["overview-opacity", "overview-blendColor", "overview-blurType", "overview-radius"]
       },
 
       "expo-override" : {
@@ -56,19 +56,19 @@
          "type" : "section",
          "title" : "Expo effect settings",
          "dependency" : "enable-expo-override=1",
-         "keys" : ["expo-opacity", "expo-colorBlend", "expo-blendColor", "expo-blurType", "expo-radius"]
+         "keys" : ["expo-opacity", "expo-blendColor", "expo-blurType", "expo-radius"]
       },
 
       "panels-override" : {
          "type" : "section",
          "title" : "Panels settings",
-         "keys" : ["enable-panels-override", "panels-info"]
+         "keys" : ["enable-panels-override", "panels-info", "allow-transparent-color-panels" ]
       },
       "panels-effect-settings" : {
          "type" : "section",
          "title" : "Panel effects settings",
-         "dependency" : "enable-panels-override=1",
-         "keys" : ["panels-opacity", "panels-colorBlend", "panels-blendColor", "panels-blurType", "panels-radius"]
+         "dependency" : "enable-panels-override",
+         "keys" : ["enable-panel-unique-settings", "panel-unique-settings", "panels-opacity", "panels-blendColor", "panels-blurType", "panels-radius"]
       }
 
    },
@@ -107,6 +107,12 @@
         "description" : "Panel effects are currently disabled under the General tab.",
         "dependency" : "!enable-panels-effects"
     },
+    "allow-transparent-color-panels" : {
+        "type": "switch",
+        "description": "Modify the panels transparency and background color (recommended)",
+        "tooltip": "Allow this extension to modify the panels transparency and background color settings. If this is disabled the extension will only apply a blur overlay under the panels. This setting should only be disabled when the theme already uses transparent panels and you want the themes setting to apply",
+        "default": true
+    },
 
     "enable-overview-override" : {
         "type": "switch",
@@ -127,6 +133,34 @@
         "default": false
     },
 
+    "enable-panel-unique-settings" : {
+        "type": "switch",
+        "description": "Use unique effect settings for each panel",
+        "dependency" : "enable-panels-override",
+        "default": false
+    },
+
+    "panel-unique-settings" : {
+        "type" : "list",
+        "description" : "Panel specific settings",
+        "dependency" : "enable-panel-unique-settings",
+        "columns" : [
+            {"id": "enabled",   "title": "Enabled",   "type": "boolean", "default": true},
+            {"id": "panels",    "title": "Panel",     "type": "integer", "default": 0, "options": { "All" : 0, "Top" : 1, "Bottom" : 2, "Left" : 3, "Right" : 4 } },
+            {"id": "monitors",  "title": "Monitor",   "type": "integer", "default": 0, "options": { "All" : 100, "1" : 0, "2" : 1, "3" : 2, "4" : 3 } },
+            {"id": "opacity",   "title": "Dimming",   "type": "integer", "default": 40,  "min": 0, "max": 100},
+            {"id": "color",     "title": "Color",     "type": "string",  "default": "rgb(0,0,0)"},
+            {"id": "blurtype",  "title": "Blur",      "type": "integer", "default": 2, "options": { "None": 0, "Simple": 1, "Gaussian": 2 } },
+            {"id": "radius",    "title": "Intensity", "type": "integer", "default": 10,  "min": 0, "max": 100}
+        ],
+        "tooltip": "Defines the effects applied to different panels. If a panel does not meet the criteria of any enabled entry in this list, it will have no effects applied. The settings of the first entry in this list that can apply to a given panel will take effect. The color field is in the rgb(#,#,#) syntax and black will be used when a color is not provided or is in an incorrect syntax",
+        "default" : [
+            { "enabled": true, "panels": 1, "monitors": 0, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10 },
+            { "enabled": true, "panels": 2, "monitors": 0, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10 },
+            { "enabled": true, "panels": 3, "monitors": 0, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10 },
+            { "enabled": true, "panels": 4, "monitors": 0, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10 }
+        ]
+    },
 
     "opacity" : {
         "type": "scale",
@@ -137,18 +171,11 @@
         "step": 1
     },
 
-    "colorBlend" : {
-        "type": "switch",
-        "description": "Enable color blend effect",
-        "tooltip": "Use a custom color as the dimming overlay color. The color intensity can be controlled using the \"Dim Background\" slider control above",
-        "default": false
-    },
-
     "blendColor": {
         "type": "colorchooser",
-        "description" : "Blend effect Color",
-        "dependency" : "colorBlend=true",
-        "default": "rgb(0,0,0)"
+        "description" : "Dimming overlay color",
+        "default": "rgb(0,0,0)",
+        "tooltip": "Defines the color that is blended into the background based on the dimming control above. Use black for a normal dimming effect or some other color for a color blend effect"
     },
 
     "blurType": {
@@ -184,18 +211,11 @@
         "step": 1
     },
 
-    "overview-colorBlend" : {
-        "type": "switch",
-        "description": "Enable color blend effect",
-        "tooltip": "Use a custom color as the dimming overlay color. The color intensity can be controlled using the \"Dim Background\" slider control above",
-        "default": false
-    },
-
     "overview-blendColor": {
         "type": "colorchooser",
-        "description" : "Blend effect Color",
-        "dependency" : "overview-colorBlend=true",
-        "default": "rgb(0,0,0)"
+        "description" : "Dimming overlay color",
+        "default": "rgb(0,0,0)",
+        "tooltip": "Defines the color that is blended into the background based on the dimming control above. Use black for a normal dimming effect or some other color for a color blend effect"
     },
 
     "overview-blurType": {
@@ -228,21 +248,16 @@
         "min": 0,
         "max": 100,
         "default": 40,
-        "step": 1
-    },
-
-    "expo-colorBlend" : {
-        "type": "switch",
-        "description": "Enable color blend effect",
-        "tooltip": "Use a custom color as the dimming overlay color. The color intensity can be controlled using the \"Dim Background\" slider control above",
-        "default": false
+        "step": 1,
+        "dependency" : "enable-expo-override=1"
     },
 
     "expo-blendColor": {
         "type": "colorchooser",
-        "description" : "Blend effect Color",
-        "dependency" : "expo-colorBlend=true",
-        "default": "rgb(0,0,0)"
+        "description" : "Dimming overlay color",
+        "default": "rgb(0,0,0)",
+        "dependency" : "enable-expo-override=1",
+        "tooltip": "Defines the color that is blended into the background based on the dimming control above. Use black for a normal dimming effect or some other color for a color blend effect"
     },
 
     "expo-blurType": {
@@ -254,7 +269,8 @@
             "Gaussian": 2
         },
         "description": "Type of blur effect",
-        "tooltip": "What type of blur algorithm should be used to blur the background"
+        "tooltip": "What type of blur algorithm should be used to blur the background",
+        "dependency" : "enable-expo-override=1"
     },
 
     "expo-radius": {
@@ -263,9 +279,9 @@
         "min" : 0.0,
         "max" : 100,
         "step" : 0.1,
-        "dependency" : "expo-blurType=2",
         "tooltip": "Adjusts the intensity of the blur effect by changing the radius use by the effect.",
-        "default": 9
+        "default": 9,
+        "dependency" : "enable-expo-override=1"
     },
 
 
@@ -275,21 +291,16 @@
         "min": 0,
         "max": 100,
         "default": 30,
-        "step": 1
-    },
-
-    "panels-colorBlend" : {
-        "type": "switch",
-        "description": "Enable color blend effect",
-        "tooltip": "Use a custom color as the dimming overlay color. The color intensity can be controlled using the \"Dim Background\" slider control above",
-        "default": false
+        "step": 1,
+        "dependency" : "!enable-panel-unique-settings"
     },
 
     "panels-blendColor": {
         "type": "colorchooser",
-        "description" : "Blend effect Color",
-        "dependency" : "panels-colorBlend=true",
-        "default": "rgb(0,0,0)"
+        "description" : "Dimming ovrerlay color",
+        "default": "rgb(0,0,0)",
+        "dependency" : "!enable-panel-unique-settings",
+        "tooltip": "Defines the color that is blended into the background based on the dimming control above. Use black for a normal dimming effect or some other color for a color blend effect"
     },
 
     "panels-blurType": {
@@ -301,17 +312,18 @@
             "Gaussian": 2
         },
         "description": "Type of blur effect",
-        "tooltip": "What type of blur algorithm should be used to blur the background"
+        "tooltip": "What type of blur algorithm should be used to blur the background",
+        "dependency" : "!enable-panel-unique-settings"
     },
 
     "panels-radius": {
         "type": "scale",
-        "description" : "Gaussian blur intensity",
+        "description" : "Blur intensity (Gaussian only)",
         "min" : 0.0,
         "max" : 100,
         "step" : 0.1,
-        "dependency" : "panels-blurType=2",
-        "tooltip": "Adjusts the intensity of the blur effect by changing the radius use by the effect.",
-        "default": 6
+        "tooltip": "Adjusts the intensity of the Gaussian blur effect by changing the radius use by the effect. This setting does not effect the Simple blur type",
+        "default": 6,
+        "dependency" : "!enable-panel-unique-settings"
     }
 }

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
@@ -1,7 +1,7 @@
 {
     "uuid": "BlurCinnamon@klangman",
     "name": "Blur Cinnamon",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Allows you to blur, colorize and adjust the dimming of some Cinnamon Desktop components (i.e. Panels, Overview, Expo)",
     "url": "https://github.com/klangman/BlurCinnamon",
     "cinnamon-version": [

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
@@ -1,14 +1,14 @@
 # BLUR CINNAMON
 # This file is put in the public domain.
-# klangman, 2017
+# klangman, 2025
 #
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: BlurCinnamon@klangman 1.0.0\n"
+"Project-Id-Version: BlurCinnamon@klangman 1.1.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-11 11:33-0500\n"
+"POT-Creation-Date: 2025-01-17 11:04-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -106,6 +106,18 @@ msgstr ""
 msgid "Panel effects are currently disabled under the General tab."
 msgstr ""
 
+#. 6.0->settings-schema.json->allow-transparent-color-panels->description
+msgid "Modify the panels transparency and background color (recommended)"
+msgstr ""
+
+#. 6.0->settings-schema.json->allow-transparent-color-panels->tooltip
+msgid ""
+"Allow this extension to modify the panels transparency and background color "
+"settings. If this is disabled the extension will only apply a blur overlay "
+"under the panels. This setting should only be disabled when the theme "
+"already uses transparent panels and you want the themes setting to apply"
+msgstr ""
+
 #. 6.0->settings-schema.json->enable-overview-override->description
 msgid "Override the generic effect settings for the Overview"
 msgstr ""
@@ -118,6 +130,52 @@ msgstr ""
 msgid "Override the generic effect settings for the Panels"
 msgstr ""
 
+#. 6.0->settings-schema.json->enable-panel-unique-settings->description
+msgid "Use unique effect settings for each panel"
+msgstr ""
+
+#. 6.0->settings-schema.json->panel-unique-settings->description
+msgid "Panel specific settings"
+msgstr ""
+
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Enabled"
+msgstr ""
+
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Panel"
+msgstr ""
+
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Monitor"
+msgstr ""
+
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Dimming"
+msgstr ""
+
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Color"
+msgstr ""
+
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Intensity"
+msgstr ""
+
+#. 6.0->settings-schema.json->panel-unique-settings->tooltip
+msgid ""
+"Defines the effects applied to different panels. If a panel does not meet "
+"the criteria of any enabled entry in this list, it will have no effects "
+"applied. The settings of the first entry in this list that can apply to a "
+"given panel will take effect. The color field is in the rgb(#,#,#) syntax "
+"and black will be used when a color is not provided or is in an incorrect "
+"syntax"
+msgstr ""
+
 #. 6.0->settings-schema.json->opacity->description
 #. 6.0->settings-schema.json->overview-opacity->description
 #. 6.0->settings-schema.json->expo-opacity->description
@@ -125,27 +183,20 @@ msgstr ""
 msgid "Dim Background (percentage)"
 msgstr ""
 
-#. 6.0->settings-schema.json->colorBlend->description
-#. 6.0->settings-schema.json->overview-colorBlend->description
-#. 6.0->settings-schema.json->expo-colorBlend->description
-#. 6.0->settings-schema.json->panels-colorBlend->description
-msgid "Enable color blend effect"
-msgstr ""
-
-#. 6.0->settings-schema.json->colorBlend->tooltip
-#. 6.0->settings-schema.json->overview-colorBlend->tooltip
-#. 6.0->settings-schema.json->expo-colorBlend->tooltip
-#. 6.0->settings-schema.json->panels-colorBlend->tooltip
-msgid ""
-"Use a custom color as the dimming overlay color. The color intensity can be "
-"controlled using the \"Dim Background\" slider control above"
-msgstr ""
-
 #. 6.0->settings-schema.json->blendColor->description
 #. 6.0->settings-schema.json->overview-blendColor->description
 #. 6.0->settings-schema.json->expo-blendColor->description
-#. 6.0->settings-schema.json->panels-blendColor->description
-msgid "Blend effect Color"
+msgid "Dimming overlay color"
+msgstr ""
+
+#. 6.0->settings-schema.json->blendColor->tooltip
+#. 6.0->settings-schema.json->overview-blendColor->tooltip
+#. 6.0->settings-schema.json->expo-blendColor->tooltip
+#. 6.0->settings-schema.json->panels-blendColor->tooltip
+msgid ""
+"Defines the color that is blended into the background based on the dimming "
+"control above. Use black for a normal dimming effect or some other color for "
+"a color blend effect"
 msgstr ""
 
 #. 6.0->settings-schema.json->blurType->options
@@ -186,15 +237,27 @@ msgstr ""
 #. 6.0->settings-schema.json->radius->description
 #. 6.0->settings-schema.json->overview-radius->description
 #. 6.0->settings-schema.json->expo-radius->description
-#. 6.0->settings-schema.json->panels-radius->description
 msgid "Gaussian blur intensity"
 msgstr ""
 
 #. 6.0->settings-schema.json->radius->tooltip
 #. 6.0->settings-schema.json->overview-radius->tooltip
 #. 6.0->settings-schema.json->expo-radius->tooltip
-#. 6.0->settings-schema.json->panels-radius->tooltip
 msgid ""
 "Adjusts the intensity of the blur effect by changing the radius use by the "
 "effect."
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blendColor->description
+msgid "Dimming ovrerlay color"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-radius->description
+msgid "Blur intensity (Gaussian only)"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-radius->tooltip
+msgid ""
+"Adjusts the intensity of the Gaussian blur effect by changing the radius use "
+"by the effect. This setting does not effect the Simple blur type"
 msgstr ""

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-11 11:33-0500\n"
+"POT-Creation-Date: 2025-01-17 11:04-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -117,6 +117,18 @@ msgid "Panel effects are currently disabled under the General tab."
 msgstr ""
 "Los efectos del panel están actualmente deshabilitados en la pestaña General."
 
+#. 6.0->settings-schema.json->allow-transparent-color-panels->description
+msgid "Modify the panels transparency and background color (recommended)"
+msgstr ""
+
+#. 6.0->settings-schema.json->allow-transparent-color-panels->tooltip
+msgid ""
+"Allow this extension to modify the panels transparency and background color "
+"settings. If this is disabled the extension will only apply a blur overlay "
+"under the panels. This setting should only be disabled when the theme "
+"already uses transparent panels and you want the themes setting to apply"
+msgstr ""
+
 #. 6.0->settings-schema.json->enable-overview-override->description
 msgid "Override the generic effect settings for the Overview"
 msgstr "Anular la configuración generica de efectos para la vista general"
@@ -129,6 +141,55 @@ msgstr "Anular la configuración generica de efectos para la exposición"
 msgid "Override the generic effect settings for the Panels"
 msgstr "Anular la configuración generica de efectos para los paneles"
 
+#. 6.0->settings-schema.json->enable-panel-unique-settings->description
+#, fuzzy
+msgid "Use unique effect settings for each panel"
+msgstr "Anular la configuración generica de efectos para los paneles"
+
+#. 6.0->settings-schema.json->panel-unique-settings->description
+#, fuzzy
+msgid "Panel specific settings"
+msgstr "Configuración de efectos del panel"
+
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Enabled"
+msgstr ""
+
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+#, fuzzy
+msgid "Panel"
+msgstr "Paneles"
+
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Monitor"
+msgstr ""
+
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Dimming"
+msgstr ""
+
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Color"
+msgstr ""
+
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Intensity"
+msgstr ""
+
+#. 6.0->settings-schema.json->panel-unique-settings->tooltip
+msgid ""
+"Defines the effects applied to different panels. If a panel does not meet "
+"the criteria of any enabled entry in this list, it will have no effects "
+"applied. The settings of the first entry in this list that can apply to a "
+"given panel will take effect. The color field is in the rgb(#,#,#) syntax "
+"and black will be used when a color is not provided or is in an incorrect "
+"syntax"
+msgstr ""
+
 #. 6.0->settings-schema.json->opacity->description
 #. 6.0->settings-schema.json->overview-opacity->description
 #. 6.0->settings-schema.json->expo-opacity->description
@@ -136,31 +197,21 @@ msgstr "Anular la configuración generica de efectos para los paneles"
 msgid "Dim Background (percentage)"
 msgstr "Fondo atenuado (porcentaje)"
 
-#. 6.0->settings-schema.json->colorBlend->description
-#. 6.0->settings-schema.json->overview-colorBlend->description
-#. 6.0->settings-schema.json->expo-colorBlend->description
-#. 6.0->settings-schema.json->panels-colorBlend->description
-msgid "Enable color blend effect"
-msgstr "Habilitar el efecto de mezcla de colores"
-
-#. 6.0->settings-schema.json->colorBlend->tooltip
-#. 6.0->settings-schema.json->overview-colorBlend->tooltip
-#. 6.0->settings-schema.json->expo-colorBlend->tooltip
-#. 6.0->settings-schema.json->panels-colorBlend->tooltip
-msgid ""
-"Use a custom color as the dimming overlay color. The color intensity can be "
-"controlled using the \"Dim Background\" slider control above"
-msgstr ""
-"Utilice un color personalizado como color de fondo de atenuación. La "
-"intensidad del color puede controlarse mediante el control deslizante "
-"\"Atenuar fondo\" situado más arriba"
-
 #. 6.0->settings-schema.json->blendColor->description
 #. 6.0->settings-schema.json->overview-blendColor->description
 #. 6.0->settings-schema.json->expo-blendColor->description
-#. 6.0->settings-schema.json->panels-blendColor->description
-msgid "Blend effect Color"
-msgstr "Efecto de mezcla de colores"
+msgid "Dimming overlay color"
+msgstr ""
+
+#. 6.0->settings-schema.json->blendColor->tooltip
+#. 6.0->settings-schema.json->overview-blendColor->tooltip
+#. 6.0->settings-schema.json->expo-blendColor->tooltip
+#. 6.0->settings-schema.json->panels-blendColor->tooltip
+msgid ""
+"Defines the color that is blended into the background based on the dimming "
+"control above. Use black for a normal dimming effect or some other color for "
+"a color blend effect"
+msgstr ""
 
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
@@ -201,17 +252,32 @@ msgstr ""
 #. 6.0->settings-schema.json->radius->description
 #. 6.0->settings-schema.json->overview-radius->description
 #. 6.0->settings-schema.json->expo-radius->description
-#. 6.0->settings-schema.json->panels-radius->description
 msgid "Gaussian blur intensity"
 msgstr "Intensidad del desenfoque gaussiano"
 
 #. 6.0->settings-schema.json->radius->tooltip
 #. 6.0->settings-schema.json->overview-radius->tooltip
 #. 6.0->settings-schema.json->expo-radius->tooltip
-#. 6.0->settings-schema.json->panels-radius->tooltip
 msgid ""
 "Adjusts the intensity of the blur effect by changing the radius use by the "
 "effect."
+msgstr ""
+"Ajusta la intensidad del efecto de desenfoque cambiando el radio utilizado "
+"por el efecto."
+
+#. 6.0->settings-schema.json->panels-blendColor->description
+msgid "Dimming ovrerlay color"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-radius->description
+msgid "Blur intensity (Gaussian only)"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-radius->tooltip
+#, fuzzy
+msgid ""
+"Adjusts the intensity of the Gaussian blur effect by changing the radius use "
+"by the effect. This setting does not effect the Simple blur type"
 msgstr ""
 "Ajusta la intensidad del efecto de desenfoque cambiando el radio utilizado "
 "por el efecto."


### PR DESCRIPTION
- Added the ability to apply different effects for every panel (or disable effects for some panels) based on the panel location and the monitor it is on
- Fixed the blur overlay animation for showing/hiding a panel when the panel is not set to "Always show panel"
- Simplify the settings: always show the dimming color but default to black giving a traditional dimming effect
- Added an option to prevent the extension from modifying the panel setting, so it it will only add a blur effect under the panel. This is useful when using a theme that is already transparent and you want the themes settings to remain