### PR TITLE
[BlurCinnamon@klangman] Applet popup menu and desaturation support

### DIFF
--- a/BlurCinnamon@klangman/CHANGELOG.md
+++ b/BlurCinnamon@klangman/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.0
+
+* Replaced the Main Menu effects with generic Popup Menu effects which covers the main menu as well as all other Applet popup menus. 
+* Added a Saturation option which allow you to desaturate the background overlay (0% grey scale to 100%)
+
 ## 1.2.0
 
 * Added the ability (disabled by default) to apply effects to the Main Menu (menu@cinnamon.org)

--- a/BlurCinnamon@klangman/README.md
+++ b/BlurCinnamon@klangman/README.md
@@ -1,25 +1,24 @@
 # Blur Cinnamon
 
-A Cinnamon extension that allows you to Dim, Blur and Colorize parts of the Cinnamon Desktop.
+A Cinnamon extension to Blur, Dim, Colorize, Desaturate and make transparent parts of the Cinnamon Desktop.
 
-Currently it can apply effects to:
+Cinnamon components you can effect (currently):
 
-* The Main Menu (menu@cinnamon.org applet) / (disabled by default)
-* The panels
-* The Overview (The window selection screen)
-* The Expo (The workspace selection screen)
+1. The overview
+2. The Expo
+3. Cinnamon Panels
+4. Applet popup menus (i.e Menu menu, Calendar, etc.)
 
-Also allows you to make the Panels and Main Menu transparent, which allows you to see the blurred background. Blurring can also be disabled if you just want a transparent or semi-transparent effect without blurring. 
+Blurring can also be disabled if you just want a transparent or semi-transparent effect without blurring. 
 
 ## Features
 
-1. Gaussian blur algorithm (borrowed from the Gnome extension Blur-my-Shell) with a user configurable intensity
-2. Dimming overlay with user configurable color and intensity (0-100%, transparent to a solid color)
-3. Simple blur algorithm (the Cinnamon built-in algorithm) which I would only recommend for very old computers
-4. Makes the Panels, Main Menu and the Expo transparent so that the desktop background image blur effects are visible
-5. Applies blurring, colorization and dimming effects to all Panels, the Main Menu, the Overview and the Expo
-6. You can use general settings for Panels/MainMenu/Overview/Expo or use unique settings for each Cinnamon component
-7. Allows unique settings for each panel based on it's location and the monitor is is on
+- Gaussian blur algorithm (borrowed from the Gnome extension Blur-my-Shell) with a user configurable intensity
+- Simple blur algorithm (the Cinnamon built-in algorithm) which I would only recommend for very old computers
+- Dimming overlay with user configurable color and intensity (fully-transparent to a solid color)
+- Makes the Panels, Popup menus and the Expo transparent so that the desktop background image effects are visible
+- Allows you to adjust the color saturation of the background overlay. You can reduced saturation all the way  down to gray scale
+- You can use general settings for Popups/Panels/Overview/Expo or use unique settings for each
 
 ## Requirements
 
@@ -36,8 +35,9 @@ Using any of the above with Blur Cinnamon may have some odd side effects that wo
 ## Limitations
 
 1. The Main Menu effects are intended to be used with the Cinnamon (6.4) theme or the Mint-Y dark desktop themes. The effects might work will with some other themes but I have not tested them so the effects might not work out just right. You can try the Mint-Y light themes but it might be hard to read the menu items without some playing around with the settings and the background image. To make sure that the blurred background does not spill over any rounded corners, the Main Menu rounded corners will be disabled when Main Menu effects are enabled. Menu Menu effects are disabled by default.
-2. Currently, any windows that are moved such that they overlap with a panel or the Main Menu will not be visible beneath the panel as you might expect with a transparent panel. This is because the blur effect is applied to a user interface element that floats above all windows just like the panel floats above the windows. At some point I hope to look into allowing the blur element to appear below all windows rather than above and make the a optional behavior setting.
-3. If you disable effects for any Cinnamon component under the General tab of the setting dialog while any "Use unique effect settings" options are enabled under the other tabs, the components "effect setting" options under the other tabs will still be visible, but changing those setting will have no effect until you re-enable the component under the General tab. Ideally those effect setting would only be visible when the component is enabled under the general tab but Cinnamon setting support is a bit limited in this way.
+2. The panel applet popup menu effects works for all the applets that I have tested except "Cinnamenu", which uses a bit of an odd way to activate the popup menu, making it more difficult to intercept the menu open process so that I can change the menu's transparency setting.
+3. Currently, any windows that are moved such that they overlap with a panel or the Main Menu will not be visible beneath the panel as you might expect with a transparent panel. This is because the blur effect is applied to a user interface element that floats above all windows just like the panel floats above the windows. At some point I hope to look into allowing the blur element to appear below all windows rather than above and make the a optional behavior setting.
+4. If you disable effects for any Cinnamon component under the General tab of the setting dialog while any "Use unique effect settings" options are enabled under the other tabs, the components "effect setting" options under the other tabs will still be visible, but changing those setting will have no effect until you re-enable the component under the General tab. Ideally those effect setting would only be visible when the component is enabled under the general tab but Cinnamon setting support is a bit limited in this way.
 
 ## Installation
 

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/settings-schema.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/settings-schema.json
@@ -1,7 +1,7 @@
 {
    "layout" : {
       "type" : "layout",
-      "pages" : ["general-page", "overview-page", "expo-page", "panels-page", "mainmenu-page"],
+      "pages" : ["general-page", "overview-page", "expo-page", "panels-page", "popup-page"],
 
       "general-page" : {
          "type" : "page",
@@ -23,21 +23,21 @@
          "title" : "Panels",
          "sections" : ["panels-override", "panels-effect-settings"]
       },
-      "mainmenu-page" : {
+      "popup-page" : {
          "type" : "page",
-         "title" : "Main Menu",
-         "sections" : ["mainmenu-override", "mainmenu-effect-settings"]
+         "title" : "Popup Menus",
+         "sections" : ["popup-override", "popup-effect-settings"]
       },
 
       "general-settings" : {
          "type" : "section",
          "title" : "Cinnamon components where effects will be applied",
-         "keys" : ["enable-overview-effects", "enable-expo-effects", "enable-panels-effects", "enable-mainmenu-effects"]
+         "keys" : ["enable-overview-effects", "enable-expo-effects", "enable-panels-effects", "enable-popup-effects"]
       },
       "generic-effect-settings" : {
          "type" : "section",
          "title" : "Generic effect settings",
-         "keys" : ["opacity", "blendColor", "blurType", "radius"]
+         "keys" : ["opacity", "blendColor", "blurType", "radius", "saturation"]
       },
 
       "overview-override" : {
@@ -49,7 +49,7 @@
          "type" : "section",
          "title" : "Overview effect settings",
          "dependency" : "enable-overview-override=1",
-         "keys" : ["overview-opacity", "overview-blendColor", "overview-blurType", "overview-radius"]
+         "keys" : ["overview-opacity", "overview-blendColor", "overview-blurType", "overview-radius", "overview-saturation"]
       },
 
       "expo-override" : {
@@ -61,31 +61,31 @@
          "type" : "section",
          "title" : "Expo effect settings",
          "dependency" : "enable-expo-override=1",
-         "keys" : ["expo-opacity", "expo-blendColor", "expo-blurType", "expo-radius"]
+         "keys" : ["expo-opacity", "expo-blendColor", "expo-blurType", "expo-radius", "expo-saturation"]
       },
 
       "panels-override" : {
          "type" : "section",
          "title" : "Panels settings",
-         "keys" : ["enable-panels-override", "panels-info", "allow-transparent-color-panels" ]
+         "keys" : ["enable-panels-override", "panels-info", "allow-transparent-color-panels"]
       },
       "panels-effect-settings" : {
          "type" : "section",
          "title" : "Panel effects settings",
          "dependency" : "enable-panels-override",
-         "keys" : ["enable-panel-unique-settings", "panel-unique-settings", "panels-opacity", "panels-blendColor", "panels-blurType", "panels-radius"]
+         "keys" : ["enable-panel-unique-settings", "panel-unique-settings", "panels-opacity", "panels-blendColor", "panels-blurType", "panels-radius", "panels-saturation"]
       },
 
-      "mainmenu-override" : {
+      "popup-override" : {
          "type" : "section",
          "title" : "Panels settings",
-         "keys" : ["enable-mainmenu-override", "mainmenu-info", "allow-transparent-color-mainmenu" ]
+         "keys" : ["enable-popup-override", "popup-info", "allow-transparent-color-popup" ]
       },
-      "mainmenu-effect-settings" : {
+      "popup-effect-settings" : {
          "type" : "section",
-         "title" : "Panel effects settings",
-         "dependency" : "enable-mainmenu-override",
-         "keys" : ["mainmenu-opacity", "mainmenu-accent-opacity", "mainmenu-blendColor", "mainmenu-blurType", "mainmenu-radius"]
+         "title" : "Popup menu effects settings",
+         "dependency" : "enable-popup-override",
+         "keys" : ["popup-opacity", "popup-accent-opacity", "popup-blendColor", "popup-blurType", "popup-radius", "popup-saturation"]
       }
 
    },
@@ -108,10 +108,10 @@
         "tooltip": "Apply effects to the Panels. This option should work well with most dark desktop themes but light themes could also be made to work with some creative use of the dimming color settings and an appropriate background image. It overrides some themes settings to achieve a (semi-)transparent panel so that the blurred background is visible.",
         "default": true
     },
-    "enable-mainmenu-effects" : {
+    "enable-popup-effects" : {
         "type": "switch",
-        "description": "Main Menu  (Please read tooltip)",
-        "tooltip": "Apply effects to the Main Menu (menu@cinnamon.org applet). This option is intended for the Cinnamon (6.4) and Mint-Y Dark desktop themes but might work well with other themes. Light themes are unlikely to give good results but might be made to work with some creative use of the dimming color settings and an appropriate background image. It overrides some theme settings to achieve a (semi-)transparent menu so that the blurred background is visible. It also removes rounded corners so that the blurred background will not spill over the rounded edges.",
+        "description": "Popup Menus  (Please read tooltip)",
+        "tooltip": "Apply effects to panel applet popup menus. This option is intended for the Cinnamon (6.4) and Mint-Y dark desktop themes but might work well with other themes. Light themes are unlikely to give good results but might be made to work with some creative use of the dimming color settings and an appropriate background image. It overrides some theme settings to achieve a (semi-)transparent menu so that the blurred background is visible. It also removes rounded corners so that the blurred background will not spill over the rounded edges.",
         "default": false
     },
 
@@ -130,10 +130,10 @@
         "description" : "Warning: Panel effects are currently disabled under the General tab.",
         "dependency" : "!enable-panels-effects"
     },
-    "mainmenu-info" : {
+    "popup-info" : {
         "type" : "label",
-        "description" : "Warning: Main Menu effects are currently disabled under the General tab.",
-        "dependency" : "!enable-mainmenu-effects"
+        "description" : "Warning: Popup Menu effects are currently disabled under the General tab.",
+        "dependency" : "!enable-popup-effects"
     },
 
     "allow-transparent-color-panels" : {
@@ -142,10 +142,10 @@
         "tooltip": "Allow this extension to modify the panels transparency and background color settings. If this is disabled the extension will only apply a blur overlay under the panels. This setting should only be disabled when the theme already uses transparent panels and you want the themes setting to apply.",
         "default": true
     },
-    "allow-transparent-color-mainmenu" : {
+    "allow-transparent-color-popup" : {
         "type": "switch",
-        "description": "Override some of the Main Menu theme settings (recommended)",
-        "tooltip": "Allow this extension to modify the Main Menu transparency, background color and rounded corner settings. If this is disabled the extension will only apply a blur overlay under the main menu. This setting should only be disabled when the theme already uses a transparent main menu and you want the themes setting to apply.",
+        "description": "Override some of the popup menu theme settings (recommended)",
+        "tooltip": "Allow this extension to modify the popup Menu transparency, background color and rounded corner settings. If this is disabled the extension will only apply a blur overlay under the popup menus. This setting should only be disabled when the theme already uses transparent popup menus and you want the themes setting to apply.",
         "default": true
     },
 
@@ -167,10 +167,10 @@
         "dependency" : "enable-panels-effects",
         "default": false
     },
-    "enable-mainmenu-override" : {
+    "enable-popup-override" : {
         "type": "switch",
-        "description": "Use unique effect settings for the Main Menu",
-        "dependency" : "enable-mainmenu-effects",
+        "description": "Use unique effect settings for the popup menus",
+        "dependency" : "enable-popup-effects",
         "default": false
     },
 
@@ -192,14 +192,15 @@
             {"id": "opacity",   "title": "Dimming",   "type": "integer", "default": 40,  "min": 0, "max": 100},
             {"id": "color",     "title": "Color",     "type": "string",  "default": "rgb(0,0,0)"},
             {"id": "blurtype",  "title": "Blur",      "type": "integer", "default": 2, "options": { "None": 0, "Simple": 1, "Gaussian": 2 } },
-            {"id": "radius",    "title": "Intensity", "type": "integer", "default": 10,  "min": 0, "max": 100}
+            {"id": "radius",    "title": "Intensity", "type": "integer", "default": 10,  "min": 0, "max": 100},
+            {"id": "saturation","title": "Saturation","type": "integer", "default": 100, "min": 0, "max": 100}
         ],
         "tooltip": "Defines the effects applied to different panels. If a panel does not meet the criteria of any enabled entry in this list, it will have no effects applied. The settings of the first entry in this list that can apply to a given panel will take effect. The color field is in the rgb(#,#,#) syntax and black will be used when a color is not provided or is in an incorrect syntax",
         "default" : [
-            { "enabled": true, "panels": 1, "monitors": 0, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10 },
-            { "enabled": true, "panels": 2, "monitors": 0, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10 },
-            { "enabled": true, "panels": 3, "monitors": 0, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10 },
-            { "enabled": true, "panels": 4, "monitors": 0, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10 }
+            { "enabled": true, "panels": 1, "monitors": 0, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100 },
+            { "enabled": true, "panels": 2, "monitors": 0, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100 },
+            { "enabled": true, "panels": 3, "monitors": 0, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100 },
+            { "enabled": true, "panels": 4, "monitors": 0, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100 }
         ]
     },
 
@@ -242,6 +243,16 @@
         "default": 9
     },
 
+    "saturation": {
+        "type": "scale",
+        "description" : "Background color saturation",
+        "min" : 0.0,
+        "max" : 100,
+        "step" : 0.1,
+        "tooltip": "Adjusts the color saturation of the background image.",
+        "default": 100
+    },
+
 
     "overview-opacity" : {
         "type": "scale",
@@ -282,6 +293,16 @@
         "default": 9
     },
 
+    "overview-saturation": {
+        "type": "scale",
+        "description" : "Background color saturation",
+        "min" : 0.0,
+        "max" : 100,
+        "step" : 0.1,
+        "tooltip": "Adjusts the color saturation of the background image.",
+        "default": 100
+    },
+
 
     "expo-opacity" : {
         "type": "scale",
@@ -289,15 +310,13 @@
         "min": 0,
         "max": 100,
         "default": 40,
-        "step": 1,
-        "dependency" : "enable-expo-override=1"
+        "step": 1
     },
 
     "expo-blendColor": {
         "type": "colorchooser",
         "description" : "Dimming overlay color",
         "default": "rgb(0,0,0)",
-        "dependency" : "enable-expo-override=1",
         "tooltip": "Defines the color that is blended into the background based on the dimming control above. Use black for a normal dimming effect or some other color for a color blend effect"
     },
 
@@ -310,8 +329,7 @@
             "Gaussian": 2
         },
         "description": "Type of blur effect",
-        "tooltip": "What type of blur algorithm should be used to blur the background",
-        "dependency" : "enable-expo-override=1"
+        "tooltip": "What type of blur algorithm should be used to blur the background"
     },
 
     "expo-radius": {
@@ -322,7 +340,17 @@
         "step" : 0.1,
         "tooltip": "Adjusts the intensity of the blur effect by changing the radius use by the effect.",
         "default": 9,
-        "dependency" : "enable-expo-override=1"
+        "dependency" : "expo-blurType=2"
+    },
+
+    "expo-saturation": {
+        "type": "scale",
+        "description" : "Background color saturation",
+        "min" : 0.0,
+        "max" : 100,
+        "step" : 0.1,
+        "tooltip": "Adjusts the color saturation of the background image.",
+        "default": 100
     },
 
 
@@ -368,36 +396,47 @@
         "dependency" : "!enable-panel-unique-settings"
     },
 
-    "mainmenu-opacity" : {
+    "panels-saturation": {
+        "type": "scale",
+        "description" : "Background color saturation",
+        "min" : 0.0,
+        "max" : 100,
+        "step" : 0.1,
+        "tooltip": "Adjusts the color saturation of the background image.",
+        "default": 100
+    },
+
+
+    "popup-opacity" : {
         "type": "scale",
         "description": "Dim/Colorize Background (percentage)",
         "min": 0,
         "max": 100,
         "default": 50,
         "step": 1,
-        "dependency" : "enable-mainmenu-override=1"
+        "dependency" : "enable-popup-override=1"
     },
 
-    "mainmenu-accent-opacity" : {
+    "popup-accent-opacity" : {
         "type": "scale",
-        "description": "Additional Main Menu accent elements dimming (percentage)",
+        "description": "Additional popup menu accent elements dimming (percentage)",
         "min": 0,
         "max": 100,
         "default": 50,
         "step": 1,
-        "dependency" : "enable-mainmenu-override=1",
-        "tooltip": "Defines the additional dimming applied to the main menu accent elements (the favorites box and the search entry box) which allow these elements to stand out from the other main menu areas"
+        "dependency" : "enable-popup-override=1",
+        "tooltip": "Defines the additional dimming applied to the popup menu accent elements (i.e. the main menu favorites box and entry boxes) which allow these elements to stand out from the other popup menu areas"
     },
 
-    "mainmenu-blendColor": {
+    "popup-blendColor": {
         "type": "colorchooser",
         "description" : "Dimming ovrerlay color",
         "default": "rgb(0,0,0)",
-        "dependency" : "enable-mainmenu-override=1",
+        "dependency" : "enable-popup-override=1",
         "tooltip": "Defines the color that is blended into the background based on the dimming control above. Use black for a normal dimming effect or some other color for a color blend effect"
     },
 
-    "mainmenu-blurType": {
+    "popup-blurType": {
         "type": "combobox",
         "default": 2,
         "options": {
@@ -407,10 +446,10 @@
         },
         "description": "Type of blur effect",
         "tooltip": "What type of blur algorithm should be used to blur the background",
-        "dependency" : "enable-mainmenu-override=1"
+        "dependency" : "enable-popup-override=1"
     },
 
-    "mainmenu-radius": {
+    "popup-radius": {
         "type": "scale",
         "description" : "Blur intensity (Gaussian only)",
         "min" : 0.0,
@@ -418,7 +457,16 @@
         "step" : 0.1,
         "tooltip": "Adjusts the intensity of the Gaussian blur effect by changing the radius use by the effect. This setting does not effect the Simple blur type",
         "default": 20,
-        "dependency" : "enable-mainmenu-override=1"
-    }
+        "dependency" : "enable-popup-override=1"
+    },
 
+    "popup-saturation": {
+        "type": "scale",
+        "description" : "Background color saturation",
+        "min" : 0.0,
+        "max" : 100,
+        "step" : 0.1,
+        "tooltip": "Adjusts the color saturation of the background image.",
+        "default": 100
+    }
 }

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
@@ -1,8 +1,8 @@
 {
     "uuid": "BlurCinnamon@klangman",
     "name": "Blur Cinnamon",
-    "version": "1.2.0",
-    "description": "Allows you to blur, colorize and adjust the dimming of some Cinnamon Desktop components (i.e. Panels, Overview, Expo)",
+    "version": "1.3.0",
+    "description": "Allows you to blur, colorize, desaturate and adjust the dimming of some Cinnamon Desktop components (i.e. Panels, Applet popup menus, Overview, Expo)",
     "url": "https://github.com/klangman/BlurCinnamon",
     "cinnamon-version": [
         "6.0"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
+"Project-Id-Version: BlurCinnamon@klangman 1.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-02-01 11:48-0500\n"
+"POT-Creation-Date: 2025-02-16 15:10-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -23,8 +23,8 @@ msgstr ""
 
 #. metadata.json->description
 msgid ""
-"Allows you to blur, colorize and adjust the dimming of some Cinnamon Desktop "
-"components (i.e. Panels, Overview, Expo)"
+"Allows you to blur, colorize, desaturate and adjust the dimming of some "
+"Cinnamon Desktop components (i.e. Panels, Applet popup menus, Overview, Expo)"
 msgstr ""
 
 #. 6.0->settings-schema.json->general-page->title
@@ -45,8 +45,8 @@ msgstr ""
 msgid "Panels"
 msgstr ""
 
-#. 6.0->settings-schema.json->mainmenu-page->title
-msgid "Main Menu"
+#. 6.0->settings-schema.json->popup-page->title
+msgid "Popup Menus"
 msgstr ""
 
 #. 6.0->settings-schema.json->general-settings->title
@@ -74,13 +74,16 @@ msgid "Expo effect settings"
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-override->title
-#. 6.0->settings-schema.json->mainmenu-override->title
+#. 6.0->settings-schema.json->popup-override->title
 msgid "Panels settings"
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-effect-settings->title
-#. 6.0->settings-schema.json->mainmenu-effect-settings->title
 msgid "Panel effects settings"
+msgstr ""
+
+#. 6.0->settings-schema.json->popup-effect-settings->title
+msgid "Popup menu effects settings"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-overview-effects->tooltip
@@ -108,20 +111,20 @@ msgid ""
 "panel so that the blurred background is visible."
 msgstr ""
 
-#. 6.0->settings-schema.json->enable-mainmenu-effects->description
-msgid "Main Menu  (Please read tooltip)"
+#. 6.0->settings-schema.json->enable-popup-effects->description
+msgid "Popup Menus  (Please read tooltip)"
 msgstr ""
 
-#. 6.0->settings-schema.json->enable-mainmenu-effects->tooltip
+#. 6.0->settings-schema.json->enable-popup-effects->tooltip
 msgid ""
-"Apply effects to the Main Menu (menu@cinnamon.org applet). This option is "
-"intended for the Cinnamon (6.4) and Mint-Y Dark desktop themes but might "
-"work well with other themes. Light themes are unlikely to give good results "
-"but might be made to work with some creative use of the dimming color "
-"settings and an appropriate background image. It overrides some theme "
-"settings to achieve a (semi-)transparent menu so that the blurred background "
-"is visible. It also removes rounded corners so that the blurred background "
-"will not spill over the rounded edges."
+"Apply effects to panel applet popup menus. This option is intended for the "
+"Cinnamon (6.4) and Mint-Y dark desktop themes but might work well with other "
+"themes. Light themes are unlikely to give good results but might be made to "
+"work with some creative use of the dimming color settings and an appropriate "
+"background image. It overrides some theme settings to achieve a "
+"(semi-)transparent menu so that the blurred background is visible. It also "
+"removes rounded corners so that the blurred background will not spill over "
+"the rounded edges."
 msgstr ""
 
 #. 6.0->settings-schema.json->overview-info->description
@@ -136,9 +139,9 @@ msgstr ""
 msgid "Warning: Panel effects are currently disabled under the General tab."
 msgstr ""
 
-#. 6.0->settings-schema.json->mainmenu-info->description
+#. 6.0->settings-schema.json->popup-info->description
 msgid ""
-"Warning: Main Menu effects are currently disabled under the General tab."
+"Warning: Popup Menu effects are currently disabled under the General tab."
 msgstr ""
 
 #. 6.0->settings-schema.json->allow-transparent-color-panels->description
@@ -153,16 +156,16 @@ msgid ""
 "already uses transparent panels and you want the themes setting to apply."
 msgstr ""
 
-#. 6.0->settings-schema.json->allow-transparent-color-mainmenu->description
-msgid "Override some of the Main Menu theme settings (recommended)"
+#. 6.0->settings-schema.json->allow-transparent-color-popup->description
+msgid "Override some of the popup menu theme settings (recommended)"
 msgstr ""
 
-#. 6.0->settings-schema.json->allow-transparent-color-mainmenu->tooltip
+#. 6.0->settings-schema.json->allow-transparent-color-popup->tooltip
 msgid ""
-"Allow this extension to modify the Main Menu transparency, background color "
+"Allow this extension to modify the popup Menu transparency, background color "
 "and rounded corner settings. If this is disabled the extension will only "
-"apply a blur overlay under the main menu. This setting should only be "
-"disabled when the theme already uses a transparent main menu and you want "
+"apply a blur overlay under the popup menus. This setting should only be "
+"disabled when the theme already uses transparent popup menus and you want "
 "the themes setting to apply."
 msgstr ""
 
@@ -178,8 +181,8 @@ msgstr ""
 msgid "Use unique effect settings for the Panels"
 msgstr ""
 
-#. 6.0->settings-schema.json->enable-mainmenu-override->description
-msgid "Use unique effect settings for the Main Menu"
+#. 6.0->settings-schema.json->enable-popup-override->description
+msgid "Use unique effect settings for the popup menus"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-panel-unique-settings->description
@@ -218,6 +221,10 @@ msgstr ""
 msgid "Intensity"
 msgstr ""
 
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Saturation"
+msgstr ""
+
 #. 6.0->settings-schema.json->panel-unique-settings->tooltip
 msgid ""
 "Defines the effects applied to different panels. If a panel does not meet "
@@ -232,7 +239,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-opacity->description
 #. 6.0->settings-schema.json->expo-opacity->description
 #. 6.0->settings-schema.json->panels-opacity->description
-#. 6.0->settings-schema.json->mainmenu-opacity->description
+#. 6.0->settings-schema.json->popup-opacity->description
 msgid "Dim/Colorize Background (percentage)"
 msgstr ""
 
@@ -246,7 +253,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-blendColor->tooltip
 #. 6.0->settings-schema.json->expo-blendColor->tooltip
 #. 6.0->settings-schema.json->panels-blendColor->tooltip
-#. 6.0->settings-schema.json->mainmenu-blendColor->tooltip
+#. 6.0->settings-schema.json->popup-blendColor->tooltip
 msgid ""
 "Defines the color that is blended into the background based on the dimming "
 "control above. Use black for a normal dimming effect or some other color for "
@@ -257,7 +264,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->mainmenu-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
 msgid "None"
 msgstr ""
 
@@ -265,7 +272,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->mainmenu-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
 msgid "Simple"
 msgstr ""
 
@@ -273,7 +280,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->mainmenu-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
 msgid "Gaussian"
 msgstr ""
 
@@ -281,7 +288,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
 #. 6.0->settings-schema.json->panels-blurType->description
-#. 6.0->settings-schema.json->mainmenu-blurType->description
+#. 6.0->settings-schema.json->popup-blurType->description
 msgid "Type of blur effect"
 msgstr ""
 
@@ -289,7 +296,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->panels-blurType->tooltip
-#. 6.0->settings-schema.json->mainmenu-blurType->tooltip
+#. 6.0->settings-schema.json->popup-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr ""
 
@@ -307,30 +314,46 @@ msgid ""
 "effect."
 msgstr ""
 
+#. 6.0->settings-schema.json->saturation->description
+#. 6.0->settings-schema.json->overview-saturation->description
+#. 6.0->settings-schema.json->expo-saturation->description
+#. 6.0->settings-schema.json->panels-saturation->description
+#. 6.0->settings-schema.json->popup-saturation->description
+msgid "Background color saturation"
+msgstr ""
+
+#. 6.0->settings-schema.json->saturation->tooltip
+#. 6.0->settings-schema.json->overview-saturation->tooltip
+#. 6.0->settings-schema.json->expo-saturation->tooltip
+#. 6.0->settings-schema.json->panels-saturation->tooltip
+#. 6.0->settings-schema.json->popup-saturation->tooltip
+msgid "Adjusts the color saturation of the background image."
+msgstr ""
+
 #. 6.0->settings-schema.json->panels-blendColor->description
-#. 6.0->settings-schema.json->mainmenu-blendColor->description
+#. 6.0->settings-schema.json->popup-blendColor->description
 msgid "Dimming ovrerlay color"
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-radius->description
-#. 6.0->settings-schema.json->mainmenu-radius->description
+#. 6.0->settings-schema.json->popup-radius->description
 msgid "Blur intensity (Gaussian only)"
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-radius->tooltip
-#. 6.0->settings-schema.json->mainmenu-radius->tooltip
+#. 6.0->settings-schema.json->popup-radius->tooltip
 msgid ""
 "Adjusts the intensity of the Gaussian blur effect by changing the radius use "
 "by the effect. This setting does not effect the Simple blur type"
 msgstr ""
 
-#. 6.0->settings-schema.json->mainmenu-accent-opacity->description
-msgid "Additional Main Menu accent elements dimming (percentage)"
+#. 6.0->settings-schema.json->popup-accent-opacity->description
+msgid "Additional popup menu accent elements dimming (percentage)"
 msgstr ""
 
-#. 6.0->settings-schema.json->mainmenu-accent-opacity->tooltip
+#. 6.0->settings-schema.json->popup-accent-opacity->tooltip
 msgid ""
-"Defines the additional dimming applied to the main menu accent elements (the "
-"favorites box and the search entry box) which allow these elements to stand "
-"out from the other main menu areas"
+"Defines the additional dimming applied to the popup menu accent elements (i."
+"e. the main menu favorites box and entry boxes) which allow these elements "
+"to stand out from the other popup menu areas"
 msgstr ""

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-02-01 11:48-0500\n"
+"POT-Creation-Date: 2025-02-16 15:10-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -23,9 +23,10 @@ msgid "Blur Cinnamon"
 msgstr "Difumina Cinnamon"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Allows you to blur, colorize and adjust the dimming of some Cinnamon Desktop "
-"components (i.e. Panels, Overview, Expo)"
+"Allows you to blur, colorize, desaturate and adjust the dimming of some "
+"Cinnamon Desktop components (i.e. Panels, Applet popup menus, Overview, Expo)"
 msgstr ""
 "Us permet difuminar, tintar i ajustar l'atenuació d'alguns dels components "
 "de l'escriptori Cinnamon (com ara Taulers, Vista general, Exposició)"
@@ -48,9 +49,9 @@ msgstr "Exposició"
 msgid "Panels"
 msgstr "Taulers"
 
-#. 6.0->settings-schema.json->mainmenu-page->title
-msgid "Main Menu"
-msgstr "Menú Principal"
+#. 6.0->settings-schema.json->popup-page->title
+msgid "Popup Menus"
+msgstr ""
 
 #. 6.0->settings-schema.json->general-settings->title
 msgid "Cinnamon components where effects will be applied"
@@ -77,13 +78,17 @@ msgid "Expo effect settings"
 msgstr "Opcions d'efecte de l'exposició"
 
 #. 6.0->settings-schema.json->panels-override->title
-#. 6.0->settings-schema.json->mainmenu-override->title
+#. 6.0->settings-schema.json->popup-override->title
 msgid "Panels settings"
 msgstr "Opcions dels taulers"
 
 #. 6.0->settings-schema.json->panels-effect-settings->title
-#. 6.0->settings-schema.json->mainmenu-effect-settings->title
 msgid "Panel effects settings"
+msgstr "Opcions d'efectes dels taulers"
+
+#. 6.0->settings-schema.json->popup-effect-settings->title
+#, fuzzy
+msgid "Popup menu effects settings"
 msgstr "Opcions d'efectes dels taulers"
 
 #. 6.0->settings-schema.json->enable-overview-effects->tooltip
@@ -121,20 +126,22 @@ msgstr ""
 "aconseguir un tauler (semi-)transparent per tal que el fons difuminat sigui "
 "visible."
 
-#. 6.0->settings-schema.json->enable-mainmenu-effects->description
-msgid "Main Menu  (Please read tooltip)"
+#. 6.0->settings-schema.json->enable-popup-effects->description
+#, fuzzy
+msgid "Popup Menus  (Please read tooltip)"
 msgstr "Menú Principal  (Si us plau, llegiu el consell informatiu)"
 
-#. 6.0->settings-schema.json->enable-mainmenu-effects->tooltip
+#. 6.0->settings-schema.json->enable-popup-effects->tooltip
+#, fuzzy
 msgid ""
-"Apply effects to the Main Menu (menu@cinnamon.org applet). This option is "
-"intended for the Cinnamon (6.4) and Mint-Y Dark desktop themes but might "
-"work well with other themes. Light themes are unlikely to give good results "
-"but might be made to work with some creative use of the dimming color "
-"settings and an appropriate background image. It overrides some theme "
-"settings to achieve a (semi-)transparent menu so that the blurred background "
-"is visible. It also removes rounded corners so that the blurred background "
-"will not spill over the rounded edges."
+"Apply effects to panel applet popup menus. This option is intended for the "
+"Cinnamon (6.4) and Mint-Y dark desktop themes but might work well with other "
+"themes. Light themes are unlikely to give good results but might be made to "
+"work with some creative use of the dimming color settings and an appropriate "
+"background image. It overrides some theme settings to achieve a "
+"(semi-)transparent menu so that the blurred background is visible. It also "
+"removes rounded corners so that the blurred background will not spill over "
+"the rounded edges."
 msgstr ""
 "Aplica efectes al Menú Principal (miniaplicació menu@cinnamon.org). Aquesta "
 "opció està pensada pel tema fosc Mint-Y de Cinnamon 6.4 però podria "
@@ -159,9 +166,10 @@ msgstr ""
 msgid "Warning: Panel effects are currently disabled under the General tab."
 msgstr "Avís: els efectes de Tauler estan desactivats a la pestanya General."
 
-#. 6.0->settings-schema.json->mainmenu-info->description
+#. 6.0->settings-schema.json->popup-info->description
+#, fuzzy
 msgid ""
-"Warning: Main Menu effects are currently disabled under the General tab."
+"Warning: Popup Menu effects are currently disabled under the General tab."
 msgstr ""
 "Avís: els efectes del Menú Principal estan desactivats a la pestanya General."
 
@@ -182,17 +190,19 @@ msgstr ""
 "tema ja faci ús de taulers transparents per defecte i voleu que les opcions "
 "del mateix s'apliquin."
 
-#. 6.0->settings-schema.json->allow-transparent-color-mainmenu->description
-msgid "Override some of the Main Menu theme settings (recommended)"
+#. 6.0->settings-schema.json->allow-transparent-color-popup->description
+#, fuzzy
+msgid "Override some of the popup menu theme settings (recommended)"
 msgstr ""
 "Sobreescriu algunes de les opcions dels temes al menú principal (recomanat)"
 
-#. 6.0->settings-schema.json->allow-transparent-color-mainmenu->tooltip
+#. 6.0->settings-schema.json->allow-transparent-color-popup->tooltip
+#, fuzzy
 msgid ""
-"Allow this extension to modify the Main Menu transparency, background color "
+"Allow this extension to modify the popup Menu transparency, background color "
 "and rounded corner settings. If this is disabled the extension will only "
-"apply a blur overlay under the main menu. This setting should only be "
-"disabled when the theme already uses a transparent main menu and you want "
+"apply a blur overlay under the popup menus. This setting should only be "
+"disabled when the theme already uses transparent popup menus and you want "
 "the themes setting to apply."
 msgstr ""
 "Permet a aquesta extensió modificar la configuració de transparència, color "
@@ -213,9 +223,10 @@ msgstr "Utilitza ajusts d'efectes exclusius per a l'Exposició"
 msgid "Use unique effect settings for the Panels"
 msgstr "Utilitza ajusts d'efectes exclusius pels Taulers"
 
-#. 6.0->settings-schema.json->enable-mainmenu-override->description
-msgid "Use unique effect settings for the Main Menu"
-msgstr "Utilitza ajusts d'efectes exclusius pel Menú Principal"
+#. 6.0->settings-schema.json->enable-popup-override->description
+#, fuzzy
+msgid "Use unique effect settings for the popup menus"
+msgstr "Utilitza ajusts d'efectes exclusius per a l'Exposició"
 
 #. 6.0->settings-schema.json->enable-panel-unique-settings->description
 msgid "Use unique effect settings for each panel"
@@ -253,6 +264,10 @@ msgstr "Difuminat"
 msgid "Intensity"
 msgstr "Intensitat"
 
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Saturation"
+msgstr ""
+
 #. 6.0->settings-schema.json->panel-unique-settings->tooltip
 msgid ""
 "Defines the effects applied to different panels. If a panel does not meet "
@@ -272,7 +287,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-opacity->description
 #. 6.0->settings-schema.json->expo-opacity->description
 #. 6.0->settings-schema.json->panels-opacity->description
-#. 6.0->settings-schema.json->mainmenu-opacity->description
+#. 6.0->settings-schema.json->popup-opacity->description
 msgid "Dim/Colorize Background (percentage)"
 msgstr "Atenuació/Tint del fons (percentatge)"
 
@@ -286,7 +301,7 @@ msgstr "Color de l'atenuació superposada"
 #. 6.0->settings-schema.json->overview-blendColor->tooltip
 #. 6.0->settings-schema.json->expo-blendColor->tooltip
 #. 6.0->settings-schema.json->panels-blendColor->tooltip
-#. 6.0->settings-schema.json->mainmenu-blendColor->tooltip
+#. 6.0->settings-schema.json->popup-blendColor->tooltip
 msgid ""
 "Defines the color that is blended into the background based on the dimming "
 "control above. Use black for a normal dimming effect or some other color for "
@@ -300,7 +315,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->mainmenu-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
 msgid "None"
 msgstr "Cap"
 
@@ -308,7 +323,7 @@ msgstr "Cap"
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->mainmenu-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
 msgid "Simple"
 msgstr "Simple"
 
@@ -316,7 +331,7 @@ msgstr "Simple"
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->mainmenu-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
 msgid "Gaussian"
 msgstr "Gaussià"
 
@@ -324,7 +339,7 @@ msgstr "Gaussià"
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
 #. 6.0->settings-schema.json->panels-blurType->description
-#. 6.0->settings-schema.json->mainmenu-blurType->description
+#. 6.0->settings-schema.json->popup-blurType->description
 msgid "Type of blur effect"
 msgstr "Tipus d'efecte de difuminat"
 
@@ -332,7 +347,7 @@ msgstr "Tipus d'efecte de difuminat"
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->panels-blurType->tooltip
-#. 6.0->settings-schema.json->mainmenu-blurType->tooltip
+#. 6.0->settings-schema.json->popup-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Tipus d'algorisme de difuminat que s'utilitzarà pel fons"
 
@@ -352,18 +367,34 @@ msgstr ""
 "Ajusta la intensitat de l'efecte de difuminat a base de modificar-ne el radi "
 "d'acció."
 
+#. 6.0->settings-schema.json->saturation->description
+#. 6.0->settings-schema.json->overview-saturation->description
+#. 6.0->settings-schema.json->expo-saturation->description
+#. 6.0->settings-schema.json->panels-saturation->description
+#. 6.0->settings-schema.json->popup-saturation->description
+msgid "Background color saturation"
+msgstr ""
+
+#. 6.0->settings-schema.json->saturation->tooltip
+#. 6.0->settings-schema.json->overview-saturation->tooltip
+#. 6.0->settings-schema.json->expo-saturation->tooltip
+#. 6.0->settings-schema.json->panels-saturation->tooltip
+#. 6.0->settings-schema.json->popup-saturation->tooltip
+msgid "Adjusts the color saturation of the background image."
+msgstr ""
+
 #. 6.0->settings-schema.json->panels-blendColor->description
-#. 6.0->settings-schema.json->mainmenu-blendColor->description
+#. 6.0->settings-schema.json->popup-blendColor->description
 msgid "Dimming ovrerlay color"
 msgstr "Color de l'atenuació superposada"
 
 #. 6.0->settings-schema.json->panels-radius->description
-#. 6.0->settings-schema.json->mainmenu-radius->description
+#. 6.0->settings-schema.json->popup-radius->description
 msgid "Blur intensity (Gaussian only)"
 msgstr "Intensitat del difuminat (només Gaussià)"
 
 #. 6.0->settings-schema.json->panels-radius->tooltip
-#. 6.0->settings-schema.json->mainmenu-radius->tooltip
+#. 6.0->settings-schema.json->popup-radius->tooltip
 msgid ""
 "Adjusts the intensity of the Gaussian blur effect by changing the radius use "
 "by the effect. This setting does not effect the Simple blur type"
@@ -371,15 +402,17 @@ msgstr ""
 "Ajusta la intensitat de l'efecte de difuminat Gaussià a base de modificar-ne "
 "el radi d'acció. Aquesta opció no afecta el tipus de difuminat Simple"
 
-#. 6.0->settings-schema.json->mainmenu-accent-opacity->description
-msgid "Additional Main Menu accent elements dimming (percentage)"
+#. 6.0->settings-schema.json->popup-accent-opacity->description
+#, fuzzy
+msgid "Additional popup menu accent elements dimming (percentage)"
 msgstr "Accent addicional a l'atenuació del Menú Principal (percentatge)"
 
-#. 6.0->settings-schema.json->mainmenu-accent-opacity->tooltip
+#. 6.0->settings-schema.json->popup-accent-opacity->tooltip
+#, fuzzy
 msgid ""
-"Defines the additional dimming applied to the main menu accent elements (the "
-"favorites box and the search entry box) which allow these elements to stand "
-"out from the other main menu areas"
+"Defines the additional dimming applied to the popup menu accent elements (i."
+"e. the main menu favorites box and entry boxes) which allow these elements "
+"to stand out from the other popup menu areas"
 msgstr ""
 "Defineix el grau d'atenuació addicional que s'aplicarà als elements del Menú "
 "Principal (caixa de preferits i camp de cerca), que permetrà que aquests "

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-02-01 11:48-0500\n"
+"POT-Creation-Date: 2025-02-16 15:10-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -22,9 +22,10 @@ msgid "Blur Cinnamon"
 msgstr "Desenfoque de Cinnamon"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Allows you to blur, colorize and adjust the dimming of some Cinnamon Desktop "
-"components (i.e. Panels, Overview, Expo)"
+"Allows you to blur, colorize, desaturate and adjust the dimming of some "
+"Cinnamon Desktop components (i.e. Panels, Applet popup menus, Overview, Expo)"
 msgstr ""
 "Permite desenfocar, colorear y ajustar la atenuación de algunos componentes "
 "de Cinnamon Desktop (es decir, Paneles, Vista general, Exposición)."
@@ -47,9 +48,9 @@ msgstr "Exposición"
 msgid "Panels"
 msgstr "Paneles"
 
-#. 6.0->settings-schema.json->mainmenu-page->title
-msgid "Main Menu"
-msgstr "Menú principal"
+#. 6.0->settings-schema.json->popup-page->title
+msgid "Popup Menus"
+msgstr ""
 
 #. 6.0->settings-schema.json->general-settings->title
 msgid "Cinnamon components where effects will be applied"
@@ -76,13 +77,17 @@ msgid "Expo effect settings"
 msgstr "Configuración de efecto de la exposición"
 
 #. 6.0->settings-schema.json->panels-override->title
-#. 6.0->settings-schema.json->mainmenu-override->title
+#. 6.0->settings-schema.json->popup-override->title
 msgid "Panels settings"
 msgstr "Configuración de los paneles"
 
 #. 6.0->settings-schema.json->panels-effect-settings->title
-#. 6.0->settings-schema.json->mainmenu-effect-settings->title
 msgid "Panel effects settings"
+msgstr "Configuración de efectos del panel"
+
+#. 6.0->settings-schema.json->popup-effect-settings->title
+#, fuzzy
+msgid "Popup menu effects settings"
 msgstr "Configuración de efectos del panel"
 
 #. 6.0->settings-schema.json->enable-overview-effects->tooltip
@@ -120,20 +125,22 @@ msgstr ""
 "temas para conseguir un panel (semi)transparente de modo que el fondo "
 "difuminado sea visible."
 
-#. 6.0->settings-schema.json->enable-mainmenu-effects->description
-msgid "Main Menu  (Please read tooltip)"
+#. 6.0->settings-schema.json->enable-popup-effects->description
+#, fuzzy
+msgid "Popup Menus  (Please read tooltip)"
 msgstr "Menú principal (lea la información sobre herramientas)"
 
-#. 6.0->settings-schema.json->enable-mainmenu-effects->tooltip
+#. 6.0->settings-schema.json->enable-popup-effects->tooltip
+#, fuzzy
 msgid ""
-"Apply effects to the Main Menu (menu@cinnamon.org applet). This option is "
-"intended for the Cinnamon (6.4) and Mint-Y Dark desktop themes but might "
-"work well with other themes. Light themes are unlikely to give good results "
-"but might be made to work with some creative use of the dimming color "
-"settings and an appropriate background image. It overrides some theme "
-"settings to achieve a (semi-)transparent menu so that the blurred background "
-"is visible. It also removes rounded corners so that the blurred background "
-"will not spill over the rounded edges."
+"Apply effects to panel applet popup menus. This option is intended for the "
+"Cinnamon (6.4) and Mint-Y dark desktop themes but might work well with other "
+"themes. Light themes are unlikely to give good results but might be made to "
+"work with some creative use of the dimming color settings and an appropriate "
+"background image. It overrides some theme settings to achieve a "
+"(semi-)transparent menu so that the blurred background is visible. It also "
+"removes rounded corners so that the blurred background will not spill over "
+"the rounded edges."
 msgstr ""
 "Aplicar efectos al menú principal (menu@cinnamon.org applet). Esta opción "
 "está pensada para los temas de escritorio Cinnamon (6.4) y Mint-Y Dark, pero "
@@ -162,9 +169,10 @@ msgstr ""
 "Advertencia: Los efectos del panel están actualmente deshabilitados en la "
 "pestaña General."
 
-#. 6.0->settings-schema.json->mainmenu-info->description
+#. 6.0->settings-schema.json->popup-info->description
+#, fuzzy
 msgid ""
-"Warning: Main Menu effects are currently disabled under the General tab."
+"Warning: Popup Menu effects are currently disabled under the General tab."
 msgstr ""
 "Advertencia: Los efectos del panel están actualmente deshabilitados en la "
 "pestaña General."
@@ -186,16 +194,18 @@ msgstr ""
 "sólo debe desactivarse cuando el tema ya utiliza paneles transparentes y "
 "desea que se aplique la configuración de temas."
 
-#. 6.0->settings-schema.json->allow-transparent-color-mainmenu->description
-msgid "Override some of the Main Menu theme settings (recommended)"
+#. 6.0->settings-schema.json->allow-transparent-color-popup->description
+#, fuzzy
+msgid "Override some of the popup menu theme settings (recommended)"
 msgstr "Anular algunos de los ajustes del tema Menú principal (recomendado)"
 
-#. 6.0->settings-schema.json->allow-transparent-color-mainmenu->tooltip
+#. 6.0->settings-schema.json->allow-transparent-color-popup->tooltip
+#, fuzzy
 msgid ""
-"Allow this extension to modify the Main Menu transparency, background color "
+"Allow this extension to modify the popup Menu transparency, background color "
 "and rounded corner settings. If this is disabled the extension will only "
-"apply a blur overlay under the main menu. This setting should only be "
-"disabled when the theme already uses a transparent main menu and you want "
+"apply a blur overlay under the popup menus. This setting should only be "
+"disabled when the theme already uses transparent popup menus and you want "
 "the themes setting to apply."
 msgstr ""
 "Permitir que esta extensión modifique la transparencia del menú principal, "
@@ -217,9 +227,10 @@ msgstr "Usar ajustes de efectos exclusivos para el efecto Exposición"
 msgid "Use unique effect settings for the Panels"
 msgstr "Usar ajustes de efectos exclusivos para los Paneles"
 
-#. 6.0->settings-schema.json->enable-mainmenu-override->description
-msgid "Use unique effect settings for the Main Menu"
-msgstr "Usar ajustes de efectos exclusivos para en Menú principal"
+#. 6.0->settings-schema.json->enable-popup-override->description
+#, fuzzy
+msgid "Use unique effect settings for the popup menus"
+msgstr "Usar ajustes de efectos exclusivos para el efecto Exposición"
 
 #. 6.0->settings-schema.json->enable-panel-unique-settings->description
 msgid "Use unique effect settings for each panel"
@@ -257,6 +268,10 @@ msgstr "Desenfoque"
 msgid "Intensity"
 msgstr "Intensidad"
 
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Saturation"
+msgstr ""
+
 #. 6.0->settings-schema.json->panel-unique-settings->tooltip
 msgid ""
 "Defines the effects applied to different panels. If a panel does not meet "
@@ -277,7 +292,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-opacity->description
 #. 6.0->settings-schema.json->expo-opacity->description
 #. 6.0->settings-schema.json->panels-opacity->description
-#. 6.0->settings-schema.json->mainmenu-opacity->description
+#. 6.0->settings-schema.json->popup-opacity->description
 msgid "Dim/Colorize Background (percentage)"
 msgstr "Atenuar/colorear fondo (porcentaje)"
 
@@ -291,7 +306,7 @@ msgstr "Atenuación del color de superposición"
 #. 6.0->settings-schema.json->overview-blendColor->tooltip
 #. 6.0->settings-schema.json->expo-blendColor->tooltip
 #. 6.0->settings-schema.json->panels-blendColor->tooltip
-#. 6.0->settings-schema.json->mainmenu-blendColor->tooltip
+#. 6.0->settings-schema.json->popup-blendColor->tooltip
 msgid ""
 "Defines the color that is blended into the background based on the dimming "
 "control above. Use black for a normal dimming effect or some other color for "
@@ -305,7 +320,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->mainmenu-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
 msgid "None"
 msgstr "Ninguno"
 
@@ -313,7 +328,7 @@ msgstr "Ninguno"
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->mainmenu-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
 msgid "Simple"
 msgstr "Sencillo"
 
@@ -321,7 +336,7 @@ msgstr "Sencillo"
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->mainmenu-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
 msgid "Gaussian"
 msgstr "Gaussiano"
 
@@ -329,7 +344,7 @@ msgstr "Gaussiano"
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
 #. 6.0->settings-schema.json->panels-blurType->description
-#. 6.0->settings-schema.json->mainmenu-blurType->description
+#. 6.0->settings-schema.json->popup-blurType->description
 msgid "Type of blur effect"
 msgstr "Tipo de efecto de desenfoque"
 
@@ -337,7 +352,7 @@ msgstr "Tipo de efecto de desenfoque"
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->panels-blurType->tooltip
-#. 6.0->settings-schema.json->mainmenu-blurType->tooltip
+#. 6.0->settings-schema.json->popup-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr ""
 "Que tipo de algoritmo de desenfoque debe utilizarse para desenfocar el fondo."
@@ -358,18 +373,34 @@ msgstr ""
 "Ajusta la intensidad del efecto de desenfoque cambiando el radio utilizado "
 "por el efecto."
 
+#. 6.0->settings-schema.json->saturation->description
+#. 6.0->settings-schema.json->overview-saturation->description
+#. 6.0->settings-schema.json->expo-saturation->description
+#. 6.0->settings-schema.json->panels-saturation->description
+#. 6.0->settings-schema.json->popup-saturation->description
+msgid "Background color saturation"
+msgstr ""
+
+#. 6.0->settings-schema.json->saturation->tooltip
+#. 6.0->settings-schema.json->overview-saturation->tooltip
+#. 6.0->settings-schema.json->expo-saturation->tooltip
+#. 6.0->settings-schema.json->panels-saturation->tooltip
+#. 6.0->settings-schema.json->popup-saturation->tooltip
+msgid "Adjusts the color saturation of the background image."
+msgstr ""
+
 #. 6.0->settings-schema.json->panels-blendColor->description
-#. 6.0->settings-schema.json->mainmenu-blendColor->description
+#. 6.0->settings-schema.json->popup-blendColor->description
 msgid "Dimming ovrerlay color"
 msgstr "Atenuación del color de superposición"
 
 #. 6.0->settings-schema.json->panels-radius->description
-#. 6.0->settings-schema.json->mainmenu-radius->description
+#. 6.0->settings-schema.json->popup-radius->description
 msgid "Blur intensity (Gaussian only)"
 msgstr "Intensidad del desenfoque (sólo Gaussiano)"
 
 #. 6.0->settings-schema.json->panels-radius->tooltip
-#. 6.0->settings-schema.json->mainmenu-radius->tooltip
+#. 6.0->settings-schema.json->popup-radius->tooltip
 msgid ""
 "Adjusts the intensity of the Gaussian blur effect by changing the radius use "
 "by the effect. This setting does not effect the Simple blur type"
@@ -377,16 +408,18 @@ msgstr ""
 "Ajusta la intensidad del efecto de desenfoque gaussiano cambiando el radio "
 "utilizado por el efecto. Este ajuste no afecta al tipo de desenfoque Simple"
 
-#. 6.0->settings-schema.json->mainmenu-accent-opacity->description
-msgid "Additional Main Menu accent elements dimming (percentage)"
+#. 6.0->settings-schema.json->popup-accent-opacity->description
+#, fuzzy
+msgid "Additional popup menu accent elements dimming (percentage)"
 msgstr ""
 "Atenuación de elementos de acento adicionales del menú principal (porcentaje)"
 
-#. 6.0->settings-schema.json->mainmenu-accent-opacity->tooltip
+#. 6.0->settings-schema.json->popup-accent-opacity->tooltip
+#, fuzzy
 msgid ""
-"Defines the additional dimming applied to the main menu accent elements (the "
-"favorites box and the search entry box) which allow these elements to stand "
-"out from the other main menu areas"
+"Defines the additional dimming applied to the popup menu accent elements (i."
+"e. the main menu favorites box and entry boxes) which allow these elements "
+"to stand out from the other popup menu areas"
 msgstr ""
 "Define la atenuación adicional aplicada a los elementos de acento del menú "
 "principal (el cuadro de favoritos y el cuadro de entrada de búsqueda) que "

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-02-01 11:48-0500\n"
+"POT-Creation-Date: 2025-02-16 15:10-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -23,9 +23,10 @@ msgid "Blur Cinnamon"
 msgstr "Flou pour Cinnamon"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Allows you to blur, colorize and adjust the dimming of some Cinnamon Desktop "
-"components (i.e. Panels, Overview, Expo)"
+"Allows you to blur, colorize, desaturate and adjust the dimming of some "
+"Cinnamon Desktop components (i.e. Panels, Applet popup menus, Overview, Expo)"
 msgstr ""
 "Permet d'estomper, de coloriser et d'ajuster la luminosité de certains "
 "composants du bureau Cinnamon (c.-à-d. Panneaux, Vue d'ensemble, Expo)."
@@ -48,9 +49,9 @@ msgstr "Expo"
 msgid "Panels"
 msgstr "Panneaux"
 
-#. 6.0->settings-schema.json->mainmenu-page->title
-msgid "Main Menu"
-msgstr "Menu principal"
+#. 6.0->settings-schema.json->popup-page->title
+msgid "Popup Menus"
+msgstr ""
 
 #. 6.0->settings-schema.json->general-settings->title
 msgid "Cinnamon components where effects will be applied"
@@ -77,13 +78,17 @@ msgid "Expo effect settings"
 msgstr "Paramètres de l'effet Expo"
 
 #. 6.0->settings-schema.json->panels-override->title
-#. 6.0->settings-schema.json->mainmenu-override->title
+#. 6.0->settings-schema.json->popup-override->title
 msgid "Panels settings"
 msgstr "Paramètres des Panneaux"
 
 #. 6.0->settings-schema.json->panels-effect-settings->title
-#. 6.0->settings-schema.json->mainmenu-effect-settings->title
 msgid "Panel effects settings"
+msgstr "Paramètres des effets du Panneau"
+
+#. 6.0->settings-schema.json->popup-effect-settings->title
+#, fuzzy
+msgid "Popup menu effects settings"
 msgstr "Paramètres des effets du Panneau"
 
 #. 6.0->settings-schema.json->enable-overview-effects->tooltip
@@ -91,8 +96,8 @@ msgid ""
 "Apply effects to the Overview (default: Ctrl+Alt+Down / 'Show all windows` "
 "hot corner)"
 msgstr ""
-"Appliquer des effets à la vue d'ensemble (par défaut : Ctrl+Alt+Bas / « "
-"Afficher toutes les fenêtres »)"
+"Appliquer des effets à la vue d'ensemble (par défaut : Ctrl+Alt+Bas / "
+"« Afficher toutes les fenêtres »)"
 
 #. 6.0->settings-schema.json->enable-expo-effects->tooltip
 msgid ""
@@ -121,20 +126,22 @@ msgstr ""
 "remplace certains paramètres des thèmes pour obtenir un panneau "
 "(semi-)transparent de sorte que l'arrière-plan flou soit visible."
 
-#. 6.0->settings-schema.json->enable-mainmenu-effects->description
-msgid "Main Menu  (Please read tooltip)"
+#. 6.0->settings-schema.json->enable-popup-effects->description
+#, fuzzy
+msgid "Popup Menus  (Please read tooltip)"
 msgstr "Menu principal (Veuillez lire l'infobulle)"
 
-#. 6.0->settings-schema.json->enable-mainmenu-effects->tooltip
+#. 6.0->settings-schema.json->enable-popup-effects->tooltip
+#, fuzzy
 msgid ""
-"Apply effects to the Main Menu (menu@cinnamon.org applet). This option is "
-"intended for the Cinnamon (6.4) and Mint-Y Dark desktop themes but might "
-"work well with other themes. Light themes are unlikely to give good results "
-"but might be made to work with some creative use of the dimming color "
-"settings and an appropriate background image. It overrides some theme "
-"settings to achieve a (semi-)transparent menu so that the blurred background "
-"is visible. It also removes rounded corners so that the blurred background "
-"will not spill over the rounded edges."
+"Apply effects to panel applet popup menus. This option is intended for the "
+"Cinnamon (6.4) and Mint-Y dark desktop themes but might work well with other "
+"themes. Light themes are unlikely to give good results but might be made to "
+"work with some creative use of the dimming color settings and an appropriate "
+"background image. It overrides some theme settings to achieve a "
+"(semi-)transparent menu so that the blurred background is visible. It also "
+"removes rounded corners so that the blurred background will not spill over "
+"the rounded edges."
 msgstr ""
 "Appliquer des effets au menu principal (menu@cinnamon.org applet). Cette "
 "option est destinée aux thèmes de bureau Cinnamon (6.4) et Mint-Y Dark, mais "
@@ -165,9 +172,10 @@ msgstr ""
 "Avertissement : Les effets des Panneaux sont actuellement désactivés dans "
 "l'onglet Général."
 
-#. 6.0->settings-schema.json->mainmenu-info->description
+#. 6.0->settings-schema.json->popup-info->description
+#, fuzzy
 msgid ""
-"Warning: Main Menu effects are currently disabled under the General tab."
+"Warning: Popup Menu effects are currently disabled under the General tab."
 msgstr ""
 "Avertissement : Les effets du Menu principal sont actuellement désactivés "
 "dans l'onglet Général."
@@ -189,16 +197,18 @@ msgstr ""
 "paramètre ne doit être désactivé que si le thème utilise déjà des panneaux "
 "transparents et que vous souhaitez que les paramètres du thème s'appliquent."
 
-#. 6.0->settings-schema.json->allow-transparent-color-mainmenu->description
-msgid "Override some of the Main Menu theme settings (recommended)"
+#. 6.0->settings-schema.json->allow-transparent-color-popup->description
+#, fuzzy
+msgid "Override some of the popup menu theme settings (recommended)"
 msgstr "Remplacer certains paramètres du thème du menu principal (recommandé)"
 
-#. 6.0->settings-schema.json->allow-transparent-color-mainmenu->tooltip
+#. 6.0->settings-schema.json->allow-transparent-color-popup->tooltip
+#, fuzzy
 msgid ""
-"Allow this extension to modify the Main Menu transparency, background color "
+"Allow this extension to modify the popup Menu transparency, background color "
 "and rounded corner settings. If this is disabled the extension will only "
-"apply a blur overlay under the main menu. This setting should only be "
-"disabled when the theme already uses a transparent main menu and you want "
+"apply a blur overlay under the popup menus. This setting should only be "
+"disabled when the theme already uses transparent popup menus and you want "
 "the themes setting to apply."
 msgstr ""
 "Permet à cette extension de modifier les paramètres de transparence, de "
@@ -220,9 +230,10 @@ msgstr "Utiliser des paramètres d'effet spécifiques pour l'Expo"
 msgid "Use unique effect settings for the Panels"
 msgstr "Utiliser des paramètres d'effet spécifiques pour les Panneaux"
 
-#. 6.0->settings-schema.json->enable-mainmenu-override->description
-msgid "Use unique effect settings for the Main Menu"
-msgstr "Utiliser des paramètres d'effet spécifiques pour le Menu principal"
+#. 6.0->settings-schema.json->enable-popup-override->description
+#, fuzzy
+msgid "Use unique effect settings for the popup menus"
+msgstr "Utiliser des paramètres d'effet spécifiques pour l'Expo"
 
 #. 6.0->settings-schema.json->enable-panel-unique-settings->description
 msgid "Use unique effect settings for each panel"
@@ -260,6 +271,10 @@ msgstr "Blur"
 msgid "Intensity"
 msgstr "Intensité"
 
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Saturation"
+msgstr ""
+
 #. 6.0->settings-schema.json->panel-unique-settings->tooltip
 msgid ""
 "Defines the effects applied to different panels. If a panel does not meet "
@@ -280,7 +295,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-opacity->description
 #. 6.0->settings-schema.json->expo-opacity->description
 #. 6.0->settings-schema.json->panels-opacity->description
-#. 6.0->settings-schema.json->mainmenu-opacity->description
+#. 6.0->settings-schema.json->popup-opacity->description
 msgid "Dim/Colorize Background (percentage)"
 msgstr "Graduer/Colorer l'arrière-plan (pourcentage)"
 
@@ -294,7 +309,7 @@ msgstr "Gradation de la couleur de l'incrustation"
 #. 6.0->settings-schema.json->overview-blendColor->tooltip
 #. 6.0->settings-schema.json->expo-blendColor->tooltip
 #. 6.0->settings-schema.json->panels-blendColor->tooltip
-#. 6.0->settings-schema.json->mainmenu-blendColor->tooltip
+#. 6.0->settings-schema.json->popup-blendColor->tooltip
 msgid ""
 "Defines the color that is blended into the background based on the dimming "
 "control above. Use black for a normal dimming effect or some other color for "
@@ -308,7 +323,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->mainmenu-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
 msgid "None"
 msgstr "Aucun"
 
@@ -316,7 +331,7 @@ msgstr "Aucun"
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->mainmenu-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
 msgid "Simple"
 msgstr "Simple"
 
@@ -324,7 +339,7 @@ msgstr "Simple"
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->mainmenu-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
 msgid "Gaussian"
 msgstr "Gaussien"
 
@@ -332,7 +347,7 @@ msgstr "Gaussien"
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
 #. 6.0->settings-schema.json->panels-blurType->description
-#. 6.0->settings-schema.json->mainmenu-blurType->description
+#. 6.0->settings-schema.json->popup-blurType->description
 msgid "Type of blur effect"
 msgstr "Type d'effet de flou"
 
@@ -340,7 +355,7 @@ msgstr "Type d'effet de flou"
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->panels-blurType->tooltip
-#. 6.0->settings-schema.json->mainmenu-blurType->tooltip
+#. 6.0->settings-schema.json->popup-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Type d'algorithme à utiliser pour rendre l'arrière-plan flou"
 
@@ -360,18 +375,34 @@ msgstr ""
 "Règle l'intensité de l'effet de flou en modifiant le rayon utilisé par "
 "l'effet."
 
+#. 6.0->settings-schema.json->saturation->description
+#. 6.0->settings-schema.json->overview-saturation->description
+#. 6.0->settings-schema.json->expo-saturation->description
+#. 6.0->settings-schema.json->panels-saturation->description
+#. 6.0->settings-schema.json->popup-saturation->description
+msgid "Background color saturation"
+msgstr ""
+
+#. 6.0->settings-schema.json->saturation->tooltip
+#. 6.0->settings-schema.json->overview-saturation->tooltip
+#. 6.0->settings-schema.json->expo-saturation->tooltip
+#. 6.0->settings-schema.json->panels-saturation->tooltip
+#. 6.0->settings-schema.json->popup-saturation->tooltip
+msgid "Adjusts the color saturation of the background image."
+msgstr ""
+
 #. 6.0->settings-schema.json->panels-blendColor->description
-#. 6.0->settings-schema.json->mainmenu-blendColor->description
+#. 6.0->settings-schema.json->popup-blendColor->description
 msgid "Dimming ovrerlay color"
 msgstr "Gradation de la couleur de l'incrustation"
 
 #. 6.0->settings-schema.json->panels-radius->description
-#. 6.0->settings-schema.json->mainmenu-radius->description
+#. 6.0->settings-schema.json->popup-radius->description
 msgid "Blur intensity (Gaussian only)"
 msgstr "Intensité du flou (gaussien uniquement)"
 
 #. 6.0->settings-schema.json->panels-radius->tooltip
-#. 6.0->settings-schema.json->mainmenu-radius->tooltip
+#. 6.0->settings-schema.json->popup-radius->tooltip
 msgid ""
 "Adjusts the intensity of the Gaussian blur effect by changing the radius use "
 "by the effect. This setting does not effect the Simple blur type"
@@ -379,17 +410,19 @@ msgstr ""
 "Règle l'intensité de l'effet de flou gaussien en modifiant le rayon utilisé "
 "par l'effet. Ce paramètre n'affecte pas le type de flou simple"
 
-#. 6.0->settings-schema.json->mainmenu-accent-opacity->description
-msgid "Additional Main Menu accent elements dimming (percentage)"
+#. 6.0->settings-schema.json->popup-accent-opacity->description
+#, fuzzy
+msgid "Additional popup menu accent elements dimming (percentage)"
 msgstr ""
 "Menu principal supplémentaire Gradation des éléments d'accentuation "
 "(pourcentage)"
 
-#. 6.0->settings-schema.json->mainmenu-accent-opacity->tooltip
+#. 6.0->settings-schema.json->popup-accent-opacity->tooltip
+#, fuzzy
 msgid ""
-"Defines the additional dimming applied to the main menu accent elements (the "
-"favorites box and the search entry box) which allow these elements to stand "
-"out from the other main menu areas"
+"Defines the additional dimming applied to the popup menu accent elements (i."
+"e. the main menu favorites box and entry boxes) which allow these elements "
+"to stand out from the other popup menu areas"
 msgstr ""
 "Définit la gradation supplémentaire appliquée aux éléments d'accentuation du "
 "menu principal (la boîte des favoris et la boîte de recherche) qui permet à "


### PR DESCRIPTION
- Replaced the Main Menu effects with generic Popup Menu effects which covers the main menu as well as all other Applet popup menus.
- Added a Saturation option which allow you to desaturate the background overlay (0%, grey scale to 100%)