### PR TITLE
BlurCinnamon@klangman: Desktop background effect + fixes

### DIFF
--- a/BlurCinnamon@klangman/CHANGELOG.md
+++ b/BlurCinnamon@klangman/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 1.4.0
+
+* Added the ability to apply effects to the Desktop background image (you can Dim, Blur and Desaturate, but currently you can't colorize the background image)
+* Improved how the blur effect keeps in sync with the size of the the panels
+* Always hid the parts of windows that are under the panels, even when no blur effect is need to be more consistent
+* Several fixes , minor improvements, optimizations and simplifications to the code
+
 ## 1.3.0
 
 * Replaced the Main Menu effects with generic Popup Menu effects which covers the main menu as well as all other Applet popup menus. 

--- a/BlurCinnamon@klangman/README.md
+++ b/BlurCinnamon@klangman/README.md
@@ -4,12 +4,13 @@ A Cinnamon extension to Blur, Dim, Colorize, Desaturate and make transparent par
 
 Cinnamon components you can effect (currently):
 
-1. The overview
+1. The Overview
 2. The Expo
-3. Cinnamon Panels
+3. The Panels
 4. Applet popup menus (i.e Menu menu, Calendar, etc.)
+5. The Desktop background image
 
-Blurring can also be disabled if you just want a transparent or semi-transparent effect without blurring. 
+Blurring can also be disabled if you just want a transparent or semi-transparent effect without blurring for Panels, Applet popup menu or the Expo.
 
 ## Features
 
@@ -17,8 +18,8 @@ Blurring can also be disabled if you just want a transparent or semi-transparent
 - Simple blur algorithm (the Cinnamon built-in algorithm) which I would only recommend for very old computers
 - Dimming overlay with user configurable color and intensity (fully-transparent to a solid color)
 - Makes the Panels, Popup menus and the Expo transparent so that the desktop background image effects are visible
-- Allows you to adjust the color saturation of the background overlay. You can reduced saturation all the way  down to gray scale
-- You can use general settings for Popups/Panels/Overview/Expo or use unique settings for each
+- Allows you to adjust the color saturation of the Cinnamon components. You can reduced saturation all the way  down to gray scale
+- You can use general settings for Popups/Panels/Overview/Expo/Background or use unique settings for each
 
 ## Requirements
 
@@ -34,9 +35,9 @@ Using any of the above with Blur Cinnamon may have some odd side effects that wo
 
 ## Limitations
 
-1. The Main Menu effects are intended to be used with the Cinnamon (6.4) theme or the Mint-Y dark desktop themes. The effects might work will with some other themes but I have not tested them so the effects might not work out just right. You can try the Mint-Y light themes but it might be hard to read the menu items without some playing around with the settings and the background image. To make sure that the blurred background does not spill over any rounded corners, the Main Menu rounded corners will be disabled when Main Menu effects are enabled. Menu Menu effects are disabled by default.
-2. The panel applet popup menu effects works for all the applets that I have tested except "Cinnamenu", which uses a bit of an odd way to activate the popup menu, making it more difficult to intercept the menu open process so that I can change the menu's transparency setting.
-3. Currently, any windows that are moved such that they overlap with a panel or the Main Menu will not be visible beneath the panel as you might expect with a transparent panel. This is because the blur effect is applied to a user interface element that floats above all windows just like the panel floats above the windows. At some point I hope to look into allowing the blur element to appear below all windows rather than above and make the a optional behavior setting.
+1. The Applet popup menu effects are intended to be used with the Cinnamon (6.4) theme or the Mint-Y dark desktop themes. The effects might work will with some other themes but I have not tested them so the effects might not work out just right. You can try the Mint-Y light themes but it might be hard to read the menu items without some playing around with the settings and the background image. To make sure that the blurred background does not spill over any rounded corners, the Main Menu rounded corners will be disabled when Main Menu effects are enabled. Menu Menu effects are disabled by default.
+2. The Applet popup menu effects works for all the applets that I have tested except "Cinnamenu", which uses a bit of an odd way to activate the popup menu, making it more difficult to intercept the menu open process so that I can change the menu's transparency setting.
+3. Currently, any windows that are moved such that they overlap with a panel or the Applet popup menus will not be visible beneath the panel/menus as you might expect with a transparent panel/menu. This is because the blur effect is applied to a user interface element that floats above all windows just like the panel floats above the windows. At some point I hope to look into allowing the blur element to appear below all windows rather than above and make the a optional behavior setting.
 4. If you disable effects for any Cinnamon component under the General tab of the setting dialog while any "Use unique effect settings" options are enabled under the other tabs, the components "effect setting" options under the other tabs will still be visible, but changing those setting will have no effect until you re-enable the component under the General tab. Ideally those effect setting would only be visible when the component is enabled under the general tab but Cinnamon setting support is a bit limited in this way.
 
 ## Installation

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/settings-schema.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/settings-schema.json
@@ -1,7 +1,7 @@
 {
    "layout" : {
       "type" : "layout",
-      "pages" : ["general-page", "overview-page", "expo-page", "panels-page", "popup-page"],
+      "pages" : ["general-page", "overview-page", "expo-page", "panels-page", "popup-page", "desktop-page"],
 
       "general-page" : {
          "type" : "page",
@@ -28,11 +28,16 @@
          "title" : "Popup Menus",
          "sections" : ["popup-override", "popup-effect-settings"]
       },
+      "desktop-page" : {
+         "type" : "page",
+         "title" : "Desktop Background",
+         "sections" : ["desktop-override", "desktop-effect-settings"]
+      },
 
       "general-settings" : {
          "type" : "section",
          "title" : "Cinnamon components where effects will be applied",
-         "keys" : ["enable-overview-effects", "enable-expo-effects", "enable-panels-effects", "enable-popup-effects"]
+         "keys" : ["enable-overview-effects", "enable-expo-effects", "enable-panels-effects", "enable-popup-effects", "enable-desktop-effects"]
       },
       "generic-effect-settings" : {
          "type" : "section",
@@ -43,7 +48,7 @@
       "overview-override" : {
          "type" : "section",
          "title" : "Overview settings",
-         "keys" : ["enable-overview-override", "overview-info"]
+         "keys" : ["overview-info", "enable-overview-override"]
       },
       "overview-effect-settings" : {
          "type" : "section",
@@ -55,7 +60,7 @@
       "expo-override" : {
          "type" : "section",
          "title" : "Expo settings",
-         "keys" : ["enable-expo-override", "expo-info"]
+         "keys" : ["expo-info", "enable-expo-override"]
       },
       "expo-effect-settings" : {
          "type" : "section",
@@ -67,7 +72,7 @@
       "panels-override" : {
          "type" : "section",
          "title" : "Panels settings",
-         "keys" : ["enable-panels-override", "panels-info", "allow-transparent-color-panels"]
+         "keys" : ["panels-info", "enable-panels-override", "allow-transparent-color-panels"]
       },
       "panels-effect-settings" : {
          "type" : "section",
@@ -79,15 +84,26 @@
       "popup-override" : {
          "type" : "section",
          "title" : "Panels settings",
-         "keys" : ["enable-popup-override", "popup-info", "allow-transparent-color-popup" ]
+         "keys" : [ "popup-info", "enable-popup-override", "allow-transparent-color-popup" ]
       },
       "popup-effect-settings" : {
          "type" : "section",
          "title" : "Popup menu effects settings",
          "dependency" : "enable-popup-override",
          "keys" : ["popup-opacity", "popup-accent-opacity", "popup-blendColor", "popup-blurType", "popup-radius", "popup-saturation"]
-      }
+      },
 
+      "desktop-override" : {
+         "type" : "section",
+         "title" : "Desktop background settings",
+         "keys" : ["desktop-info", "enable-desktop-override", "desktop-without-focus"]
+      },
+      "desktop-effect-settings" : {
+         "type" : "section",
+         "title" : "Desktop background effects settings",
+         "dependency" : "enable-desktop-override",
+         "keys" : ["desktop-with-focus", "desktop-opacity", "desktop-blurType", "desktop-radius", "desktop-saturation"]
+      }
    },
 
     "enable-overview-effects" : {
@@ -114,6 +130,12 @@
         "tooltip": "Apply effects to panel applet popup menus. This option is intended for the Cinnamon (6.4) and Mint-Y dark desktop themes but might work well with other themes. Light themes are unlikely to give good results but might be made to work with some creative use of the dimming color settings and an appropriate background image. It overrides some theme settings to achieve a (semi-)transparent menu so that the blurred background is visible. It also removes rounded corners so that the blurred background will not spill over the rounded edges.",
         "default": false
     },
+    "enable-desktop-effects" : {
+        "type": "switch",
+        "description": "Desktop background",
+        "tooltip": "Apply effects to desktop background image. On the Desktop Background tab you can choose if the effect applies always or just when a window has the focus.",
+        "default": false
+    },
 
     "overview-info" : {
         "type" : "label",
@@ -135,6 +157,11 @@
         "description" : "Warning: Popup Menu effects are currently disabled under the General tab.",
         "dependency" : "!enable-popup-effects"
     },
+    "desktop-info" : {
+        "type" : "label",
+        "description" : "Warning: Desktop background effects are currently disabled under the General tab.",
+        "dependency" : "!enable-desktop-effects"
+    },
 
     "allow-transparent-color-panels" : {
         "type": "switch",
@@ -152,25 +179,26 @@
     "enable-overview-override" : {
         "type": "switch",
         "description": "Use unique effect settings for the Overview",
-        "dependency" : "enable-overview-effects",
         "default": false
     },
     "enable-expo-override" : {
         "type": "switch",
         "description": "Use unique effect settings for the Expo",
-        "dependency" : "enable-expo-effects",
         "default": false
     },
     "enable-panels-override" : {
         "type": "switch",
         "description": "Use unique effect settings for the Panels",
-        "dependency" : "enable-panels-effects",
         "default": false
     },
     "enable-popup-override" : {
         "type": "switch",
         "description": "Use unique effect settings for the popup menus",
-        "dependency" : "enable-popup-effects",
+        "default": false
+    },
+    "enable-desktop-override" : {
+        "type": "switch",
+        "description": "Use unique effect settings for the desktop background",
         "default": false
     },
 
@@ -197,10 +225,10 @@
         ],
         "tooltip": "Defines the effects applied to different panels. If a panel does not meet the criteria of any enabled entry in this list, it will have no effects applied. The settings of the first entry in this list that can apply to a given panel will take effect. The color field is in the rgb(#,#,#) syntax and black will be used when a color is not provided or is in an incorrect syntax",
         "default" : [
-            { "enabled": true, "panels": 1, "monitors": 0, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100 },
-            { "enabled": true, "panels": 2, "monitors": 0, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100 },
-            { "enabled": true, "panels": 3, "monitors": 0, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100 },
-            { "enabled": true, "panels": 4, "monitors": 0, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100 }
+            { "enabled": true, "panels": 1, "monitors": 100, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100 },
+            { "enabled": true, "panels": 2, "monitors": 100, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100 },
+            { "enabled": true, "panels": 3, "monitors": 100, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100 },
+            { "enabled": true, "panels": 4, "monitors": 100, "opacity": 40, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100 }
         ]
     },
 
@@ -403,7 +431,8 @@
         "max" : 100,
         "step" : 0.1,
         "tooltip": "Adjusts the color saturation of the background image.",
-        "default": 100
+        "default": 100,
+        "dependency" : "!enable-panel-unique-settings"
     },
 
 
@@ -462,11 +491,81 @@
 
     "popup-saturation": {
         "type": "scale",
-        "description" : "Background color saturation",
+        "description" : "Background image color saturation",
         "min" : 0.0,
         "max" : 100,
         "step" : 0.1,
         "tooltip": "Adjusts the color saturation of the background image.",
         "default": 100
+    },
+
+
+    "desktop-without-focus" : {
+        "type": "switch",
+        "description": "Only apply effect settings if the desktop is not in focus",
+        "tooltip": "When enabled, the desktop background image effects will only apply when the desktop is not in focus",
+        "default": true
+    },
+
+    "desktop-with-focus" : {
+        "type": "switch",
+        "description": "Apply the generic effect settings when the desktop is in focus",
+        "tooltip": "When enabled, the generic effect settings (on the General tab) will apply to the desktop background image when the desktop is in focus",
+        "default": false,
+        "dependency" : "enable-desktop-override=1"
+    },
+
+    "desktop-opacity" : {
+        "type": "scale",
+        "description": "Dim background Image (percentage)",
+        "min": 0,
+        "max": 100,
+        "default": 50,
+        "step": 1,
+        "dependency" : "enable-desktop-override=1"
+    },
+
+    "desktop-blendColor": {
+        "type": "colorchooser",
+        "description" : "Dimming ovrerlay color",
+        "default": "rgb(0,0,0)",
+        "dependency" : "enable-desktop-override=1",
+        "tooltip": "Defines the color that is blended into the background based on the dimming control above. Use black for a normal dimming effect or some other color for a color blend effect"
+    },
+
+    "desktop-blurType": {
+        "type": "combobox",
+        "default": 2,
+        "options": {
+            "None": 0,
+            "Simple": 1,
+            "Gaussian": 2
+        },
+        "description": "Type of blur effect",
+        "tooltip": "What type of blur algorithm should be used to blur the background",
+        "dependency" : "enable-desktop-override=1"
+    },
+
+    "desktop-radius": {
+        "type": "scale",
+        "description" : "Blur intensity (Gaussian only)",
+        "min" : 0.0,
+        "max" : 100,
+        "step" : 0.1,
+        "tooltip": "Adjusts the intensity of the Gaussian blur effect by changing the radius use by the effect. This setting does not effect the Simple blur type",
+        "default": 20,
+        "dependency" : "enable-desktop-override=1"
+    },
+
+    "desktop-saturation": {
+        "type": "scale",
+        "description" : "Background color saturation",
+        "min" : 0.0,
+        "max" : 100,
+        "step" : 0.1,
+        "tooltip": "Adjusts the color saturation of the background image.",
+        "default": 100,
+        "dependency" : "enable-desktop-override=1"
     }
+
 }

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
@@ -1,7 +1,7 @@
 {
     "uuid": "BlurCinnamon@klangman",
     "name": "Blur Cinnamon",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "description": "Allows you to blur, colorize, desaturate and adjust the dimming of some Cinnamon Desktop components (i.e. Panels, Applet popup menus, Overview, Expo)",
     "url": "https://github.com/klangman/BlurCinnamon",
     "cinnamon-version": [

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: BlurCinnamon@klangman 1.3.0\n"
+"Project-Id-Version: BlurCinnamon@klangman 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-02-16 15:10-0500\n"
+"POT-Creation-Date: 2025-03-02 19:42-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -49,6 +49,10 @@ msgstr ""
 msgid "Popup Menus"
 msgstr ""
 
+#. 6.0->settings-schema.json->desktop-page->title
+msgid "Desktop Background"
+msgstr ""
+
 #. 6.0->settings-schema.json->general-settings->title
 msgid "Cinnamon components where effects will be applied"
 msgstr ""
@@ -84,6 +88,14 @@ msgstr ""
 
 #. 6.0->settings-schema.json->popup-effect-settings->title
 msgid "Popup menu effects settings"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-override->title
+msgid "Desktop background settings"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-effect-settings->title
+msgid "Desktop background effects settings"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-overview-effects->tooltip
@@ -127,6 +139,16 @@ msgid ""
 "the rounded edges."
 msgstr ""
 
+#. 6.0->settings-schema.json->enable-desktop-effects->description
+msgid "Desktop background"
+msgstr ""
+
+#. 6.0->settings-schema.json->enable-desktop-effects->tooltip
+msgid ""
+"Apply effects to desktop background image. On the Desktop Background tab you "
+"can choose if the effect applies always or just when a window has the focus."
+msgstr ""
+
 #. 6.0->settings-schema.json->overview-info->description
 msgid "Warning: Overview effects are currently disabled under the General tab."
 msgstr ""
@@ -142,6 +164,12 @@ msgstr ""
 #. 6.0->settings-schema.json->popup-info->description
 msgid ""
 "Warning: Popup Menu effects are currently disabled under the General tab."
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-info->description
+msgid ""
+"Warning: Desktop background effects are currently disabled under the General "
+"tab."
 msgstr ""
 
 #. 6.0->settings-schema.json->allow-transparent-color-panels->description
@@ -183,6 +211,10 @@ msgstr ""
 
 #. 6.0->settings-schema.json->enable-popup-override->description
 msgid "Use unique effect settings for the popup menus"
+msgstr ""
+
+#. 6.0->settings-schema.json->enable-desktop-override->description
+msgid "Use unique effect settings for the desktop background"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-panel-unique-settings->description
@@ -254,6 +286,7 @@ msgstr ""
 #. 6.0->settings-schema.json->expo-blendColor->tooltip
 #. 6.0->settings-schema.json->panels-blendColor->tooltip
 #. 6.0->settings-schema.json->popup-blendColor->tooltip
+#. 6.0->settings-schema.json->desktop-blendColor->tooltip
 msgid ""
 "Defines the color that is blended into the background based on the dimming "
 "control above. Use black for a normal dimming effect or some other color for "
@@ -265,6 +298,7 @@ msgstr ""
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
 msgid "None"
 msgstr ""
 
@@ -273,6 +307,7 @@ msgstr ""
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
 msgid "Simple"
 msgstr ""
 
@@ -281,6 +316,7 @@ msgstr ""
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
 msgid "Gaussian"
 msgstr ""
 
@@ -289,6 +325,7 @@ msgstr ""
 #. 6.0->settings-schema.json->expo-blurType->description
 #. 6.0->settings-schema.json->panels-blurType->description
 #. 6.0->settings-schema.json->popup-blurType->description
+#. 6.0->settings-schema.json->desktop-blurType->description
 msgid "Type of blur effect"
 msgstr ""
 
@@ -297,6 +334,7 @@ msgstr ""
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->panels-blurType->tooltip
 #. 6.0->settings-schema.json->popup-blurType->tooltip
+#. 6.0->settings-schema.json->desktop-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr ""
 
@@ -318,7 +356,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-saturation->description
 #. 6.0->settings-schema.json->expo-saturation->description
 #. 6.0->settings-schema.json->panels-saturation->description
-#. 6.0->settings-schema.json->popup-saturation->description
+#. 6.0->settings-schema.json->desktop-saturation->description
 msgid "Background color saturation"
 msgstr ""
 
@@ -327,21 +365,25 @@ msgstr ""
 #. 6.0->settings-schema.json->expo-saturation->tooltip
 #. 6.0->settings-schema.json->panels-saturation->tooltip
 #. 6.0->settings-schema.json->popup-saturation->tooltip
+#. 6.0->settings-schema.json->desktop-saturation->tooltip
 msgid "Adjusts the color saturation of the background image."
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-blendColor->description
 #. 6.0->settings-schema.json->popup-blendColor->description
+#. 6.0->settings-schema.json->desktop-blendColor->description
 msgid "Dimming ovrerlay color"
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-radius->description
 #. 6.0->settings-schema.json->popup-radius->description
+#. 6.0->settings-schema.json->desktop-radius->description
 msgid "Blur intensity (Gaussian only)"
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-radius->tooltip
 #. 6.0->settings-schema.json->popup-radius->tooltip
+#. 6.0->settings-schema.json->desktop-radius->tooltip
 msgid ""
 "Adjusts the intensity of the Gaussian blur effect by changing the radius use "
 "by the effect. This setting does not effect the Simple blur type"
@@ -356,4 +398,32 @@ msgid ""
 "Defines the additional dimming applied to the popup menu accent elements (i."
 "e. the main menu favorites box and entry boxes) which allow these elements "
 "to stand out from the other popup menu areas"
+msgstr ""
+
+#. 6.0->settings-schema.json->popup-saturation->description
+msgid "Background image color saturation"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-without-focus->description
+msgid "Only apply effect settings if the desktop is not in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-without-focus->tooltip
+msgid ""
+"When enabled, the desktop background image effects will only apply when the "
+"desktop is not in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-with-focus->description
+msgid "Apply the generic effect settings when the desktop is in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-with-focus->tooltip
+msgid ""
+"When enabled, the generic effect settings (on the General tab) will apply to "
+"the desktop background image when the desktop is in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-opacity->description
+msgid "Dim background Image (percentage)"
 msgstr ""

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-02-16 15:10-0500\n"
+"POT-Creation-Date: 2025-03-02 19:42-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -53,6 +53,10 @@ msgstr "Taulers"
 msgid "Popup Menus"
 msgstr "Menús emergents"
 
+#. 6.0->settings-schema.json->desktop-page->title
+msgid "Desktop Background"
+msgstr ""
+
 #. 6.0->settings-schema.json->general-settings->title
 msgid "Cinnamon components where effects will be applied"
 msgstr "Components de Cinnamon als quals s'aplicaran els efectes"
@@ -88,6 +92,15 @@ msgstr "Opcions d'efectes dels taulers"
 
 #. 6.0->settings-schema.json->popup-effect-settings->title
 msgid "Popup menu effects settings"
+msgstr "Opcions d'efectes dels menús emergents"
+
+#. 6.0->settings-schema.json->desktop-override->title
+msgid "Desktop background settings"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-effect-settings->title
+#, fuzzy
+msgid "Desktop background effects settings"
 msgstr "Opcions d'efectes dels menús emergents"
 
 #. 6.0->settings-schema.json->enable-overview-effects->tooltip
@@ -149,6 +162,16 @@ msgstr ""
 "visible. També elimina les cantonades arrodonides per tal que la difuminació "
 "no s'hi escampi per les vores."
 
+#. 6.0->settings-schema.json->enable-desktop-effects->description
+msgid "Desktop background"
+msgstr ""
+
+#. 6.0->settings-schema.json->enable-desktop-effects->tooltip
+msgid ""
+"Apply effects to desktop background image. On the Desktop Background tab you "
+"can choose if the effect applies always or just when a window has the focus."
+msgstr ""
+
 #. 6.0->settings-schema.json->overview-info->description
 msgid "Warning: Overview effects are currently disabled under the General tab."
 msgstr ""
@@ -169,6 +192,14 @@ msgid ""
 msgstr ""
 "Avís: els efectes dels menús emergents estan desactivats a la pestanya "
 "General."
+
+#. 6.0->settings-schema.json->desktop-info->description
+#, fuzzy
+msgid ""
+"Warning: Desktop background effects are currently disabled under the General "
+"tab."
+msgstr ""
+"Avís: els efectes de l'Exposició estan desactivats a la pestanya General."
 
 #. 6.0->settings-schema.json->allow-transparent-color-panels->description
 msgid "Override some of the panels theme settings (recommended)"
@@ -222,6 +253,11 @@ msgstr "Utilitza ajusts d'efectes exclusius pels Taulers"
 #. 6.0->settings-schema.json->enable-popup-override->description
 msgid "Use unique effect settings for the popup menus"
 msgstr "Utilitza ajusts d'efectes exclusius pels menús emergents"
+
+#. 6.0->settings-schema.json->enable-desktop-override->description
+#, fuzzy
+msgid "Use unique effect settings for the desktop background"
+msgstr "Utilitza ajusts d'efectes exclusius per a l'Exposició"
 
 #. 6.0->settings-schema.json->enable-panel-unique-settings->description
 msgid "Use unique effect settings for each panel"
@@ -297,6 +333,7 @@ msgstr "Color de l'atenuació superposada"
 #. 6.0->settings-schema.json->expo-blendColor->tooltip
 #. 6.0->settings-schema.json->panels-blendColor->tooltip
 #. 6.0->settings-schema.json->popup-blendColor->tooltip
+#. 6.0->settings-schema.json->desktop-blendColor->tooltip
 msgid ""
 "Defines the color that is blended into the background based on the dimming "
 "control above. Use black for a normal dimming effect or some other color for "
@@ -311,6 +348,7 @@ msgstr ""
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
 msgid "None"
 msgstr "Cap"
 
@@ -319,6 +357,7 @@ msgstr "Cap"
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
 msgid "Simple"
 msgstr "Simple"
 
@@ -327,6 +366,7 @@ msgstr "Simple"
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
 msgid "Gaussian"
 msgstr "Gaussià"
 
@@ -335,6 +375,7 @@ msgstr "Gaussià"
 #. 6.0->settings-schema.json->expo-blurType->description
 #. 6.0->settings-schema.json->panels-blurType->description
 #. 6.0->settings-schema.json->popup-blurType->description
+#. 6.0->settings-schema.json->desktop-blurType->description
 msgid "Type of blur effect"
 msgstr "Tipus d'efecte de difuminat"
 
@@ -343,6 +384,7 @@ msgstr "Tipus d'efecte de difuminat"
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->panels-blurType->tooltip
 #. 6.0->settings-schema.json->popup-blurType->tooltip
+#. 6.0->settings-schema.json->desktop-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Tipus d'algorisme de difuminat que s'utilitzarà pel fons"
 
@@ -366,7 +408,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-saturation->description
 #. 6.0->settings-schema.json->expo-saturation->description
 #. 6.0->settings-schema.json->panels-saturation->description
-#. 6.0->settings-schema.json->popup-saturation->description
+#. 6.0->settings-schema.json->desktop-saturation->description
 msgid "Background color saturation"
 msgstr "Saturació del color de fons"
 
@@ -375,21 +417,25 @@ msgstr "Saturació del color de fons"
 #. 6.0->settings-schema.json->expo-saturation->tooltip
 #. 6.0->settings-schema.json->panels-saturation->tooltip
 #. 6.0->settings-schema.json->popup-saturation->tooltip
+#. 6.0->settings-schema.json->desktop-saturation->tooltip
 msgid "Adjusts the color saturation of the background image."
 msgstr "Ajusta la saturació de color de la imatge de fons."
 
 #. 6.0->settings-schema.json->panels-blendColor->description
 #. 6.0->settings-schema.json->popup-blendColor->description
+#. 6.0->settings-schema.json->desktop-blendColor->description
 msgid "Dimming ovrerlay color"
 msgstr "Color de l'atenuació superposada"
 
 #. 6.0->settings-schema.json->panels-radius->description
 #. 6.0->settings-schema.json->popup-radius->description
+#. 6.0->settings-schema.json->desktop-radius->description
 msgid "Blur intensity (Gaussian only)"
 msgstr "Intensitat del difuminat (només Gaussià)"
 
 #. 6.0->settings-schema.json->panels-radius->tooltip
 #. 6.0->settings-schema.json->popup-radius->tooltip
+#. 6.0->settings-schema.json->desktop-radius->tooltip
 msgid ""
 "Adjusts the intensity of the Gaussian blur effect by changing the radius use "
 "by the effect. This setting does not effect the Simple blur type"
@@ -410,3 +456,33 @@ msgstr ""
 "Defineix el grau d'atenuació addicional que s'aplicarà als elements dels "
 "menús emergents (caixa de preferits i camp de cerca), que permetrà que "
 "aquests elements ressaltin sobre la resta d'àrees del menú"
+
+#. 6.0->settings-schema.json->popup-saturation->description
+#, fuzzy
+msgid "Background image color saturation"
+msgstr "Saturació del color de fons"
+
+#. 6.0->settings-schema.json->desktop-without-focus->description
+msgid "Only apply effect settings if the desktop is not in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-without-focus->tooltip
+msgid ""
+"When enabled, the desktop background image effects will only apply when the "
+"desktop is not in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-with-focus->description
+msgid "Apply the generic effect settings when the desktop is in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-with-focus->tooltip
+msgid ""
+"When enabled, the generic effect settings (on the General tab) will apply to "
+"the desktop background image when the desktop is in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-opacity->description
+#, fuzzy
+msgid "Dim background Image (percentage)"
+msgstr "Atenuació/Tint del fons (percentatge)"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-02-16 15:10-0500\n"
+"POT-Creation-Date: 2025-03-02 19:42-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -52,6 +52,10 @@ msgstr "Paneles"
 msgid "Popup Menus"
 msgstr "Menús emergentes"
 
+#. 6.0->settings-schema.json->desktop-page->title
+msgid "Desktop Background"
+msgstr ""
+
 #. 6.0->settings-schema.json->general-settings->title
 msgid "Cinnamon components where effects will be applied"
 msgstr "Componentes de Cinnamon donde se aplicarán los efectos"
@@ -87,6 +91,15 @@ msgstr "Configuración de efectos del panel"
 
 #. 6.0->settings-schema.json->popup-effect-settings->title
 msgid "Popup menu effects settings"
+msgstr "Configuración de los efectos del menú emergente"
+
+#. 6.0->settings-schema.json->desktop-override->title
+msgid "Desktop background settings"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-effect-settings->title
+#, fuzzy
+msgid "Desktop background effects settings"
 msgstr "Configuración de los efectos del menú emergente"
 
 #. 6.0->settings-schema.json->enable-overview-effects->tooltip
@@ -148,6 +161,16 @@ msgstr ""
 "que el fondo difuminado sea visible. También elimina las esquinas "
 "redondeadas para que el fondo difuminado no sobrepase los bordes redondeados."
 
+#. 6.0->settings-schema.json->enable-desktop-effects->description
+msgid "Desktop background"
+msgstr ""
+
+#. 6.0->settings-schema.json->enable-desktop-effects->tooltip
+msgid ""
+"Apply effects to desktop background image. On the Desktop Background tab you "
+"can choose if the effect applies always or just when a window has the focus."
+msgstr ""
+
 #. 6.0->settings-schema.json->overview-info->description
 msgid "Warning: Overview effects are currently disabled under the General tab."
 msgstr ""
@@ -172,6 +195,15 @@ msgid ""
 msgstr ""
 "Advertencia: Los efectos del menú emergente están actualmente desactivados "
 "en la pestaña General."
+
+#. 6.0->settings-schema.json->desktop-info->description
+#, fuzzy
+msgid ""
+"Warning: Desktop background effects are currently disabled under the General "
+"tab."
+msgstr ""
+"Advertencia: Los efectos de exposición están actualmente deshabilitados en "
+"la pestaña General."
 
 #. 6.0->settings-schema.json->allow-transparent-color-panels->description
 msgid "Override some of the panels theme settings (recommended)"
@@ -225,6 +257,11 @@ msgstr "Usar ajustes de efectos exclusivos para los Paneles"
 #. 6.0->settings-schema.json->enable-popup-override->description
 msgid "Use unique effect settings for the popup menus"
 msgstr "Usar ajustes de efectos exclusivos para los menús emergentes"
+
+#. 6.0->settings-schema.json->enable-desktop-override->description
+#, fuzzy
+msgid "Use unique effect settings for the desktop background"
+msgstr "Usar ajustes de efectos exclusivos para el efecto Exposición"
 
 #. 6.0->settings-schema.json->enable-panel-unique-settings->description
 msgid "Use unique effect settings for each panel"
@@ -301,6 +338,7 @@ msgstr "Atenuación del color de superposición"
 #. 6.0->settings-schema.json->expo-blendColor->tooltip
 #. 6.0->settings-schema.json->panels-blendColor->tooltip
 #. 6.0->settings-schema.json->popup-blendColor->tooltip
+#. 6.0->settings-schema.json->desktop-blendColor->tooltip
 msgid ""
 "Defines the color that is blended into the background based on the dimming "
 "control above. Use black for a normal dimming effect or some other color for "
@@ -315,6 +353,7 @@ msgstr ""
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
 msgid "None"
 msgstr "Ninguno"
 
@@ -323,6 +362,7 @@ msgstr "Ninguno"
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
 msgid "Simple"
 msgstr "Sencillo"
 
@@ -331,6 +371,7 @@ msgstr "Sencillo"
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
 msgid "Gaussian"
 msgstr "Gaussiano"
 
@@ -339,6 +380,7 @@ msgstr "Gaussiano"
 #. 6.0->settings-schema.json->expo-blurType->description
 #. 6.0->settings-schema.json->panels-blurType->description
 #. 6.0->settings-schema.json->popup-blurType->description
+#. 6.0->settings-schema.json->desktop-blurType->description
 msgid "Type of blur effect"
 msgstr "Tipo de efecto de desenfoque"
 
@@ -347,6 +389,7 @@ msgstr "Tipo de efecto de desenfoque"
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->panels-blurType->tooltip
 #. 6.0->settings-schema.json->popup-blurType->tooltip
+#. 6.0->settings-schema.json->desktop-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr ""
 "Que tipo de algoritmo de desenfoque debe utilizarse para desenfocar el fondo."
@@ -371,7 +414,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-saturation->description
 #. 6.0->settings-schema.json->expo-saturation->description
 #. 6.0->settings-schema.json->panels-saturation->description
-#. 6.0->settings-schema.json->popup-saturation->description
+#. 6.0->settings-schema.json->desktop-saturation->description
 msgid "Background color saturation"
 msgstr "Saturación del color de fondo"
 
@@ -380,21 +423,25 @@ msgstr "Saturación del color de fondo"
 #. 6.0->settings-schema.json->expo-saturation->tooltip
 #. 6.0->settings-schema.json->panels-saturation->tooltip
 #. 6.0->settings-schema.json->popup-saturation->tooltip
+#. 6.0->settings-schema.json->desktop-saturation->tooltip
 msgid "Adjusts the color saturation of the background image."
 msgstr "Ajusta la saturación de color de la imagen de fondo."
 
 #. 6.0->settings-schema.json->panels-blendColor->description
 #. 6.0->settings-schema.json->popup-blendColor->description
+#. 6.0->settings-schema.json->desktop-blendColor->description
 msgid "Dimming ovrerlay color"
 msgstr "Atenuación del color de superposición"
 
 #. 6.0->settings-schema.json->panels-radius->description
 #. 6.0->settings-schema.json->popup-radius->description
+#. 6.0->settings-schema.json->desktop-radius->description
 msgid "Blur intensity (Gaussian only)"
 msgstr "Intensidad del desenfoque (sólo Gaussiano)"
 
 #. 6.0->settings-schema.json->panels-radius->tooltip
 #. 6.0->settings-schema.json->popup-radius->tooltip
+#. 6.0->settings-schema.json->desktop-radius->tooltip
 msgid ""
 "Adjusts the intensity of the Gaussian blur effect by changing the radius use "
 "by the effect. This setting does not effect the Simple blur type"
@@ -417,3 +464,33 @@ msgstr ""
 "emergente (es decir, el cuadro de favoritos del menú principal y los cuadros "
 "de entrada) que permiten que estos elementos destaquen de las demás áreas "
 "del menú emergente"
+
+#. 6.0->settings-schema.json->popup-saturation->description
+#, fuzzy
+msgid "Background image color saturation"
+msgstr "Saturación del color de fondo"
+
+#. 6.0->settings-schema.json->desktop-without-focus->description
+msgid "Only apply effect settings if the desktop is not in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-without-focus->tooltip
+msgid ""
+"When enabled, the desktop background image effects will only apply when the "
+"desktop is not in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-with-focus->description
+msgid "Apply the generic effect settings when the desktop is in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-with-focus->tooltip
+msgid ""
+"When enabled, the generic effect settings (on the General tab) will apply to "
+"the desktop background image when the desktop is in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-opacity->description
+#, fuzzy
+msgid "Dim background Image (percentage)"
+msgstr "Atenuar/colorear fondo (porcentaje)"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-02-16 15:10-0500\n"
+"POT-Creation-Date: 2025-03-02 19:42-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -53,6 +53,10 @@ msgstr "Panneaux"
 msgid "Popup Menus"
 msgstr ""
 
+#. 6.0->settings-schema.json->desktop-page->title
+msgid "Desktop Background"
+msgstr ""
+
 #. 6.0->settings-schema.json->general-settings->title
 msgid "Cinnamon components where effects will be applied"
 msgstr "Composants de Cinnamon où les effets seront appliqués"
@@ -89,6 +93,15 @@ msgstr "Paramètres des effets du Panneau"
 #. 6.0->settings-schema.json->popup-effect-settings->title
 #, fuzzy
 msgid "Popup menu effects settings"
+msgstr "Paramètres des effets du Panneau"
+
+#. 6.0->settings-schema.json->desktop-override->title
+msgid "Desktop background settings"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-effect-settings->title
+#, fuzzy
+msgid "Desktop background effects settings"
 msgstr "Paramètres des effets du Panneau"
 
 #. 6.0->settings-schema.json->enable-overview-effects->tooltip
@@ -154,6 +167,16 @@ msgstr ""
 "supprime également les coins arrondis afin que l'arrière-plan flou ne "
 "déborde pas sur les bords arrondis."
 
+#. 6.0->settings-schema.json->enable-desktop-effects->description
+msgid "Desktop background"
+msgstr ""
+
+#. 6.0->settings-schema.json->enable-desktop-effects->tooltip
+msgid ""
+"Apply effects to desktop background image. On the Desktop Background tab you "
+"can choose if the effect applies always or just when a window has the focus."
+msgstr ""
+
 #. 6.0->settings-schema.json->overview-info->description
 msgid "Warning: Overview effects are currently disabled under the General tab."
 msgstr ""
@@ -179,6 +202,15 @@ msgid ""
 msgstr ""
 "Avertissement : Les effets du Menu principal sont actuellement désactivés "
 "dans l'onglet Général."
+
+#. 6.0->settings-schema.json->desktop-info->description
+#, fuzzy
+msgid ""
+"Warning: Desktop background effects are currently disabled under the General "
+"tab."
+msgstr ""
+"Avertissement : Les effets Expo sont actuellement désactivés dans l'onglet "
+"Général."
 
 #. 6.0->settings-schema.json->allow-transparent-color-panels->description
 msgid "Override some of the panels theme settings (recommended)"
@@ -233,6 +265,11 @@ msgstr "Utiliser des paramètres d'effet spécifiques pour les Panneaux"
 #. 6.0->settings-schema.json->enable-popup-override->description
 #, fuzzy
 msgid "Use unique effect settings for the popup menus"
+msgstr "Utiliser des paramètres d'effet spécifiques pour l'Expo"
+
+#. 6.0->settings-schema.json->enable-desktop-override->description
+#, fuzzy
+msgid "Use unique effect settings for the desktop background"
 msgstr "Utiliser des paramètres d'effet spécifiques pour l'Expo"
 
 #. 6.0->settings-schema.json->enable-panel-unique-settings->description
@@ -310,6 +347,7 @@ msgstr "Gradation de la couleur de l'incrustation"
 #. 6.0->settings-schema.json->expo-blendColor->tooltip
 #. 6.0->settings-schema.json->panels-blendColor->tooltip
 #. 6.0->settings-schema.json->popup-blendColor->tooltip
+#. 6.0->settings-schema.json->desktop-blendColor->tooltip
 msgid ""
 "Defines the color that is blended into the background based on the dimming "
 "control above. Use black for a normal dimming effect or some other color for "
@@ -324,6 +362,7 @@ msgstr ""
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
 msgid "None"
 msgstr "Aucun"
 
@@ -332,6 +371,7 @@ msgstr "Aucun"
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
 msgid "Simple"
 msgstr "Simple"
 
@@ -340,6 +380,7 @@ msgstr "Simple"
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
 msgid "Gaussian"
 msgstr "Gaussien"
 
@@ -348,6 +389,7 @@ msgstr "Gaussien"
 #. 6.0->settings-schema.json->expo-blurType->description
 #. 6.0->settings-schema.json->panels-blurType->description
 #. 6.0->settings-schema.json->popup-blurType->description
+#. 6.0->settings-schema.json->desktop-blurType->description
 msgid "Type of blur effect"
 msgstr "Type d'effet de flou"
 
@@ -356,6 +398,7 @@ msgstr "Type d'effet de flou"
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->panels-blurType->tooltip
 #. 6.0->settings-schema.json->popup-blurType->tooltip
+#. 6.0->settings-schema.json->desktop-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Type d'algorithme à utiliser pour rendre l'arrière-plan flou"
 
@@ -379,7 +422,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-saturation->description
 #. 6.0->settings-schema.json->expo-saturation->description
 #. 6.0->settings-schema.json->panels-saturation->description
-#. 6.0->settings-schema.json->popup-saturation->description
+#. 6.0->settings-schema.json->desktop-saturation->description
 msgid "Background color saturation"
 msgstr ""
 
@@ -388,21 +431,25 @@ msgstr ""
 #. 6.0->settings-schema.json->expo-saturation->tooltip
 #. 6.0->settings-schema.json->panels-saturation->tooltip
 #. 6.0->settings-schema.json->popup-saturation->tooltip
+#. 6.0->settings-schema.json->desktop-saturation->tooltip
 msgid "Adjusts the color saturation of the background image."
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-blendColor->description
 #. 6.0->settings-schema.json->popup-blendColor->description
+#. 6.0->settings-schema.json->desktop-blendColor->description
 msgid "Dimming ovrerlay color"
 msgstr "Gradation de la couleur de l'incrustation"
 
 #. 6.0->settings-schema.json->panels-radius->description
 #. 6.0->settings-schema.json->popup-radius->description
+#. 6.0->settings-schema.json->desktop-radius->description
 msgid "Blur intensity (Gaussian only)"
 msgstr "Intensité du flou (gaussien uniquement)"
 
 #. 6.0->settings-schema.json->panels-radius->tooltip
 #. 6.0->settings-schema.json->popup-radius->tooltip
+#. 6.0->settings-schema.json->desktop-radius->tooltip
 msgid ""
 "Adjusts the intensity of the Gaussian blur effect by changing the radius use "
 "by the effect. This setting does not effect the Simple blur type"
@@ -427,3 +474,32 @@ msgstr ""
 "Définit la gradation supplémentaire appliquée aux éléments d'accentuation du "
 "menu principal (la boîte des favoris et la boîte de recherche) qui permet à "
 "ces éléments de se démarquer des autres zones du menu principal"
+
+#. 6.0->settings-schema.json->popup-saturation->description
+msgid "Background image color saturation"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-without-focus->description
+msgid "Only apply effect settings if the desktop is not in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-without-focus->tooltip
+msgid ""
+"When enabled, the desktop background image effects will only apply when the "
+"desktop is not in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-with-focus->description
+msgid "Apply the generic effect settings when the desktop is in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-with-focus->tooltip
+msgid ""
+"When enabled, the generic effect settings (on the General tab) will apply to "
+"the desktop background image when the desktop is in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-opacity->description
+#, fuzzy
+msgid "Dim background Image (percentage)"
+msgstr "Graduer/Colorer l'arrière-plan (pourcentage)"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/nl.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-02-16 15:10-0500\n"
+"POT-Creation-Date: 2025-03-02 19:42-0500\n"
 "PO-Revision-Date: 2025-02-21 09:56+0100\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -51,6 +51,10 @@ msgstr "Panelen"
 msgid "Popup Menus"
 msgstr "Pop-upmenu's"
 
+#. 6.0->settings-schema.json->desktop-page->title
+msgid "Desktop Background"
+msgstr ""
+
 #. 6.0->settings-schema.json->general-settings->title
 msgid "Cinnamon components where effects will be applied"
 msgstr "Cinnamon-componenten waarop effecten worden toegepast"
@@ -86,6 +90,15 @@ msgstr "Effectinstellingen voor Panelen"
 
 #. 6.0->settings-schema.json->popup-effect-settings->title
 msgid "Popup menu effects settings"
+msgstr "Effectinstellingen voor pop-upmenu's"
+
+#. 6.0->settings-schema.json->desktop-override->title
+msgid "Desktop background settings"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-effect-settings->title
+#, fuzzy
+msgid "Desktop background effects settings"
 msgstr "Effectinstellingen voor pop-upmenu's"
 
 #. 6.0->settings-schema.json->enable-overview-effects->tooltip
@@ -148,6 +161,16 @@ msgstr ""
 "verwijderd, zodat de vervaagde achtergrond niet over de ronde randen "
 "uitloopt."
 
+#. 6.0->settings-schema.json->enable-desktop-effects->description
+msgid "Desktop background"
+msgstr ""
+
+#. 6.0->settings-schema.json->enable-desktop-effects->tooltip
+msgid ""
+"Apply effects to desktop background image. On the Desktop Background tab you "
+"can choose if the effect applies always or just when a window has the focus."
+msgstr ""
+
 #. 6.0->settings-schema.json->overview-info->description
 msgid "Warning: Overview effects are currently disabled under the General tab."
 msgstr ""
@@ -172,6 +195,15 @@ msgid ""
 msgstr ""
 "Waarschuwing: effecten voor Pop-upmenu's zijn momenteel uitgeschakeld op het "
 "tabblad Algemeen."
+
+#. 6.0->settings-schema.json->desktop-info->description
+#, fuzzy
+msgid ""
+"Warning: Desktop background effects are currently disabled under the General "
+"tab."
+msgstr ""
+"Waarschuwing: effecten voor Expo zijn momenteel uitgeschakeld op het tabblad "
+"Algemeen."
 
 #. 6.0->settings-schema.json->allow-transparent-color-panels->description
 msgid "Override some of the panels theme settings (recommended)"
@@ -225,6 +257,11 @@ msgstr "Unieke effectinstellingen gebruiken voor Panelen"
 #. 6.0->settings-schema.json->enable-popup-override->description
 msgid "Use unique effect settings for the popup menus"
 msgstr "Unieke effectinstellingen gebruiken voor pop-upmenu’s"
+
+#. 6.0->settings-schema.json->enable-desktop-override->description
+#, fuzzy
+msgid "Use unique effect settings for the desktop background"
+msgstr "Unieke effectinstellingen gebruiken voor Expo"
 
 #. 6.0->settings-schema.json->enable-panel-unique-settings->description
 msgid "Use unique effect settings for each panel"
@@ -301,6 +338,7 @@ msgstr "Verduisteringslaag kleur"
 #. 6.0->settings-schema.json->expo-blendColor->tooltip
 #. 6.0->settings-schema.json->panels-blendColor->tooltip
 #. 6.0->settings-schema.json->popup-blendColor->tooltip
+#. 6.0->settings-schema.json->desktop-blendColor->tooltip
 msgid ""
 "Defines the color that is blended into the background based on the dimming "
 "control above. Use black for a normal dimming effect or some other color for "
@@ -315,6 +353,7 @@ msgstr ""
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
 msgid "None"
 msgstr "Geen"
 
@@ -323,6 +362,7 @@ msgstr "Geen"
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
 msgid "Simple"
 msgstr "Eenvoudig"
 
@@ -331,6 +371,7 @@ msgstr "Eenvoudig"
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
 msgid "Gaussian"
 msgstr "Gaussiaans"
 
@@ -339,6 +380,7 @@ msgstr "Gaussiaans"
 #. 6.0->settings-schema.json->expo-blurType->description
 #. 6.0->settings-schema.json->panels-blurType->description
 #. 6.0->settings-schema.json->popup-blurType->description
+#. 6.0->settings-schema.json->desktop-blurType->description
 msgid "Type of blur effect"
 msgstr "Type van het vervagingseffect"
 
@@ -347,6 +389,7 @@ msgstr "Type van het vervagingseffect"
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->panels-blurType->tooltip
 #. 6.0->settings-schema.json->popup-blurType->tooltip
+#. 6.0->settings-schema.json->desktop-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Welk type algoritme wordt gebruikt om de achtergrond te vervagen."
 
@@ -370,7 +413,7 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-saturation->description
 #. 6.0->settings-schema.json->expo-saturation->description
 #. 6.0->settings-schema.json->panels-saturation->description
-#. 6.0->settings-schema.json->popup-saturation->description
+#. 6.0->settings-schema.json->desktop-saturation->description
 msgid "Background color saturation"
 msgstr "Achtergrondkleurverzadiging"
 
@@ -379,21 +422,25 @@ msgstr "Achtergrondkleurverzadiging"
 #. 6.0->settings-schema.json->expo-saturation->tooltip
 #. 6.0->settings-schema.json->panels-saturation->tooltip
 #. 6.0->settings-schema.json->popup-saturation->tooltip
+#. 6.0->settings-schema.json->desktop-saturation->tooltip
 msgid "Adjusts the color saturation of the background image."
 msgstr "Past de kleurverzadiging van de achtergrondafbeelding aan."
 
 #. 6.0->settings-schema.json->panels-blendColor->description
 #. 6.0->settings-schema.json->popup-blendColor->description
+#. 6.0->settings-schema.json->desktop-blendColor->description
 msgid "Dimming ovrerlay color"
 msgstr "Verduisteringslaag kleur"
 
 #. 6.0->settings-schema.json->panels-radius->description
 #. 6.0->settings-schema.json->popup-radius->description
+#. 6.0->settings-schema.json->desktop-radius->description
 msgid "Blur intensity (Gaussian only)"
 msgstr "Vervagingsintensiteit (alleen Gaussiaans)"
 
 #. 6.0->settings-schema.json->panels-radius->tooltip
 #. 6.0->settings-schema.json->popup-radius->tooltip
+#. 6.0->settings-schema.json->desktop-radius->tooltip
 msgid ""
 "Adjusts the intensity of the Gaussian blur effect by changing the radius use "
 "by the effect. This setting does not effect the Simple blur type"
@@ -408,10 +455,40 @@ msgstr "Extra verduistering van pop-upmenu-accentelementen (percentage)"
 
 #. 6.0->settings-schema.json->popup-accent-opacity->tooltip
 msgid ""
-"Defines the additional dimming applied to the popup menu accent elements "
-"(i.e. the main menu favorites box and entry boxes) which allow these "
-"elements to stand out from the other popup menu areas"
+"Defines the additional dimming applied to the popup menu accent elements (i."
+"e. the main menu favorites box and entry boxes) which allow these elements "
+"to stand out from the other popup menu areas"
 msgstr ""
 "Bepaalt de extra verduistering die wordt toegepast op accentelementen in pop-"
 "upmenu’s, zoals het favorietenveld en invoervelden in het hoofdmenu, zodat "
 "deze elementen opvallen ten opzichte van andere delen van het pop-upmenu."
+
+#. 6.0->settings-schema.json->popup-saturation->description
+#, fuzzy
+msgid "Background image color saturation"
+msgstr "Achtergrondkleurverzadiging"
+
+#. 6.0->settings-schema.json->desktop-without-focus->description
+msgid "Only apply effect settings if the desktop is not in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-without-focus->tooltip
+msgid ""
+"When enabled, the desktop background image effects will only apply when the "
+"desktop is not in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-with-focus->description
+msgid "Apply the generic effect settings when the desktop is in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-with-focus->tooltip
+msgid ""
+"When enabled, the generic effect settings (on the General tab) will apply to "
+"the desktop background image when the desktop is in focus"
+msgstr ""
+
+#. 6.0->settings-schema.json->desktop-opacity->description
+#, fuzzy
+msgid "Dim background Image (percentage)"
+msgstr "Verduistering/Inkleuring van de achtergrond (percentage)"


### PR DESCRIPTION
- Added the ability to apply effects to the Desktop background image (you can Dim, Blur and Desaturate, but currently you can't colorize the background image)
- Improved how the blur effect keeps in sync with the size of the the panels
- Always hid the parts of windows that are under the panels, even when no blur effect is need to be more consistent
- Several fixes , minor improvements, optimizations and simplifications to the code