### PR TITLE
[CinnamonBurnMyWindows@klangman] V0.9.8, new effects, minimize events

### DIFF
--- a/CinnamonBurnMyWindows@klangman/CHANGELOG.md
+++ b/CinnamonBurnMyWindows@klangman/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 0.9.8
+
+* Added new effects from the Gnome version (Aura Glow, Mushroom, RGB Warp, Team Rocket)
+* Added Magic Lap effect based on hermes83/compiz-alike-magic-lamp-effect (same as CinnamonMagicLamp)
+* Added the ability to apply effects to the minimize & unminimize events
+* Fixed an issue where the window was jumping a pixel to the right post open animation (finally!)
+* Added Fire effect presets (5 pre-configured fire setups)
+* Changed the Random Effects tab to use a standard List widget
+* Moved the Application Specific settings options to it's own tab
+* Added a custom color selection widget to save configurator GUI space
+* Use WM_CLASS when adding a app specific setting if no app can be found
+* Improvements to the Focus effect (from Gnome version)
+* Added an "About" tab with credits to the various authors
+
 ## 0.9.7
 
 - Added options in the configuration that allows you to define which effects will be used (if any) for dialog windows (i.e. a file open dialog). This allows you to use a more subtle or shorter running effect (i.e focus or glide) for all the dialog windows which are typically opened/closed more frequently.

--- a/CinnamonBurnMyWindows@klangman/README.md
+++ b/CinnamonBurnMyWindows@klangman/README.md
@@ -1,6 +1,6 @@
 # CinnamonBurnMyWindows
 
-Window open and close effects for the Cinnamon desktop
+Window open, close, minimize and unminimize effects for the Cinnamon desktop
 
 This is a Cinnamon port of the Gnome extension Burn-my-Windows which can be found here: 
 
@@ -21,12 +21,14 @@ This extension needs the Cinnamon.GLSLEffect class which is only available in Ci
 2. When closing the Steam Client "setting" window the 'close window effect' does not show the windows contents, resulting in the closing effect to show where the window had existed but otherwise has no negative effect.
 3. When running VirtualBox, some actions (like restarting Cinnamon or changing panel hide settings) will show a full screen animation of both the Open and Close effect. I assume this is caused by some weirdness with how VirtualBox was written. The problem can be avoided by using two "Application specific settings" list entries to disable open/close animations for the "VirtualBox" and "VirtualBoxVM" WM_CLASS names (entered under the "Application" entry box). New installs of this extension will have these entries by default, but installs that are upgraded to the latest version will need to manually enter these app rules to avoid the issues.
 4. The Doom open effect seems to finish animating at a noticeably lower position than where the window is actually located. This results in the sudden jump up after the animation is completed. When used as a close effect it works correctly.
-5. All open window effects seem to animate in a location that is one pixel off the windows real location. This causes a very small (nearly unnoticeable) jump of the window after the animation has finished. The only exception is "Doom", which as stated above has a more pronounced jump.
-6. The window shadows are not part of the animation and therefore they suddenly appear or disappear right after or before the animation.
+5. The window shadows are not part of the animation and therefore they suddenly appear or disappear right after or before the animation.
+6. After upgrading to 0.9.8 the Fire effect setting and the effects included in the randomized sets will be reset to default.
+7. The Magic Lap effect when used as a minimize effect the window "flashes" the window at the start of the effect and so far I have not been able to determine why. The issue does not appear when used as a close event which is very odd. For this reason you might want to continue using the standalone Magic Lamp Effect extension until I find a way to fix this.
 
 ### Currently these effects are working in Cinnamon:
 
 - Apparition
+- Aura Glow
 - Doom
 - Energize A
 - Energize B
@@ -36,10 +38,14 @@ This extension needs the Cinnamon.GLSLEffect class which is only available in Ci
 - Glitch
 - Hexagon
 - Incinerate
+- Magic Lamp
+- Mushroom
 - Pixelate
 - Pixel Wheel
 - Pixel Wipe
 - Portal
+- RGB Warp
+- Team Rocket
 - TV Effect
 - TV Glitch
 - Wisps
@@ -74,3 +80,17 @@ https://github.com/Schneegans/Burn-My-Windows
 
 If you want to help others find this Cinnamon extension, consider staring it here and on my Github page so that more people might learn of it's existence. The more stars it gets the more encouragement I'll have to continue working on it.
 Thanks!
+
+## Credits
+
+Ported to Cinnamon by Kevin Langman
+
+https://github.com/klangman/CinnamonBurnMyWindows
+
+Based on the Burn-My-Windows code by Schneegans and contributors
+
+https://github.com/Schneegans/Burn-My-Windows
+
+The Magic Lamp Effect is based on code by hermes83
+
+https://github.com/hermes83/compiz-alike-magic-lamp-effect"

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/CustomWidgets.py
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/CustomWidgets.py
@@ -4,40 +4,141 @@ import random
 from JsonSettingsWidgets import *
 from gi.repository import Gio, Gtk
 
-class TwoCheckButtonsTitleWidget(SettingsWidget):
-    def __init__(self, info, key, settings):
+class FireColorChooser(SettingsWidget):
+   def __init__(self, info, key, settings):
         SettingsWidget.__init__(self)
         self.key = key
         self.settings = settings
         self.info = info
-
-        self.descLabel = Gtk.Label('', halign=Gtk.Align.START)
-        self.descLabel.set_markup('<b>' + _(info['description']) + '</b>');
-
-        self.label1 = Gtk.Label('', halign=Gtk.Align.END)
-        self.label1.set_markup('<b>' + _(info['titleB']) + '</b>');
-
-        self.label2 = Gtk.Label('', halign=Gtk.Align.END)
-        self.label2.set_markup('<b>' + _(info['titleA']) + '</b>');
-
-        self.pack_start(self.descLabel, True, True, 0)
-        self.pack_end(self.label1, False, False, 10)
-        self.pack_end(self.label2, False, False, 10)
-
-
-class TwoCheckButtonsWidget(SettingsWidget):
-    def __init__(self, info, key, settings):
-        SettingsWidget.__init__(self)
-        self.key = key
-        self.settings = settings
-        self.info = info
+        rgba = Gdk.RGBA()
 
         self.pack_start(Gtk.Label(_(info['description']), halign=Gtk.Align.START), True, True, 0)
-        self.chkBtn1 = Gtk.CheckButton()
-        self.chkBtn1.set_margin_start(17)
-        self.chkBtn2 = Gtk.CheckButton()
-        self.chkBtn2.set_margin_start(17)
-        self.settings.bind(info['close'], self.chkBtn1, 'active', Gio.SettingsBindFlags.DEFAULT)
-        self.settings.bind(info['open'], self.chkBtn2, 'active', Gio.SettingsBindFlags.DEFAULT)
-        self.pack_end(self.chkBtn1, False, False, 10)
-        self.pack_end(self.chkBtn2, False, False, 10)
+        self.cBtn1 = Gtk.ColorButton()
+        self.cBtn1.set_use_alpha(True)
+        self.cBtn1.set_margin_start(2)
+
+        self.cBtn2 = Gtk.ColorButton()
+        self.cBtn2.set_use_alpha(True)
+        self.cBtn2.set_margin_start(2)
+
+        self.cBtn3 = Gtk.ColorButton()
+        self.cBtn3.set_use_alpha(True)
+        self.cBtn3.set_margin_start(2)
+
+        self.cBtn4 = Gtk.ColorButton()
+        self.cBtn4.set_use_alpha(True)
+        self.cBtn4.set_margin_start(2)
+
+        self.cBtn5 = Gtk.ColorButton()
+        self.cBtn5.set_use_alpha(True)
+        self.cBtn5.set_margin_start(2)
+
+        self.pack_end(self.cBtn5, False, False, 2)
+        self.pack_end(self.cBtn4, False, False, 2)
+        self.pack_end(self.cBtn3, False, False, 2)
+        self.pack_end(self.cBtn2, False, False, 2)
+        self.pack_end(self.cBtn1, False, False, 2)
+
+        rgba.parse(settings.get_value(info["color1"]))
+        self.cBtn1.set_rgba(rgba);
+        rgba.parse(settings.get_value(info["color2"]))
+        self.cBtn2.set_rgba(rgba);
+        rgba.parse(settings.get_value(info["color3"]))
+        self.cBtn3.set_rgba(rgba);
+        rgba.parse(settings.get_value(info["color4"]))
+        self.cBtn4.set_rgba(rgba);
+        rgba.parse(settings.get_value(info["color5"]))
+        self.cBtn5.set_rgba(rgba);
+
+        self.cBtn1.connect('color-set', self.on_my_value_changed)
+        self.cBtn2.connect('color-set', self.on_my_value_changed)
+        self.cBtn3.connect('color-set', self.on_my_value_changed)
+        self.cBtn4.connect('color-set', self.on_my_value_changed)
+        self.cBtn5.connect('color-set', self.on_my_value_changed)
+
+   def on_my_value_changed(self, widget):
+       color_string = self.cBtn1.get_rgba().to_string()
+       self.settings.set_value(self.info["color1"], color_string)
+       color_string = self.cBtn2.get_rgba().to_string()
+       self.settings.set_value(self.info["color2"], color_string)
+       color_string = self.cBtn3.get_rgba().to_string()
+       self.settings.set_value(self.info["color3"], color_string)
+       color_string = self.cBtn4.get_rgba().to_string()
+       self.settings.set_value(self.info["color4"], color_string)
+       color_string = self.cBtn5.get_rgba().to_string()
+       self.settings.set_value(self.info["color5"], color_string)
+
+
+class MushroomColorChooser(SettingsWidget):
+   def __init__(self, info, key, settings):
+        SettingsWidget.__init__(self)
+        self.key = key
+        self.settings = settings
+        self.info = info
+        rgba = Gdk.RGBA()
+
+        self.pack_start(Gtk.Label(_(info['description']), halign=Gtk.Align.START), True, True, 0)
+        self.cBtn1 = Gtk.ColorButton()
+        self.cBtn1.set_use_alpha(True)
+        self.cBtn1.set_margin_start(2)
+
+        self.cBtn2 = Gtk.ColorButton()
+        self.cBtn2.set_use_alpha(True)
+        self.cBtn2.set_margin_start(2)
+
+        self.cBtn3 = Gtk.ColorButton()
+        self.cBtn3.set_use_alpha(True)
+        self.cBtn3.set_margin_start(2)
+
+        self.cBtn4 = Gtk.ColorButton()
+        self.cBtn4.set_use_alpha(True)
+        self.cBtn4.set_margin_start(2)
+
+        self.cBtn5 = Gtk.ColorButton()
+        self.cBtn5.set_use_alpha(True)
+        self.cBtn5.set_margin_start(2)
+
+        self.cBtn6 = Gtk.ColorButton()
+        self.cBtn6.set_use_alpha(True)
+        self.cBtn6.set_margin_start(2)
+
+        self.pack_end(self.cBtn6, False, False, 2)
+        self.pack_end(self.cBtn5, False, False, 2)
+        self.pack_end(self.cBtn4, False, False, 2)
+        self.pack_end(self.cBtn3, False, False, 2)
+        self.pack_end(self.cBtn2, False, False, 2)
+        self.pack_end(self.cBtn1, False, False, 2)
+
+        rgba.parse(settings.get_value(info["color1"]))
+        self.cBtn1.set_rgba(rgba);
+        rgba.parse(settings.get_value(info["color2"]))
+        self.cBtn2.set_rgba(rgba);
+        rgba.parse(settings.get_value(info["color3"]))
+        self.cBtn3.set_rgba(rgba);
+        rgba.parse(settings.get_value(info["color4"]))
+        self.cBtn4.set_rgba(rgba);
+        rgba.parse(settings.get_value(info["color5"]))
+        self.cBtn5.set_rgba(rgba);
+        rgba.parse(settings.get_value(info["color6"]))
+        self.cBtn6.set_rgba(rgba);
+
+        self.cBtn1.connect('color-set', self.on_my_value_changed)
+        self.cBtn2.connect('color-set', self.on_my_value_changed)
+        self.cBtn3.connect('color-set', self.on_my_value_changed)
+        self.cBtn4.connect('color-set', self.on_my_value_changed)
+        self.cBtn5.connect('color-set', self.on_my_value_changed)
+        self.cBtn6.connect('color-set', self.on_my_value_changed)
+
+   def on_my_value_changed(self, widget):
+       color_string = self.cBtn1.get_rgba().to_string()
+       self.settings.set_value(self.info["color1"], color_string)
+       color_string = self.cBtn2.get_rgba().to_string()
+       self.settings.set_value(self.info["color2"], color_string)
+       color_string = self.cBtn3.get_rgba().to_string()
+       self.settings.set_value(self.info["color3"], color_string)
+       color_string = self.cBtn4.get_rgba().to_string()
+       self.settings.set_value(self.info["color4"], color_string)
+       color_string = self.cBtn5.get_rgba().to_string()
+       self.settings.set_value(self.info["color5"], color_string)
+       color_string = self.cBtn6.get_rgba().to_string()
+       self.settings.set_value(self.info["color6"], color_string)

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/ShaderFactory.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/ShaderFactory.js
@@ -73,7 +73,7 @@ var ShaderFactory = class ShaderFactory {
         });
       }
 
-      // Now create a niew instance of the newly registered shader type.
+      // Now create a new instance of the newly registered shader type.
       // GObject.Object.new is only available with newer versions of GJS.
       if (GObject.Object.new) {
         shader = GObject.Object.new(GObject.type_from_name(typeName), {});

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/settings-schema.json
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/settings-schema.json
@@ -1,28 +1,38 @@
 {
   "layout" : {
     "type" : "layout",
-    "pages" : ["general-page", "effects-page", "random-page"],
+    "pages" : ["general-page", "effects-page", "application-page", "random-page", "about-page"],
 
     "general-page" : {
       "type" : "page",
       "title" : "General",
-      "sections" : ["general-settings", "app-specific-settings"]
+      "sections" : ["general-settings"]
     },
     "effects-page" : {
       "type" : "page",
       "title" : "Effect Settings",
-      "sections" : ["effect-selector-section", "effect-settings"]
+      "sections" : ["effect-selector-section", "effect-settings", "mushroom-custom-section", "fire-custom-section"]
+    },
+    "application-page": {
+      "type" : "page",
+      "title" : "Application Specifics",
+      "sections" : ["app-specific-settings"]
     },
     "random-page" : {
       "type" : "page",
       "title" : "Random Effects",
       "sections" : ["random-section"]
     },
+    "about-page" : {
+      "type" : "page",
+      "title" : "About",
+      "sections" : ["about-section"]
+    },
 
     "general-settings" : {
       "type" : "section",
       "title" : "Burn My Windows General Settings",
-      "keys" : ["open-window-effect", "close-window-effect", "dialog-special", "dialog-open-effect", "dialog-close-effect"]
+      "keys" : ["open-window-effect", "close-window-effect", "minimize-effect", "unminimize-effect", "dialog-special", "dialog-open-effect", "dialog-close-effect"]
     },
 
     "app-specific-settings" : {
@@ -40,28 +50,55 @@
       "type" : "section",
       "title" : "Effect Specific Settings",
       "keys" : ["apparition-shake-intensity", "apparition-twirl-intensity", "apparition-suction-intensity", "apparition-randomness", "apparition-animation-time",
+                "aura-glow-random-color", "aura-glow-start-hue", "aura-glow-speed", "aura-glow-saturation", "aura-glow-edge-size", "aura-glow-edge-hardness", "aura-glow-blur", "aura-glow-animation-time",
                 "doom-horizontal-scale", "doom-vertical-scale", "doom-pixel-size", "doom-animation-time",
                 "energize-a-scale", "energize-a-color", "energize-a-animation-time",
                 "energize-b-scale", "energize-b-color", "energize-b-animation-time",
-                "fire-scale", "fire-movement-speed", "fire-3d-noise", "fire-color-1", "fire-color-2", "fire-color-3", "fire-color-4", "fire-color-5", "fire-animation-time",
+                "fire-presets", "fire-3d-noise", "fire-animation-time",
                 "focus-blur-amount", "focus-blur-quality", "focus-animation-time",
                 "glide-scale", "glide-squish", "glide-tilt", "glide-shift", "glide-animation-time",
                 "glitch-scale", "glitch-strength", "glitch-speed", "glitch-color", "glitch-animation-time",
                 "hexagon-scale", "hexagon-line-width", "hexagon-line-color", "hexagon-glow-color", "hexagon-additive-blending", "hexagon-animation-time",
                 "incinerate-scale", "incinerate-turbulence", "incinerate-color", "incinerate-use-pointer", "incinerate-animation-time",
+                "magiclamp-effect", "magiclamp-x-tiles", "magiclamp-y-tiles", "magiclamp-animation-time",
+                "mushroom-presets", "mushroom-animation-time",
                 "pixelate-noise", "pixelate-pixel-size", "pixelate-animation-time",
                 "pixel-wheel-spoke-count", "pixel-wheel-pixel-size", "pixel-wheel-animation-time",
                 "pixel-wipe-pixel-size", "pixel-wipe-animation-time",
                 "portal-color", "portal-rotation-speed", "portal-whirling", "portal-details", "portal-animation-time",
+                "rgbwarp-brightness", "rgbwarp-speed-r", "rgbwarp-speed-g", "rgbwarp-speed-b", "rgbwarp-animation-time",
+                "team-rocket-animation-split", "team-rocket-horizontal-sparkle-position", "team-rocket-vertical-sparkle-position", "team-rocket-window-rotation", "team-rocket-sparkle-rot", "team-rocket-sparkle-size", "team-rocket-animation-time",
                 "tv-effect-color", "tv-animation-time",
                 "tv-glitch-scale", "tv-glitch-strength", "tv-glitch-speed", "tv-glitch-color", "tv-glitch-animation-time",
                 "wisps-scale", "wisps-color-1", "wisps-color-2", "wisps-color-3", "wisps-animation-time"]
     },
+    "fire-custom-section" : {
+     "type" : "section",
+     "title" : "Setting for the custom preset:",
+     "keys" : ["fire-custom-scale", "fire-custom-movement-speed", "fire-colors"],
+     "dependency" : "effect-selector=5"
+    },
+    "mushroom-custom-section" : {
+     "type" : "section",
+     "title" : "Setting for the custom preset:",
+     "keys" : ["mushroom-custom-scale-style", "mushroom-custom-spark-count", "mushroom-custom-spark-color", "mushroom-custom-spark-rotation", "mushroom-custom-rays-color", "mushroom-custom-ring-count", "mushroom-custom-ring-rotation", "mushroom-custom-star-count", "mushroom-star-colors"],
+     "dependency" : "effect-selector=25"
+    },
     "random-section" : {
       "type" : "section",
       "title" : "Effects included in the randomized sets:",
-      "keys" : ["random-title", "apparition-random-include", "doom-random-include", "energize-a-random-include", "energize-b-random-include", "fire-random-include", "focus-random-include", "glide-random-include", "glitch-random-include", "hexagon-random-include", "incinerate-random-include", "pixelate-random-include", "pixel-wheel-random-include", "pixel-wipe-random-include", "portal-random-include", "tv-effect-random-include", "tv-glitch-random-include", "wisps-random-include"]
+      "keys" : ["random-include"]
+    },
+    "about-section" : {
+      "type" : "section",
+      "title" : "About Cinnamon Burn-My-Windows",
+      "keys" : ["about-text"]
     }
+  },
+
+  "about-text": {
+     "type" : "label",
+     "description" : "Ported to Cinnamon by Kevin Langman\nGithub: https://github.com/klangman/CinnamonBurnMyWindows\n\nBased on the Burn-My-Windows code by Schneegans and contributors\nGithub: https://github.com/Schneegans/Burn-My-Windows\n\nThe Magic Lamp Effect is ported from code by hermes83\nGitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
   },
 
   "app-rules": {
@@ -69,8 +106,9 @@
     "description" : "Application Specific Rules",
     "columns" : [
         {"id": "enabled",     "title": "Enabled",      "type": "boolean", "default": true},
-        {"id": "open",        "title": "Open Effect",  "type": "integer", "default": 0, "options": {
+        {"id": "open",        "title": "Open",  "type": "integer", "default": 0, "options": {
             "Apparition": 0,
+            "Aura Glow": 22,
             "Doom": 2,
             "Energize A": 3,
             "Energize B": 4,
@@ -80,10 +118,14 @@
             "Glitch": 7,
             "Hexagon": 8,
             "Incinerate": 9,
+            "Magic Lamp": 26,
+            "Mushroom": 25,
             "Pixelate": 12,
             "Pixel Wheel": 13,
             "Pixel Wipe": 14,
             "Portal": 15,
+            "RGB Warp": 24,
+            "Team Rocket": 23,
             "TV Effect": 18,
             "TV Glitch": 19,
             "Wisps": 20,
@@ -91,8 +133,9 @@
             "None": 1000
            }
         },
-        {"id": "close",       "title": "Close Effect", "type": "integer", "default": 0, "options": {
+        {"id": "close",       "title": "Close", "type": "integer", "default": 0, "options": {
             "Apparition": 0,
+            "Aura Glow": 22,
             "Doom": 2,
             "Energize A": 3,
             "Energize B": 4,
@@ -102,10 +145,68 @@
             "Glitch": 7,
             "Hexagon": 8,
             "Incinerate": 9,
+            "Magic Lamp": 26,
+            "Mushroom": 25,
             "Pixelate": 12,
             "Pixel Wheel": 13,
             "Pixel Wipe": 14,
             "Portal": 15,
+            "RGB Warp": 24,
+            "Team Rocket": 23,
+            "TV Effect": 18,
+            "TV Glitch": 19,
+            "Wisps": 20,
+            "Randomized": 999,
+            "None": 1000
+           }
+        },
+        {"id": "minimize",       "title": "Minimize", "type": "integer", "default": 1000, "options": {
+            "Apparition": 0,
+            "Aura Glow": 22,
+            "Doom": 2,
+            "Energize A": 3,
+            "Energize B": 4,
+            "Fire": 5,
+            "Focus": 21,
+            "Glide": 6,
+            "Glitch": 7,
+            "Hexagon": 8,
+            "Incinerate": 9,
+            "Magic Lamp": 26,
+            "Mushroom": 25,
+            "Pixelate": 12,
+            "Pixel Wheel": 13,
+            "Pixel Wipe": 14,
+            "Portal": 15,
+            "RGB Warp": 24,
+            "Team Rocket": 23,
+            "TV Effect": 18,
+            "TV Glitch": 19,
+            "Wisps": 20,
+            "Randomized": 999,
+            "None": 1000
+           }
+        },
+        {"id": "unminimize",       "title": "Unminimize", "type": "integer", "default": 1000, "options": {
+            "Apparition": 0,
+            "Aura Glow": 22,
+            "Doom": 2,
+            "Energize A": 3,
+            "Energize B": 4,
+            "Fire": 5,
+            "Focus": 21,
+            "Glide": 6,
+            "Glitch": 7,
+            "Hexagon": 8,
+            "Incinerate": 9,
+            "Magic Lamp": 26,
+            "Mushroom": 25,
+            "Pixelate": 12,
+            "Pixel Wheel": 13,
+            "Pixel Wipe": 14,
+            "Portal": 15,
+            "RGB Warp": 24,
+            "Team Rocket": 23,
             "TV Effect": 18,
             "TV Glitch": 19,
             "Wisps": 20,
@@ -119,11 +220,15 @@
     "default": [ { "enabled": true,
                    "open": 1000,
                    "close": 1000,
+                   "minimize": 1000,
+                   "unminimize": 1000,
                    "application": "VirtualBox"
                  },
                  { "enabled": true,
                    "open": 1000,
                    "close": 1000,
+                   "minimize": 1000,
+                   "unminimize": 1000,
                    "application": "VirtualBoxVM"
                  }
                ]
@@ -135,193 +240,48 @@
     "tooltip" : "Focus a window you want to enable application specific setting for then return here and press this button."
   },
 
-  "random-title" : {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsTitleWidget",
-    "description" : "Effect",
-    "titleA" : "Open",
-    "titleB" : "Close"
+  "random-include" : {
+    "type" : "list",
+    "description" : "Effects included in the randomized sets",
+    "tooltip": "Defines which effects are included in the randomized sets for each window event type. When 'Randomized' is selected for any event on the General tab these sets are used.",
+    "show-buttons" : false,
+    "height" : 450,
+    "columns" : [
+        {"id": "name",       "title": "Effect Name         ", "type": "string",  "default": ""},
+        {"id": "open",       "title": "      Open        ", "type": "boolean", "default": true},
+        {"id": "close",      "title": "      Close       ", "type": "boolean", "default": true},
+        {"id": "minimize",   "title": "     Minimize     ", "type": "boolean", "default": true},
+        {"id": "unminimize", "title": "    Unminimize    ", "type": "boolean", "default": true}
+        ],
+    "default": [
+        { "name": "Apparition",  "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "Aura Glow",   "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "Doom",        "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "Energize A",  "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "Energize B",  "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "Fire",        "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "Focus",       "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "Glide",       "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "Glitch",      "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "Hexagon",     "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "Incinerate",  "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "Pixelate",    "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "Pixel Wheel", "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "Pixel Wipe",  "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "Portal",      "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "Team Rocket", "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "TV Effect",   "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "TV Glitch",   "open": true, "close": true, "minimize": true, "unminimize": true },
+        { "name": "Wisps",       "open": true, "close": true, "minimize": true, "unminimize": true }
+        ]
   },
-
-  "apparition-random-include": {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsWidget",
-    "description" : "Apparition",
-    "open" : "apparition-random-include-open",
-    "close" : "apparition-random-include-close"
-  },
-  "doom-random-include": {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsWidget",
-    "description" : "Doom",
-    "open" : "doom-random-include-open",
-    "close" : "doom-random-include-close"
-  },
-  "energize-a-random-include": {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsWidget",
-    "description" : "Energize A",
-    "open" : "energize-a-random-include-open",
-    "close" : "energize-a-random-include-close"
-  },
-  "energize-b-random-include": {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsWidget",
-    "description" : "Energize B",
-    "open" : "energize-b-random-include-open",
-    "close" : "energize-b-random-include-close"
-  },
-  "fire-random-include": {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsWidget",
-    "description" : "Fire",
-    "open" : "fire-random-include-open",
-    "close" : "fire-random-include-close"
-  },
-  "focus-random-include": {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsWidget",
-    "description" : "Focus",
-    "open" : "focus-random-include-open",
-    "close" : "focus-random-include-close"
-  },
-  "glide-random-include": {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsWidget",
-    "description" : "Glide",
-    "open" : "glide-random-include-open",
-    "close" : "glide-random-include-close"
-  },
-  "glitch-random-include": {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsWidget",
-    "description" : "Glitch",
-    "open" : "glitch-random-include-open",
-    "close" : "glitch-random-include-close"
-  },
-  "hexagon-random-include": {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsWidget",
-    "description" : "Hexagon",
-    "open" : "hexagon-random-include-open",
-    "close" : "hexagon-random-include-close"
-  },
-  "incinerate-random-include": {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsWidget",
-    "description" : "Incinerate",
-    "open" : "incinerate-random-include-open",
-    "close" : "incinerate-random-include-close"
-  },
-  "pixelate-random-include": {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsWidget",
-    "description" : "Pixelate",
-    "open" : "pixelate-random-include-open",
-    "close" : "pixelate-random-include-close"
-  },
-  "pixel-wheel-random-include": {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsWidget",
-    "description" : "Pixel Wheel",
-    "open" : "pixel-wheel-random-include-open",
-    "close" : "pixel-wheel-random-include-close"
-  },
-  "pixel-wipe-random-include": {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsWidget",
-    "description" : "Pixel Wipe",
-    "open" : "pixel-wipe-random-include-open",
-    "close" : "pixel-wipe-random-include-close"
-  },
-  "portal-random-include": {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsWidget",
-    "description" : "Portal",
-    "open" : "portal-random-include-open",
-    "close" : "portal-random-include-close"
-  },
-  "tv-effect-random-include": {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsWidget",
-    "description" : "TV Effect",
-    "open" : "tv-effect-random-include-open",
-    "close" : "tv-effect-random-include-close"
-  },
-  "tv-glitch-random-include": {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsWidget",
-    "description" : "TV Glitch",
-    "open" : "tv-glitch-random-include-open",
-    "close" : "tv-glitch-random-include-close"
-  },
-  "wisps-random-include": {
-    "type" : "custom",
-    "file" : "CustomWidgets.py",
-    "widget" : "TwoCheckButtonsWidget",
-    "description" : "Wisps",
-    "open" : "wisps-random-include-open",
-    "close" : "wisps-random-include-close"
-  },
-
-  "apparition-random-include-open" :  { "type": "generic", "default": true },
-  "doom-random-include-open" :        { "type": "generic", "default": true },
-  "energize-a-random-include-open" :  { "type": "generic", "default": true },
-  "energize-b-random-include-open" :  { "type": "generic", "default": true },
-  "fire-random-include-open" :        { "type": "generic", "default": true },
-  "focus-random-include-open" :       { "type": "generic", "default": true },
-  "glide-random-include-open" :       { "type": "generic", "default": true },
-  "glitch-random-include-open" :      { "type": "generic", "default": true },
-  "hexagon-random-include-open" :     { "type": "generic", "default": true },
-  "incinerate-random-include-open" :  { "type": "generic", "default": true },
-  "pixelate-random-include-open" :    { "type": "generic", "default": true },
-  "pixel-wheel-random-include-open" : { "type": "generic", "default": true },
-  "pixel-wipe-random-include-open" :  { "type": "generic", "default": true },
-  "portal-random-include-open" :      { "type": "generic", "default": true },
-  "tv-effect-random-include-open" :   { "type": "generic", "default": true },
-  "tv-glitch-random-include-open" :   { "type": "generic", "default": true },
-  "wisps-random-include-open" :       { "type": "generic", "default": true },
-
-  "apparition-random-include-close" :  { "type": "generic", "default": true },
-  "doom-random-include-close" :        { "type": "generic", "default": true },
-  "energize-a-random-include-close" :  { "type": "generic", "default": true },
-  "energize-b-random-include-close" :  { "type": "generic", "default": true },
-  "fire-random-include-close" :        { "type": "generic", "default": true },
-  "focus-random-include-close" :       { "type": "generic", "default": true },
-  "glide-random-include-close" :       { "type": "generic", "default": true },
-  "glitch-random-include-close" :      { "type": "generic", "default": true },
-  "hexagon-random-include-close" :     { "type": "generic", "default": true },
-  "incinerate-random-include-close" :  { "type": "generic", "default": true },
-  "pixelate-random-include-close" :    { "type": "generic", "default": true },
-  "pixel-wheel-random-include-close" : { "type": "generic", "default": true },
-  "pixel-wipe-random-include-close" :  { "type": "generic", "default": true },
-  "portal-random-include-close" :      { "type": "generic", "default": true },
-  "tv-effect-random-include-close" :   { "type": "generic", "default": true },
-  "tv-glitch-random-include-close" :   { "type": "generic", "default": true },
-  "wisps-random-include-close" :       { "type": "generic", "default": true },
 
   "effect-selector": {
     "type": "combobox",
     "default": 0,
     "options": {
       "Apparition": 0,
+      "Aura Glow": 22,
       "Doom": 2,
       "Energize A": 3,
       "Energize B": 4,
@@ -331,10 +291,14 @@
       "Glitch": 7,
       "Hexagon": 8,
       "Incinerate": 9,
+      "Magic Lamp": 26,
+      "Mushroom": 25,
       "Pixelate": 12,
       "Pixel Wheel": 13,
       "Pixel Wipe": 14,
       "Portal": 15,
+      "RGB Warp": 24,
+      "Team Rocket": 23,
       "TV Effect": 18,
       "TV Glitch": 19,
       "Wisps": 20
@@ -347,6 +311,7 @@
     "default": 0,
     "options": {
       "Apparition": 0,
+      "Aura Glow": 22,
       "Doom": 2,
       "Energize A": 3,
       "Energize B": 4,
@@ -356,10 +321,14 @@
       "Glitch": 7,
       "Hexagon": 8,
       "Incinerate": 9,
+      "Magic Lamp": 26,
+      "Mushroom": 25,
       "Pixelate": 12,
       "Pixel Wheel": 13,
       "Pixel Wipe": 14,
       "Portal": 15,
+      "RGB Warp": 24,
+      "Team Rocket": 23,
       "TV Effect": 18,
       "TV Glitch": 19,
       "Wisps": 20,
@@ -374,6 +343,7 @@
     "default": 0,
     "options": {
       "Apparition": 0,
+      "Aura Glow": 22,
       "Doom": 2,
       "Energize A": 3,
       "Energize B": 4,
@@ -383,10 +353,14 @@
       "Glitch": 7,
       "Hexagon": 8,
       "Incinerate": 9,
+      "Magic Lamp": 26,
+      "Mushroom": 25,
       "Pixelate": 12,
       "Pixel Wheel": 13,
       "Pixel Wipe": 14,
       "Portal": 15,
+      "RGB Warp": 24,
+      "Team Rocket": 23,
       "TV Effect": 18,
       "TV Glitch": 19,
       "Wisps": 20,
@@ -408,6 +382,7 @@
     "default": 0,
     "options": {
       "Apparition": 0,
+      "Aura Glow": 22,
       "Doom": 2,
       "Energize A": 3,
       "Energize B": 4,
@@ -417,10 +392,14 @@
       "Glitch": 7,
       "Hexagon": 8,
       "Incinerate": 9,
+      "Magic Lamp": 26,
+      "Mushroom": 25,
       "Pixelate": 12,
       "Pixel Wheel": 13,
       "Pixel Wipe": 14,
       "Portal": 15,
+      "RGB Warp": 24,
+      "Team Rocket": 23,
       "TV Effect": 18,
       "TV Glitch": 19,
       "Wisps": 20,
@@ -436,6 +415,7 @@
     "default": 0,
     "options": {
       "Apparition": 0,
+      "Aura Glow": 22,
       "Doom": 2,
       "Energize A": 3,
       "Energize B": 4,
@@ -445,10 +425,14 @@
       "Glitch": 7,
       "Hexagon": 8,
       "Incinerate": 9,
+      "Magic Lamp": 26,
+      "Mushroom": 25,
       "Pixelate": 12,
       "Pixel Wheel": 13,
       "Pixel Wipe": 14,
       "Portal": 15,
+      "RGB Warp": 24,
+      "Team Rocket": 23,
       "TV Effect": 18,
       "TV Glitch": 19,
       "Wisps": 20,
@@ -457,6 +441,70 @@
     },
     "description": "Close dialog window effect",
     "dependency" : "dialog-special=true"
+  },
+
+  "minimize-effect": {
+    "type": "combobox",
+    "default": 1000,
+    "options": {
+      "Apparition": 0,
+      "Aura Glow": 22,
+      "Doom": 2,
+      "Energize A": 3,
+      "Energize B": 4,
+      "Fire": 5,
+      "Focus": 21,
+      "Glide": 6,
+      "Glitch": 7,
+      "Hexagon": 8,
+      "Incinerate": 9,
+      "Magic Lamp": 26,
+      "Mushroom": 25,
+      "Pixelate": 12,
+      "Pixel Wheel": 13,
+      "Pixel Wipe": 14,
+      "Portal": 15,
+      "RGB Warp": 24,
+      "Team Rocket": 23,
+      "TV Effect": 18,
+      "TV Glitch": 19,
+      "Wisps": 20,
+      "Randomized": 999,
+      "None": 1000
+    },
+    "description": "Minimize window effect"
+  },
+
+  "unminimize-effect": {
+    "type": "combobox",
+    "default": 1000,
+    "options": {
+      "Apparition": 0,
+      "Aura Glow": 22,
+      "Doom": 2,
+      "Energize A": 3,
+      "Energize B": 4,
+      "Fire": 5,
+      "Focus": 21,
+      "Glide": 6,
+      "Glitch": 7,
+      "Hexagon": 8,
+      "Incinerate": 9,
+      "Magic Lamp": 26,
+      "Mushroom": 25,
+      "Pixelate": 12,
+      "Pixel Wheel": 13,
+      "Pixel Wipe": 14,
+      "Portal": 15,
+      "RGB Warp": 24,
+      "Team Rocket": 23,
+      "TV Effect": 18,
+      "TV Glitch": 19,
+      "Wisps": 20,
+      "Randomized": 999,
+      "None": 1000
+    },
+    "description": "Unminimize window effect"
   },
 
   "apparition-shake-intensity": {
@@ -507,6 +555,83 @@
      "step" : 10,
      "dependency" : "effect-selector=0",
      "default": 300
+  },
+
+  "aura-glow-random-color": {
+    "type" : "switch",
+    "description": "Random Color",
+     "dependency" : "effect-selector=22",
+     "default": false
+  },
+
+  "aura-glow-start-hue": {
+     "type": "scale",
+     "description" : "Start Hue",
+     "min" : 0.0,
+     "max" : 1.0,
+     "step" : 0.1,
+     "dependency" : "effect-selector=22",
+     "default": 0.0
+  },
+
+  "aura-glow-speed": {
+     "type": "scale",
+     "description" : "Speed",
+     "min" : -5,
+     "max" : 5,
+     "step" : 0.25,
+     "dependency" : "effect-selector=22",
+     "default": 2.5
+  },
+
+  "aura-glow-saturation": {
+     "type": "scale",
+     "description" : "Saturation",
+     "min" : 0.0,
+     "max" : 1.0,
+     "step" : 0.1,
+     "dependency" : "effect-selector=22",
+     "default": 0.75
+  },
+
+  "aura-glow-edge-size": {
+     "type": "scale",
+     "description" : "Edge Size",
+     "min" : 0.0,
+     "max" : 1.0,
+     "step" : 0.05,
+     "dependency" : "effect-selector=22",
+     "default": 0.75
+  },
+
+  "aura-glow-edge-hardness": {
+     "type": "scale",
+     "description" : "Edge Hardness",
+     "min" : 0.0,
+     "max" : 1.0,
+     "step" : 0.1,
+     "dependency" : "effect-selector=22",
+     "default": 0.25
+  },
+
+  "aura-glow-blur": {
+     "type": "scale",
+     "description" : "Blur Amount",
+     "min" : 0,
+     "max" : 30,
+     "step" : 0.5,
+     "dependency" : "effect-selector=22",
+     "default": 15
+  },
+
+  "aura-glow-animation-time": {
+     "type": "scale",
+     "description" : "Effect Duration (milliseconds)",
+     "min" : 100,
+     "max" : 3000,
+     "step" : 10,
+     "dependency" : "effect-selector=22",
+     "default": 750
   },
 
   "doom-horizontal-scale": {
@@ -603,7 +728,23 @@
      "default": 1000
   },
 
-  "fire-scale": {
+
+  "fire-presets": {
+    "type": "combobox",
+    "default": "Default Fire",
+    "options": {
+      "Default Fire": "Default Fire",
+      "Hell Fire" : "Hell Fire",
+      "Dark and Smutty" : "Dark and Smutty",
+      "Cold Breeze" : "Cold Breeze",
+      "Santa is Coming" : "Santa is Coming",
+      "Custom" : "Custom"
+    },
+    "description": "Fire preset",
+    "dependency" : "effect-selector=5"
+  },
+
+  "fire-custom-scale": {
      "type": "scale",
      "description" : "Scale",
      "min" : 0.1,
@@ -613,7 +754,7 @@
      "default": 0.5
   },
 
-  "fire-movement-speed": {
+  "fire-custom-movement-speed": {
      "type": "scale",
      "description" : "Fire Movement Speed",
      "min" : -2,
@@ -627,42 +768,44 @@
     "type" : "switch",
     "description": "Fire 3D Noise",
     "tooltip": "Creates a more dynamic fire but requires more GPU power.",
-     "dependency" : "effect-selector=5",
-     "default": false
+    "dependency" : "effect-selector=5",
+    "default": false
   },
 
-  "fire-color-1": {
-     "type": "colorchooser",
-     "description" : "Color #1",
-     "dependency" : "effect-selector=5",
+  "fire-colors": {
+    "type" : "custom",
+    "file" : "CustomWidgets.py",
+    "widget" : "FireColorChooser",
+    "description" : "Colors 1-5",
+    "color1" : "fire-custom-color-1",
+    "color2" : "fire-custom-color-2",
+    "color3" : "fire-custom-color-3",
+    "color4" : "fire-custom-color-4",
+    "color5" : "fire-custom-color-5"
+  },
+
+  "fire-custom-color-1": {
+     "type": "generic",
      "default": "rgba(76, 51, 25, 0.0)"
   },
 
-  "fire-color-2": {
-     "type": "colorchooser",
-     "description" : "Color #2",
-     "dependency" : "effect-selector=5",
+  "fire-custom-color-2": {
+     "type": "generic",
      "default": "rgba(180, 55, 30, 0.7)"
   },
 
-  "fire-color-3": {
-     "type": "colorchooser",
-     "description" : "Color #3",
-     "dependency" : "effect-selector=5",
+  "fire-custom-color-3": {
+     "type": "generic",
      "default": "rgba(255, 76, 38, 0.9)"
   },
 
-  "fire-color-4": {
-     "type": "colorchooser",
-     "description" : "Color #4",
-     "dependency" : "effect-selector=5",
+  "fire-custom-color-4": {
+     "type": "generic",
      "default": "rgba(255, 166, 25, 1)"
   },
 
-  "fire-color-5": {
-     "type": "colorchooser",
-     "description" : "Color #5",
-     "dependency" : "effect-selector=5",
+  "fire-custom-color-5": {
+     "type": "generic",
      "default": "rgba(255, 255, 255, 1)"
   },
 
@@ -675,6 +818,7 @@
      "dependency" : "effect-selector=5",
      "default": 1500
   },
+
 
   "focus-blur-amount": {
      "type": "scale",
@@ -901,6 +1045,55 @@
      "default": 2000
   },
 
+
+  "magiclamp-effect": {
+    "type": "combobox",
+    "default": 0,
+    "options": {
+      "default": 0,
+      "sine": 1,
+      "random": 2,
+      "Minimize: Default - Unminimize: Sine": 3,
+      "Minimize: Sine - Unminimize: Default": 4
+    },
+    "description": "The type of effect",
+    "dependency" : "effect-selector=26",
+    "tooltip": "Using 'default' will result in a curved effect where using 'sine' will result in a more wavy effect"
+  },
+
+  "magiclamp-x-tiles": {
+    "type": "scale",
+    "default": 20,
+    "min": 3,
+    "max": 50,
+    "step": 1,
+    "description": "X Tiles",
+    "dependency" : "effect-selector=26",
+    "tooltip": "This effects the quality and the cost of the animation"
+  },
+
+  "magiclamp-y-tiles": {
+    "type": "scale",
+    "default": 20,
+    "min": 3,
+    "max": 50,
+    "step": 1,
+    "description": "Y Tiles",
+    "dependency" : "effect-selector=26",
+    "tooltip": "This effects the quality and the costs of the animation"
+  },
+
+  "magiclamp-animation-time": {
+     "type": "scale",
+     "description" : "Effect Duration (milliseconds)",
+     "min" : 100,
+     "max" : 3000,
+     "step" : 10,
+     "dependency" : "effect-selector=26",
+     "default": 1200
+  },
+
+
   "matrix-scale": {
      "type": "generic",
      "default": 20
@@ -930,6 +1123,153 @@
      "type": "generic",
      "default": 1500
   },
+
+
+  "mushroom-presets": {
+    "type": "combobox",
+    "default": "New Bros 2",
+    "options": {
+      "8Bit Plumber" : "8Bit Plumber",
+      "New Bros 2" : "New Bros 2",
+      "The True North" : "The True North",
+      "Red White and Blue" : "Red White and Blue",
+      "Rainbow" : "Rainbow",
+      "Cattuccino" : "Cattuccino",
+      "Dracula" : "Dracula",
+      "Sparkle" : "Sparkle",
+      "Custom" : "Custom"
+    },
+    "description": "Mushroom preset",
+    "dependency" : "effect-selector=25"
+  },
+
+  "mushroom-custom-scale-style": {
+     "type": "spinbutton",
+     "description" : "Scale Style",
+     "min" : 0,
+     "max" : 1,
+     "step" : 0.1,
+     "dependency" : "effect-selector=25",
+     "default": 1
+  },
+
+  "mushroom-custom-spark-count": {
+     "type": "spinbutton",
+     "description" : "Spark Count",
+     "min" : 0,
+     "max" : 25,
+     "step" : 1,
+     "dependency" : "effect-selector=25",
+     "default": 4
+  },
+
+  "mushroom-custom-spark-color": {
+     "type": "colorchooser",
+     "description" : "Spark Color",
+     "dependency" : "effect-selector=25",
+     "default": "rgba(255, 255, 255, 1.0)"
+  },
+
+  "mushroom-custom-spark-rotation": {
+     "type": "spinbutton",
+     "description" : "Spark Rotation",
+     "min" : -3,
+     "max" : 3,
+     "step" : 0.5,
+     "dependency" : "effect-selector=25",
+     "default": 0.3
+  },
+
+  "mushroom-custom-rays-color": {
+     "type": "colorchooser",
+     "description" : "Rays Color",
+     "dependency" : "effect-selector=25",
+     "default": "rgba(255, 255, 255, 1.0)"
+  },
+
+  "mushroom-custom-ring-count": {
+     "type": "spinbutton",
+     "description" : "Star Rings Count",
+     "min" : 0,
+     "max" : 5,
+     "step" : 1,
+     "dependency" : "effect-selector=25",
+     "default": 3
+  },
+
+  "mushroom-custom-ring-rotation": {
+     "type": "spinbutton",
+     "description" : "Star Ring Rotation",
+     "min" : -3,
+     "max" : 3,
+     "step" : 0.25,
+     "dependency" : "effect-selector=25",
+     "default": 1.33
+  },
+
+  "mushroom-custom-star-count": {
+     "type": "spinbutton",
+     "description" : "Stars Count Per Ring",
+     "min" : 0,
+     "max" : 7,
+     "step" : 1,
+     "dependency" : "effect-selector=25",
+     "default": 4
+  },
+
+  "mushroom-star-colors": {
+    "type" : "custom",
+    "file" : "CustomWidgets.py",
+    "widget" : "MushroomColorChooser",
+    "description" : "Colors 1-6",
+    "color1" : "mushroom-custom-star-color-0",
+    "color2" : "mushroom-custom-star-color-1",
+    "color3" : "mushroom-custom-star-color-2",
+    "color4" : "mushroom-custom-star-color-3",
+    "color5" : "mushroom-custom-star-color-4",
+    "color6" : "mushroom-custom-star-color-5"
+  },
+
+  "mushroom-custom-star-color-0": {
+     "type": "generic",
+     "default": "rgba(233,249,0,1.0)"
+  },
+
+  "mushroom-custom-star-color-1": {
+     "type": "generic",
+     "default": "rgba(233,249,0,1.0)"
+  },
+
+  "mushroom-custom-star-color-2": {
+     "type": "generic",
+     "default": "rgba(91,255,0,1.0)"
+  },
+
+  "mushroom-custom-star-color-3": {
+     "type": "generic",
+     "default": "rgba(91,255,0,1.0)"
+  },
+
+  "mushroom-custom-star-color-4": {
+     "type": "generic",
+     "default": "rgba(0,240,236,1.0)"
+  },
+
+  "mushroom-custom-star-color-5": {
+     "type": "generic",
+     "default": "rgba(0,240,236,1.0)"
+  },
+
+  "mushroom-animation-time": {
+     "type": "scale",
+     "description" : "Effect Duration (milliseconds)",
+     "min" : 100,
+     "max" : 5000,
+     "step" : 10,
+     "dependency" : "effect-selector=25",
+     "default": 1500
+  },
+
 
   "pixelate-noise": {
      "type": "scale",
@@ -1056,6 +1396,123 @@
      "step" : 10,
      "dependency" : "effect-selector=15",
      "default": 1250
+  },
+
+  "rgbwarp-brightness": {
+     "type": "scale",
+     "description" : "Brightness",
+     "min" : 0,
+     "max" : 1,
+     "step" : 0.1,
+     "dependency" : "effect-selector=24",
+     "default": 1
+  },
+
+  "rgbwarp-speed-r": {
+     "type": "scale",
+     "description" : "Red Speed",
+     "min" : 0,
+     "max" : 1,
+     "step" : 0.01,
+     "dependency" : "effect-selector=24",
+     "default": 1.0
+  },
+
+  "rgbwarp-speed-g": {
+     "type": "scale",
+     "description" : "Green Speed",
+     "min" : 0,
+     "max" : 1,
+     "step" : 0.01,
+     "dependency" : "effect-selector=24",
+     "default": 0.9
+  },
+
+  "rgbwarp-speed-b": {
+     "type": "scale",
+     "description" : "Blue Speed",
+     "min" : 0,
+     "max" : 1,
+     "step" : 0.01,
+     "dependency" : "effect-selector=24",
+     "default": 0.8
+  },
+
+  "rgbwarp-animation-time": {
+     "type": "scale",
+     "description" : "Effect Duration (milliseconds)",
+     "min" : 100,
+     "max" : 5000,
+     "step" : 10,
+     "dependency" : "effect-selector=24",
+     "default": 750
+  },
+
+  "team-rocket-animation-split": {
+     "type": "scale",
+     "description" : "Animation Split",
+     "min" : 0.2,
+     "max" : 0.8,
+     "step" : 0.01,
+     "dependency" : "effect-selector=23",
+     "default": 0.5
+  },
+
+  "team-rocket-horizontal-sparkle-position": {
+     "type": "scale",
+     "description" : "Horizontal Sparkle Position",
+     "min" : -1.0,
+     "max" : 1.0,
+     "step" : 0.01,
+     "dependency" : "effect-selector=23",
+     "default": 0.0
+  },
+
+  "team-rocket-vertical-sparkle-position": {
+     "type": "scale",
+     "description" : "Vertical Sparkle Position",
+     "min" : -1.0,
+     "max" : 1.0,
+     "step" : 0.01,
+     "dependency" : "effect-selector=23",
+     "default": 0.5
+  },
+
+  "team-rocket-window-rotation": {
+    "type" : "switch",
+    "description": "Rotate Window",
+     "dependency" : "effect-selector=23",
+     "default": true
+  },
+
+  "team-rocket-sparkle-rot": {
+     "type": "scale",
+     "description" : "Sparkle Rotation",
+     "min" : -1.0,
+     "max" : 1.0,
+     "step" : 0.1,
+     "dependency" : "effect-selector=23",
+     "default": 0.33
+  },
+
+  "team-rocket-sparkle-size": {
+     "type": "scale",
+     "description" : "Sparkle Size",
+     "min" : 0.5,
+     "max" : 1.0,
+     "step" : 0.1,
+     "dependency" : "effect-selector=23",
+     "default": 0.75
+  },
+
+  "team-rocket-animation-time": {
+     "type": "scale",
+     "description" : "Effect Duration (milliseconds)",
+     "min" : 100,
+     "max" : 5000,
+     "step" : 10,
+     "dependency" : "effect-selector=23",
+     "default": 1500
   },
 
   "tv-effect-color": {

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/ShouldAnimateManager.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/ShouldAnimateManager.js
@@ -67,9 +67,9 @@ class ShouldAnimateManager {
       return null;
    }
 
-   disconnect() {
+   disconnect(event=null) {
       for (let i=0 ; i<Main.wm._shouldAnimateManager.length ; i++) {
-         if (Main.wm._shouldAnimateManager[i].owner == this._uuid) {
+         if (Main.wm._shouldAnimateManager[i].owner == this._uuid && (!event || event == Main.wm._shouldAnimateManager[i].event)) {
             Main.wm._shouldAnimateManager.splice( i, 1 );
             // Setup a new _shouldAnimate override or restore the original if there are no manager entries left.
             if (Main.wm._shouldAnimateManager.length === 0) {

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/AuraGlow.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/AuraGlow.js
@@ -1,0 +1,148 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//          )                                                   (                       //
+//       ( /(   (  (               )    (       (  (  (         )\ )    (  (            //
+//       )\()) ))\ )(   (         (     )\ )    )\))( )\  (    (()/( (  )\))(  (        //
+//      ((_)\ /((_|()\  )\ )      )\  '(()/(   ((_)()((_) )\ )  ((_)))\((_)()\ )\       //
+//      | |(_|_))( ((_)_(_/(    _((_))  )(_))  _(()((_|_)_(_/(  _| |((_)(()((_|(_)      //
+//      | '_ \ || | '_| ' \))  | '  \()| || |  \ V  V / | ' \)) _` / _ \ V  V (_-<      //
+//      |_.__/\_,_|_| |_||_|   |_|_|_|  \_, |   \_/\_/|_|_||_|\__,_\___/\_/\_//__/      //
+//                                 |__/                                                 //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Justin Garza <JGarza9788@gmail.com>
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+'use strict';
+
+//import * as utils from '../utils.js';
+
+// We import the ShaderFactory only in the Shell process as it is not required in the
+// preferences process. The preferences process does not create any shader instances, it
+// only uses the static metadata of the effect.
+//const ShaderFactory = await utils.importInShellOnly('./ShaderFactory.js');
+const {ShaderFactory} = require('./ShaderFactory.js');
+
+//const _ = await utils.importGettext();
+const Gettext = imports.gettext;
+const GLib = imports.gi.GLib;
+const UUID = "CinnamonBurnMyWindows@klangman";
+
+Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
+
+function _(text) {
+  let locText = Gettext.dgettext(UUID, text);
+  if (locText == text) {
+    locText = window._(text);
+  }
+  return locText;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// This effect was inspired by apple's new siri effect.                                 //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// The effect class can be used to get some metadata (like the effect's name or supported
+// GNOME Shell versions), to initialize the respective page of the settings dialog, as
+// well as to create the actual shader for the effect.
+var Effect = class Effect {
+  // The constructor creates a ShaderFactory which will be used by extension.js to create
+  // shader instances for this effect. The shaders will be automagically created using the
+  // GLSL file in resources/shaders/<nick>.glsl. The callback will be called for each
+  // newly created shader instance.
+
+  constructor() {
+    this.shaderFactory = new ShaderFactory(Effect.getNick(), (shader) => {
+      // Store uniform locations of newly created shaders.
+      shader._uSpeed        = shader.get_uniform_location('uSpeed');
+      shader._uRandomColor  = shader.get_uniform_location('uRandomColor');
+      shader._uStartHue     = shader.get_uniform_location('uStartHue');
+      shader._uSaturation   = shader.get_uniform_location('uSaturation');
+      shader._uEdgeSize     = shader.get_uniform_location('uEdgeSize');
+      shader._uEdgeHardness = shader.get_uniform_location('uEdgeHardness');
+      shader._uBlur         = shader.get_uniform_location('uBlur');
+      shader._uSeed         = shader.get_uniform_location('uSeed');
+
+      // Write all uniform values at the start of each animation.
+      shader.connect('begin-animation', (shader, settings) => {
+        // clang-format off
+        shader.set_uniform_float(shader._uSpeed,        1, [settings.getValue('aura-glow-speed')]);
+        shader.set_uniform_float(shader._uRandomColor, 1, [settings.getValue('aura-glow-random-color')]);
+        shader.set_uniform_float(shader._uStartHue,       1, [settings.getValue('aura-glow-start-hue')]);
+        shader.set_uniform_float(shader._uSaturation,   1, [settings.getValue('aura-glow-saturation')]);
+        shader.set_uniform_float(shader._uEdgeSize,          1, [settings.getValue('aura-glow-edge-size')]);
+        shader.set_uniform_float(shader._uEdgeHardness,      1, [settings.getValue('aura-glow-edge-hardness')]);
+        shader.set_uniform_float(shader._uBlur,              1, [settings.getValue('aura-glow-blur')]);
+        shader.set_uniform_float(shader._uSeed,              2, [Math.random(), Math.random()]);
+        // clang-format on
+      });
+    });
+  }
+
+
+
+  // ---------------------------------------------------------------------------- metadata
+
+  // The effect is available on all GNOME Shell versions supported by this extension.
+  static getMinShellVersion() {
+    return [3, 36];
+  }
+
+  // This will be called in various places where a unique identifier for this effect is
+  // required. It should match the prefix of the settings keys which store whether the
+  // effect is enabled currently (e.g. '*-enable-effect'), and its animation time
+  // (e.g. '*-animation-time'). Also, the shader file and the settings UI files should be
+  // named likes this.
+  static getNick() {
+    return 'aura-glow';
+  }
+
+  // This will be shown in the sidebar of the preferences dialog as well as in the
+  // drop-down menus where the user can choose the effect.
+  static getLabel() {
+    return _('Aura Glow');
+  }
+
+  // -------------------------------------------------------------------- API for prefs.js
+
+  // This is called by the preferences dialog whenever a new effect profile is loaded. It
+  // binds all user interface elements to the respective settings keys of the profile.
+  static bindPreferences(dialog) {
+    dialog.bindAdjustment('aura-glow-animation-time');
+    dialog.bindAdjustment('aura-glow-speed');
+    dialog.bindSwitch('aura-glow-random-color');
+    dialog.bindAdjustment('aura-glow-start-hue');
+    dialog.bindAdjustment('aura-glow-saturation');
+    dialog.bindAdjustment('aura-glow-edge-size');
+    dialog.bindAdjustment('aura-glow-edge-hardness');
+    dialog.bindAdjustment('aura-glow-blur');
+
+    // enable and disable the one slider
+    function enableDisablePref(dialog, state) {
+      dialog.getBuilder().get_object('aura-glow-start-hue-slider').set_sensitive(!state);
+    }
+
+    const switchWidget = dialog.getBuilder().get_object('aura-glow-random-color');
+
+    // Connect to the "state-set" signal to update preferences dynamically based on
+    // the switch state.
+    switchWidget.connect('state-set', (widget, state) => {
+      enableDisablePref(dialog, state);  // Update sensitivity when the state changes.
+    });
+
+    // Manually call the update function on startup, using the initial state of the
+    // switch.
+    const initialState =
+      switchWidget.get_active();  // Get the current state of the switch.
+    enableDisablePref(dialog, initialState);
+  }
+
+  // ---------------------------------------------------------------- API for extension.js
+
+  // The getActorScale() is called from extension.js to adjust the actor's size during the
+  // animation. This is useful if the effect requires drawing something beyond the usual
+  // bounds of the actor. This only works for GNOME 3.38+.
+  static getActorScale(settings, forOpening, actor) {
+    return {x: 1.0, y: 1.0};
+  }
+}

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/MagicLamp.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/MagicLamp.js
@@ -1,0 +1,540 @@
+/*
+ * extension.js
+ * Copyright (C) 2025 Kevin Langman <klangman@gmail.com>
+ *
+ * This is a Cinnamon port of the Gnome Compiz-alike-magic-lamp-effect code
+ * modified to work as a Burn-My-Windows effect in CinnamonBurnMyWindows:
+ * Copyright (C) 2020 Mauro Pepe <https://github.com/hermes83/compiz-alike-magic-lamp-effect>
+ *
+ * The MagicLamp Effect is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by the
+ * Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * THe MagicLamp Effect is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ * See the GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program.  If not, see <http://www.gnu.org/licenses/>.
+*/
+const St = imports.gi.St;
+const Clutter = imports.gi.Clutter;
+const Meta = imports.gi.Meta;
+const GObject = imports.gi.GObject;
+const Main = imports.ui.main;
+const GLib = imports.gi.GLib;
+const Gettext = imports.gettext;
+const Panel = imports.ui.panel;
+//const Mainloop = imports.mainloop;
+
+const ShouldAnimateManager = require("ShouldAnimateManager.js");
+
+const MINIMIZE_EFFECT_NAME = "minimize-magic-lamp-effect";
+const UNMINIMIZE_EFFECT_NAME = "unminimize-magic-lamp-effect";
+
+const UUID = "CinnamonBurnMyWindows@klangman";
+
+const EffectType = {
+   Default: 0,
+   Sine: 1,
+   Random: 2,
+   DefaultSine: 3,
+   SineDefault: 4
+}
+
+Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
+
+function _(text) {
+  let locText = Gettext.dgettext(UUID, text);
+  if (locText == text) {
+    locText = window._(text);
+  }
+  return locText;
+}
+
+function getIcon(actor) {
+   let [success, icon] = actor.meta_window.get_icon_geometry();
+   if (success) {
+      return icon;
+   }
+
+   let monitor = actor.meta_window.get_monitor();
+   let panels = Main.panelManager.getPanelsInMonitor(monitor);
+   let loc = -1;
+   icon = {x: monitor.x + monitor.width / 2, y: monitor.y + monitor.height, width: 0, height: 0};
+   // Find a panel and set the icon location to be the middle of the panel.
+   // If more than one panel exists, use the below probability order to select
+   // the most likely window-list location based on typical usage.
+   // Window list location probability order: Bottom, Top, Left, Right
+   for (let i = 0; i < panels.length; i++) {
+      if (panels[i].panelPosition == Panel.PanelLoc.top) {
+         loc = Panel.PanelLoc.top;
+         icon.x = panels[i].monitor.x + panels[i].monitor.width / 2;
+         icon.y = panels[i].monitor.y;
+      } else if (loc != Panel.PanelLoc.top && loc != Panel.PanelLoc.left && panels[i].panelPosition == Panel.PanelLoc.right) {
+         loc = Panel.PanelLoc.right;
+         icon.x = panels[i].monitor.x + panels[i].monitor.width;
+         icon.y = panels[i].monitor.y + panels[i].monitor.height / 2;
+      } else if (loc != Panel.PanelLoc.top && panels[i].panelPosition == Panel.PanelLoc.left) {
+         loc = Panel.PanelLoc.left;
+         icon.x = panels[i].monitor.x;
+         icon.y = panels[i].monitor.y + panels[i].monitor.height / 2;
+      } else if (panels[i].panelPosition == Panel.PanelLoc.bottom) {
+         loc = Panel.PanelLoc.bottom;
+         icon.x = panels[i].monitor.x + panels[i].monitor.width / 2;
+         icon.y = panels[i].monitor.y + panels[i].monitor.height;
+         break;
+      }
+   }
+   return icon;
+}
+
+var Effect = class Effect {
+
+   constructor(){
+      this.shaderFactory = new MagicLampFactory();
+   }
+
+   static getNick() {
+      return 'magiclamp';
+   }
+
+   // We don't see any scaling for this effect
+   static getActorScale(settings, forOpening, actor) {
+      return {x: 1.0, y: 1.0};
+   }
+}
+
+// Since the MagicLamp is not a GLSLEffect, we have to implement our own Factory.
+var MagicLampFactory = class MagicLampFactory {
+   constructor() {
+      // These arrays contains previously created effects which are not currently in use.
+      this._freeMinimizeEffects = [];
+      this._freeUnminimizeEffects = [];
+   }
+
+   // Returns the appropriate MagicLamp effect object by creating a new instance or by
+   // using a cached instance that has been used previously
+   getShader(event) {
+      let effect;
+
+      if (event === ShouldAnimateManager.Events.MapWindow || event === ShouldAnimateManager.Events.Unminimize) {
+         if (this._freeUnminimizeEffects.length == 0) {
+            effect = new MagicLampUnminimizeEffect(this);
+         } else {
+            effect = this._freeUnminimizeEffects.pop();
+         }
+      } else {
+         if (this._freeMinimizeEffects.length == 0) {
+            effect = new MagicLampMinimizeEffect(this);
+         } else {
+            effect = this._freeMinimizeEffects.pop();
+         }
+      }
+      // Allow the effect to decide how to animate based on the event type (currently not used)
+      effect.setEvent(event);
+      return effect;
+   }
+}
+
+var AbstractCommonMagicLampEffect = GObject.registerClass( {GTypeName : `Cjs_AbstractCommonMagicLampEffect_${Math.floor(Math.random() * 100000) + 1}`},
+
+class AbstractCommonMagicLampEffect extends Clutter.DeformEffect {
+
+   _init() {
+      super._init();
+
+      this.EPSILON = 40;
+
+      this.isMinimizeEffect = false;
+      this.newFrameEvent = null;
+      this.completedEvent = null;
+
+      this.timerId = null;
+      this.msecs = 0;
+
+      this.monitor = {x: 0, y: 0, width: 0, height: 0};
+      this.iconMonitor = {x: 0, y: 0, width: 0, height: 0};
+      this.window = {x: 0, y: 0, width: 0, height: 0, scale: 1};
+
+      this.progress = 0;
+      this.split = 0.3;
+      this.k = 0;
+      this.j = 0;
+      this.expandWidth = 0;
+      this.fullWidth = 0;
+      this.expandHeight = 0;
+      this.fullHeight = 0;
+      this.width = 0;
+      this.height = 0;
+      this.x = 0;
+      this.y = 0;
+      this.offsetX = 0;
+      this.offsetY = 0;
+      this.effectX = 0;
+      this.effectY = 0;
+      this.iconPosition = null;
+
+      this.toTheBorder = true;   // true
+      this.maxIconSize = null;    // 48
+      this.alignIcon = 'center';  // 'left-top'
+
+      this.initialized = false;
+   }
+
+   destroy_actor(actor) {}
+
+   on_tick_elapsed(timer, msecs) {}
+
+   vfunc_set_actor(actor) {
+      super.vfunc_set_actor(actor);
+
+      if (!this.actor || this.initialized) {
+         return;
+      }
+
+      this.initialized = true;
+      //if (this.event === ShouldAnimateManager.Events.MapWindow || this.event === ShouldAnimateManager.Events.DestroyWindow) {
+      //   let [px,py,mods] = global.get_pointer();
+      //   this.icon = {x: px, y: py, width: 1, height: 1};
+      //   this.toTheBorder = false;
+      //} else {
+         this.icon = getIcon(actor);
+         //this.toTheBorder = true;
+      //}
+
+      this.monitor = Main.layoutManager.monitors[actor.meta_window.get_monitor()];
+
+      [this.window.x, this.window.y] = [this.actor.get_x() - this.monitor.x, this.actor.get_y() - this.monitor.y];
+      [this.window.width, this.window.height] = actor.get_size();
+
+      if (!this.icon || (this.icon.x == 0 && this.icon.y == 0 && this.icon.width == 0 && this.icon.height == 0)) {
+         this.icon.x = this.monitor.x + this.monitor.width / 2;
+         this.icon.y = this.monitor.height + this.monitor.y;
+      }
+
+      Main.layoutManager.monitors.forEach((monitor, monitorIndex)  => {
+         let scale = 1;
+         if (global.display && global.display.get_monitor_scale) {
+            scale = global.display.get_monitor_scale(monitorIndex);
+         }
+
+         if (this.icon.x >= monitor.x && this.icon.x <= monitor.x + monitor.width * scale && this.icon.y >= monitor.y && this.icon.y <= monitor.y + monitor.height * scale)  {
+             this.iconMonitor = monitor;
+         }
+      });
+      if (this.iconMonitor.x == 0 && this.iconMonitor.y == 0 && this.iconMonitor.width == 0 && this.iconMonitor.height == 0) {
+         this.iconMonitor = this.monitor;
+         // this.icon.x = this.monitor.x + this.monitor.width / 2;
+         // this.icon.y = this.monitor.height + this.monitor.y;
+      }
+
+      [this.icon.x, this.icon.y, this.icon.width, this.icon.height] = [this.icon.x - this.monitor.x, this.icon.y - this.monitor.y, this.icon.width, this.icon.height];
+
+      if (this.icon.y + this.icon.height >= this.monitor.height - this.EPSILON) {
+         this.iconPosition = St.Side.BOTTOM;
+         if (this.toTheBorder) {
+            this.icon.y = this.iconMonitor.y + this.iconMonitor.height - this.monitor.y
+            this.icon.height = 0;
+         }
+      } else if (this.icon.x <= this.EPSILON) {
+         this.iconPosition = St.Side.LEFT;
+         if (this.toTheBorder) {
+            this.icon.x = this.iconMonitor.x - this.monitor.x;
+            this.icon.width = 0;
+         }
+      } else if (this.icon.x + this.icon.width >= this.monitor.width - this.EPSILON) {
+         this.iconPosition = St.Side.RIGHT;
+         if (this.toTheBorder) {
+            this.icon.x = this.iconMonitor.x + this.iconMonitor.width - this.monitor.x;
+            this.icon.width = 0;
+         }
+      } else {
+         this.iconPosition = St.Side.TOP;
+         if (this.toTheBorder) {
+            this.icon.y = this.iconMonitor.y - this.monitor.y;
+            this.icon.height = 0;
+         }
+      }
+   }
+
+   destroy() {
+      if (this.timerId) {
+         if (this.newFrameEvent) {
+            this.timerId.disconnect(this.newFrameEvent);
+            this.newFrameEvent = null;
+         }
+         if (this.completedEvent) {
+            this.timerId.disconnect(this.completedEvent);
+            this.completedEvent = null;
+         }
+         this.timerId = null;
+      }
+
+      let actor = this.get_actor();
+      if (actor) {
+         if (this.paintEvent) {
+            actor.disconnect(this.paintEvent);
+            this.paintEvent = null;
+         }
+
+         this.destroy_actor(actor);
+      }
+   }
+
+   vfunc_deform_vertex(w, h, v) {
+      if (this.initialized) {
+         let propX = w / this.window.width;
+         let propY = h / this.window.height;
+
+         if (this.iconPosition == St.Side.LEFT) {
+            this.width = this.window.width - this.icon.width + this.window.x * this.k;
+
+            this.x = (this.width - this.j * this.width) * v.tx;
+            this.y = v.ty * this.window.height * (this.x + (this.width - this.x) * (1 - this.k)) / this.width + 
+                     v.ty * this.icon.height * (this.width - this.x) / this.width;
+
+            this.offsetX = this.icon.width - this.window.x * this.k;
+            this.offsetY = (this.icon.y - this.window.y) * ((this.width - this.x) / this.width) * this.k;
+
+            if (this.EFFECT === EffectType.Sine) {
+               this.effectY = Math.sin(this.x / this.width * Math.PI * 4) * this.window.height / 14 * this.k;
+            } else {
+               this.effectY = Math.sin((0.5 - (this.width - this.x) / this.width) * 2 * Math.PI) * (this.window.y + this.window.height * v.ty - (this.icon.y + this.icon.height * v.ty)) / 7 * this.k;
+            }
+         } else if (this.iconPosition == St.Side.TOP) {
+            this.height = this.window.height - this.icon.height + this.window.y * this.k;
+
+            this.y = (this.height - this.j * this.height) * v.ty;
+            this.x = v.tx * this.window.width * (this.y + (this.height - this.y) * (1 - this.k)) / this.height + 
+                     v.tx * this.icon.width * (this.height - this.y) / this.height;
+
+            this.offsetX = (this.icon.x - this.window.x) * ((this.height - this.y) / this.height) * this.k;
+            this.offsetY = this.icon.height - this.window.y * this.k;
+
+            if (this.EFFECT === EffectType.Sine) {
+                this.effectX = Math.sin(this.y / this.height * Math.PI * 4) * this.window.width / 14 * this.k;
+            } else {
+                this.effectX = Math.sin((0.5 - (this.height - this.y) / this.height) * 2 * Math.PI) * (this.window.x + this.window.width * v.tx - (this.icon.x + this.icon.width * v.tx)) / 7 * this.k;
+            }
+         } else if (this.iconPosition == St.Side.RIGHT) {
+            this.expandWidth = (this.iconMonitor.width - this.icon.width - this.window.x - this.window.width);
+            this.fullWidth = (this.iconMonitor.width - this.icon.width - this.window.x) - this.expandWidth * (1 - this.k);
+            this.width = this.fullWidth - this.j * this.fullWidth;
+
+            this.x = v.tx * this.width;
+            this.y = v.ty * (this.icon.height) +
+                     v.ty * (this.window.height - this.icon.height) * (1 - this.j) * (1 - v.tx) +
+                     v.ty * (this.window.height - this.icon.height) * (1 - this.k) * (v.tx);
+
+            this.offsetY = (this.icon.y - this.window.y) * (this.x / this.fullWidth) * this.k + (this.icon.y - this.window.y) * this.j;
+            this.offsetX = this.iconMonitor.width - this.icon.width - this.window.x - this.width - this.expandWidth * (1 - this.k);
+
+            if (this.EFFECT === EffectType.Sine) {
+                this.effectY = Math.sin((this.width - this.x) / this.fullWidth * Math.PI * 4) * this.window.height / 14 * this.k;
+            } else {
+                this.effectY = Math.sin(((this.width - this.x) / this.fullWidth) * 2 * Math.PI + Math.PI) * (this.window.y + this.window.height * v.ty - (this.icon.y + this.icon.height * v.ty)) / 7 * this.k;
+            }
+         } else if (this.iconPosition == St.Side.BOTTOM) {
+            this.expandHeight = (this.iconMonitor.height - this.icon.height - this.window.y - this.window.height);
+            this.fullHeight = (this.iconMonitor.height - this.icon.height - this.window.y) - this.expandHeight * (1 - this.k);
+            this.height = this.fullHeight - this.j * this.fullHeight;
+
+            this.y = v.ty * this.height;
+            this.x = v.tx * (this.icon.width) +
+                     v.tx * (this.window.width - this.icon.width) * (1 - this.j) * (1 - v.ty) +
+                     v.tx * (this.window.width - this.icon.width) * (1 - this.k) * (v.ty);
+
+            this.offsetX = (this.icon.x - this.window.x) * (this.y / this.fullHeight) * this.k + (this.icon.x - this.window.x) * this.j;
+            this.offsetY = this.iconMonitor.height - this.icon.height - this.window.y - this.height - this.expandHeight * (1 - this.k);
+
+            if (this.EFFECT === EffectType.Sine) {
+               this.effectX = Math.sin((this.height - this.y) / this.fullHeight * Math.PI * 4) * this.window.width / 14 * this.k;
+            } else {
+               this.effectX = Math.sin(((this.height - this.y) / this.fullHeight) * 2 * Math.PI + Math.PI) * (this.window.x + this.window.width * v.tx - (this.icon.x + this.icon.width * v.tx)) / 7 * this.k;
+            }
+         }
+
+         v.x = (this.x + this.offsetX + this.effectX) * propX;
+         v.y = (this.y + this.offsetY + this.effectY) * propY;
+      }
+   }
+}
+
+);
+
+var MagicLampMinimizeEffect = GObject.registerClass( {
+      GTypeName: `Cjs_MagicLampMinimizeEffect_${Math.floor(Math.random() * 100000) + 1}`,
+      Signals: { 'end-animation': {} }
+      },
+
+class MagicLampMinimizeEffect extends AbstractCommonMagicLampEffect {
+   _init(factory) {
+      super._init();
+
+      this.k = 0;
+      this.j = 0;
+      this.isMinimizeEffect = true;
+      this.factory = factory;
+   }
+
+   setEvent(event) {
+      this.event = event;
+   }
+
+   // This is called once each time the shader is used.
+   beginAnimation(settings, forOpening, testMode, duration, actor) {
+      this.DURATION = duration;
+      this.X_TILES = settings.getValue("magiclamp-x-tiles");
+      this.Y_TILES = settings.getValue("magiclamp-y-tiles");
+      this.EFFECT = settings.getValue("magiclamp-effect");
+      if (this.EFFECT === EffectType.Random) {
+         this.EFFECT = Math.floor(Math.random() * 2);
+      } else if (this.EFFECT === EffectType.DefaultSine) {
+         this.EFFECT = EffectType.Default;
+      } else if (this.EFFECT === EffectType.SineDefault) {
+            this.EFFECT = EffectType.Sine;
+      }
+      this.set_n_tiles(this.X_TILES, this.Y_TILES);
+      this.timerId = new Clutter.Timeline({ duration: this.DURATION + (this.monitor.width * this.monitor.height) / (this.window.width * this.window.height) });
+      this.newFrameEvent = this.timerId.connect('new-frame', this.on_tick_elapsed.bind(this));
+      this.completedEvent = this.timerId.connect('completed', this.destroy.bind(this));
+      this.timerId.start();
+      // Make sure that no fullscreen window is drawn over our animations.
+      Meta.disable_unredirect_for_display(global.display);
+      global.begin_work();
+   }
+
+   // This will stop any running animation and emit the end-animation signal.
+   endAnimation() {
+      // This will call endAnimation() again, so we can return for now.
+      if (this.timerId.is_playing()) {
+        this.timerId.stop();
+        return;
+      }
+
+      // Restore unredirecting behavior for fullscreen windows.
+      Meta.enable_unredirect_for_display(global.display);
+      global.end_work();
+
+      this.emit('end-animation');
+   }
+
+   // This can be called to mark this instance to be re-usable.
+   returnToFactory() {
+      this.factory._freeMinimizeEffects.push(this);
+   }
+
+   destroy_actor(actor) {
+      this.initialized = false;
+      this.emit('end-animation');
+   }
+
+   on_tick_elapsed(timer, msecs) {
+      if (Main.overview.visible) {
+          this.destroy();
+      }
+
+      this.progress = timer.get_progress();
+      this.k = this.progress <= this.split ? this.progress * (1 / 1 / this.split) : 1;
+      this.j = this.progress > this.split ? (this.progress - this.split) * (1 / 1 / (1 - this.split)) : 0;
+
+      //this.actor.get_parent().queue_redraw();
+      this.invalidate();
+   }
+
+   vfunc_modify_paint_volume(pv) {
+      return false;
+   }
+}
+
+);
+
+var MagicLampUnminimizeEffect = GObject.registerClass( {
+      GTypeName: `Cjs_MagicLampUnminimizeEffect_${Math.floor(Math.random() * 100000) + 1}`,
+      Signals: { 'end-animation': {} }
+      },
+
+class MagicLampUnminimizeEffect extends AbstractCommonMagicLampEffect {
+   _init(factory) {
+      super._init();
+
+      this.k = 1;
+      this.j = 1;
+      this.isMinimizeEffect = false;
+      this.factory = factory;
+   }
+
+   setEvent(event) {
+      this.event = event;
+   }
+
+   // This is called once each time the shader is used.
+   beginAnimation(settings, forOpening, testMode, duration, actor) {
+      this.DURATION = duration;
+      this.X_TILES = settings.getValue("magiclamp-x-tiles");
+      this.Y_TILES = settings.getValue("magiclamp-y-tiles");
+      this.EFFECT = settings.getValue("magiclamp-effect");
+      if (this.EFFECT === EffectType.Random) {
+         this.EFFECT = Math.floor(Math.random() * 2);
+      } else if (this.EFFECT === EffectType.DefaultSine) {
+         this.EFFECT = EffectType.Sine;
+      } else if (this.EFFECT === EffectType.SineDefault) {
+         this.EFFECT = EffectType.Default;
+      }
+      this.set_n_tiles(this.X_TILES, this.Y_TILES);
+      this.timerId = new Clutter.Timeline({ duration: this.DURATION + (this.monitor.width * this.monitor.height) / (this.window.width * this.window.height) });
+      this.newFrameEvent = this.timerId.connect('new-frame', this.on_tick_elapsed.bind(this));
+      this.completedEvent = this.timerId.connect('completed', this.destroy.bind(this));
+      this.timerId.start();
+      // Make sure that no fullscreen window is drawn over our animations.
+      Meta.disable_unredirect_for_display(global.display);
+      global.begin_work();
+   }
+
+   // This will stop any running animation and emit the end-animation signal.
+   endAnimation() {
+      // This will call endAnimation() again, so we can return for now.
+      if (this.timerId.is_playing()) {
+        this.timerId.stop();
+        return;
+      }
+
+      // Restore unredirecting behavior for fullscreen windows.
+      Meta.enable_unredirect_for_display(global.display);
+      global.end_work();
+
+      this.emit('end-animation');
+   }
+
+    // This can be called to mark this instance to be re-usable.
+    returnToFactory() {
+       this.factory._freeUnminimizeEffects.push(this);
+    }
+
+   destroy_actor(actor) {
+      this.initialized = false;
+      this.emit('end-animation');
+   }
+
+   on_tick_elapsed(timer, msecs) {
+      if (Main.overview.visible) {
+         this.destroy();
+      }
+
+      this.progress = timer.get_progress();
+      this.k = 1 - (this.progress > (1 - this.split) ? (this.progress - (1 - this.split)) * (1 / 1 / (1 - (1 - this.split))) : 0);
+      this.j = 1 - (this.progress <= (1 - this.split) ? this.progress * (1 / 1 / (1 - this.split)) : 1);
+
+      //this.actor.get_parent().queue_redraw();
+      this.invalidate();
+   }
+
+   vfunc_modify_paint_volume(pv) {
+      return false;
+   }
+}
+
+);

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Mushroom.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Mushroom.js
@@ -1,0 +1,409 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//          )                                                   (                       //
+//       ( /(   (  (               )    (       (  (  (         )\ )    (  (            //
+//       )\()) ))\ )(   (         (     )\ )    )\))( )\  (    (()/( (  )\))(  (        //
+//      ((_)\ /((_|()\  )\ )      )\  '(()/(   ((_)()((_) )\ )  ((_)))\((_)()\ )\       //
+//      | |(_|_))( ((_)_(_/(    _((_))  )(_))  _(()((_|_)_(_/(  _| |((_)(()((_|(_)      //
+//      | '_ \ || | '_| ' \))  | '  \()| || |  \ V  V / | ' \)) _` / _ \ V  V (_-<      //
+//      |_.__/\_,_|_| |_||_|   |_|_|_|  \_, |   \_/\_/|_|_||_|\__,_\___/\_/\_//__/      //
+//                                 |__/                                                 //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Justin Garza JGarza9788@gmail.com
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+'use strict';
+
+// Import the Gio module from the GNOME platform (GObject Introspection).
+// This module provides APIs for I/O operations, settings management, and other core
+// features.
+//import Gio from 'gi://Gio';
+const Clutter = imports.gi.Clutter;
+
+// Import utility functions from the local utils.js file.
+// These utilities likely contain helper functions or shared logic used across the
+// application.
+//import * as utils from '../utils.js';
+
+// We import the ShaderFactory only in the Shell process as it is not required in the
+// preferences process. The preferences process does not create any shader instances, it
+// only uses the static metadata of the effect.
+//const ShaderFactory = await utils.importInShellOnly('./ShaderFactory.js');
+const {ShaderFactory} = require('./ShaderFactory.js');
+
+
+//const _ = await utils.importGettext();
+const Gettext = imports.gettext;
+const GLib = imports.gi.GLib;
+const UUID = "CinnamonBurnMyWindows@klangman";
+
+Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
+
+function _(text) {
+  let locText = Gettext.dgettext(UUID, text);
+  if (locText == text) {
+    locText = window._(text);
+  }
+  return locText;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// This effect is inspired by the old 8bit mario video games and the New Super Mario //
+// Bros 2 specifically when mario gets the mushroom. i hope you enjoy this little blast //
+// from the past. //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// The effect class can be used to get some metadata (like the effect's name or supported
+// GNOME Shell versions), to initialize the respective page of the settings dialog, as
+// well as to create the actual shader for the effect.
+var Effect = class Effect {
+  // The constructor creates a ShaderFactory which will be used by extension.js to create
+  // shader instances for this effect. The shaders will be automagically created using the
+  // GLSL file in resources/shaders/<nick>.glsl. The callback will be called for each
+  // newly created shader instance.
+  constructor(signalManager, settings) {
+    // Adjust the Mushroom settings when a different preset is selected
+    signalManager.connect(settings, "changed::mushroom-presets", () => this._setupUsingPresets(settings));
+    signalManager.connect(settings, "changed::mushroom-custom-scale-style", () => this._setupUsingPresets(settings));
+    signalManager.connect(settings, "changed::mushroom-custom-spark-count", () => this._setupUsingPresets(settings));
+    signalManager.connect(settings, "changed::mushroom-custom-spark-color", () => this._setupUsingPresets(settings));
+    signalManager.connect(settings, "changed::mushroom-custom-spark-rotation", () => this._setupUsingPresets(settings));
+    signalManager.connect(settings, "changed::mushroom-custom-rays-color", () => this._setupUsingPresets(settings));
+    signalManager.connect(settings, "changed::mushroom-custom-ring-count", () => this._setupUsingPresets(settings));
+    signalManager.connect(settings, "changed::mushroom-custom-ring-rotation", () => this._setupUsingPresets(settings));
+    signalManager.connect(settings, "changed::mushroom-custom-star-count", () => this._setupUsingPresets(settings));
+    for (let i = 0; i <= 5; i++) {
+      signalManager.connect(settings, "changed::mushroom-custom-star-color-" + i, () => this._setupUsingPresets(settings));
+    }
+    this._setupUsingPresets(settings);
+    this.shaderFactory = new ShaderFactory(Effect.getNick(), (shader) => {
+      // Store all uniform locations.
+      shader._uGradient = [
+        shader.get_uniform_location('uStarColor0'),
+        shader.get_uniform_location('uStarColor1'),
+        shader.get_uniform_location('uStarColor2'),
+        shader.get_uniform_location('uStarColor3'),
+        shader.get_uniform_location('uStarColor4'),
+        shader.get_uniform_location('uStarColor5'),
+      ];
+
+
+      shader._uScaleStyle = shader.get_uniform_location('uScaleStyle');
+
+      shader._uSparkCount    = shader.get_uniform_location('uSparkCount');
+      shader._uSparkColor    = shader.get_uniform_location('uSparkColor');
+      shader._uSparkRotation = shader.get_uniform_location('uSparkRotation');
+
+      shader._uRaysColor = shader.get_uniform_location('uRaysColor');
+
+      shader._uRingCount    = shader.get_uniform_location('uRingCount');
+      shader._uRingRotation = shader.get_uniform_location('uRingRotation');
+      shader._uStarCount    = shader.get_uniform_location('uStarCount');
+
+      shader._uSeed = shader.get_uniform_location('uSeed');
+
+      // And update all uniforms at the start of each animation.
+      shader.connect('begin-animation', (shader, settings) => {
+        for (let i = 0; i <= 5; i++) {
+          shader.set_uniform_float(
+            shader._uGradient[i], 4,
+            this.parseColor(settings.mushroomStarColors[i]));
+        }
+
+        // clang-format off
+        shader.set_uniform_float(shader._uScaleStyle,    1, [settings.mushroomScaleStyle]);
+        shader.set_uniform_float(shader._uSparkCount,    1, [settings.mushroomSparkCount]);
+        shader.set_uniform_float(shader._uSparkColor,    4, this.parseColor(settings.mushroomSparkColor));
+        shader.set_uniform_float(shader._uSparkRotation, 1, [settings.mushroomSparkRotation]);
+        shader.set_uniform_float(shader._uRaysColor,     4, this.parseColor(settings.mushroomRaysColor));
+        shader.set_uniform_float(shader._uRingCount,     1, [settings.mushroomRingCount]);
+        shader.set_uniform_float(shader._uRingRotation,  1, [settings.mushroomRingRotation]);
+        shader.set_uniform_float(shader._uStarCount,     1, [settings.mushroomStarCount]);
+
+        shader.set_uniform_float(shader._uSeed,  2, [Math.random(), Math.random()]);
+        // clang-format on
+      });
+    });
+  }
+
+  parseColor(string) {
+    let [ok, color] = Clutter.Color.from_string(string);
+    if (ok) {
+      return( [color.red / 255, color.green / 255, color.blue / 255, color.alpha / 255] );
+    }
+  }
+  // ---------------------------------------------------------------------------- metadata
+
+  // The effect is available on all GNOME Shell versions supported by this extension.
+  static getMinShellVersion() {
+    return [3, 36];
+  }
+
+  // This will be called in various places where a unique identifier for this effect is
+  // required. It should match the prefix of the settings keys which store whether the
+  // effect is enabled currently (e.g. '*-enable-effect'), and its animation time
+  // (e.g. '*-animation-time'). Also, the shader file and the settings UI files should be
+  // named likes this.
+  static getNick() {
+    return 'mushroom';
+  }
+
+  // This will be shown in the sidebar of the preferences dialog as well as in the
+  // drop-down menus where the user can choose the effect.
+  static getLabel() {
+    return _('Mushroom');
+  }
+
+  // -------------------------------------------------------------------- API for prefs.js
+
+  // This is called by the preferences dialog whenever a new effect profile is loaded. It
+  // binds all user interface elements to the respective settings keys of the profile.
+  static bindPreferences(dialog) {
+    // Empty for now... Code is added here later in the tutorial!
+    dialog.bindAdjustment('mushroom-animation-time');
+    // dialog.bindSwitch('mushroom-8bit-enable');
+
+    dialog.bindAdjustment('mushroom-scale-style');
+
+    dialog.bindAdjustment('mushroom-spark-count');
+    dialog.bindColorButton('mushroom-spark-color');
+    dialog.bindAdjustment('mushroom-spark-rotation');
+
+    dialog.bindColorButton('mushroom-rays-color');
+
+    dialog.bindAdjustment('mushroom-ring-count');
+    dialog.bindAdjustment('mushroom-ring-rotation');
+    dialog.bindAdjustment('mushroom-star-count');
+
+    dialog.bindColorButton('mushroom-star-color-0');
+    dialog.bindColorButton('mushroom-star-color-1');
+    dialog.bindColorButton('mushroom-star-color-2');
+    dialog.bindColorButton('mushroom-star-color-3');
+    dialog.bindColorButton('mushroom-star-color-4');
+    dialog.bindColorButton('mushroom-star-color-5');
+
+
+    // Ensure the button connections and other bindings happen only once,
+    // even if the bindPreferences function is called multiple times.
+    if (!Effect._isConnected) {
+      Effect._isConnected = true;
+
+      // Bind the "reset-star-colors" button to reset all star colors to their default
+      // values.
+      dialog.getBuilder().get_object('reset-star-colors').connect('clicked', () => {
+        // Reset each mushroom star color setting.
+        dialog.getProfileSettings().reset('mushroom-star-color-0');
+        dialog.getProfileSettings().reset('mushroom-star-color-1');
+        dialog.getProfileSettings().reset('mushroom-star-color-2');
+        dialog.getProfileSettings().reset('mushroom-star-color-3');
+        dialog.getProfileSettings().reset('mushroom-star-color-4');
+        dialog.getProfileSettings().reset('mushroom-star-color-5');
+      });
+
+
+      // Initialize the preset dropdown menu for mushroom star colors.
+      Effect._createMushroomPresets(dialog);
+    }
+  }
+
+  // ---------------------------------------------------------------- API for extension.js
+
+  // The getActorScale() is called from extension.js to adjust the actor's size during the
+  // animation. This is useful if the effect requires drawing something beyond the usual
+  // bounds of the actor. This only works for GNOME 3.38+.
+  static getActorScale(settings, forOpening, actor) {
+    return {x: 1.0, y: 1.0};
+  }
+
+  // ---------------------------------------------------------------- Presets
+
+  // This function initializes the preset dropdown menu for configuring fire options.
+  // It defines multiple color presets for the "mushroom star" effect and sets up
+  // the logic to apply these presets when selected.
+
+  _setupUsingPresets(settings) {
+    const presets = [
+     {
+       name: _('8Bit Plumber'),
+       ScaleStyle: 0.0,
+       SparkCount: 0,
+       SparkColor: 'rgba(255,255,255,0.0)',
+       SparkRotation: 0.33,
+       RayColor: 'rgba(255,255,255,0.0)',
+       RingCount: 0,
+       RingRotation: 0.0,
+       StarCount: 0,
+       color0: 'rgba(233,249,0,1.0)',
+       color1: 'rgba(233,249,0,1.0)',
+       color2: 'rgba(91,255,0,1.0)',
+       color3: 'rgba(91,255,0,1.0)',
+       color4: 'rgba(0,240,236,1.0)',
+       color5: 'rgba(0,240,236,1.0)',
+     },
+     {
+       name: _('New Bros 2'),
+       ScaleStyle: 1.0,
+       SparkCount: 4,
+       SparkColor: 'rgba(255,255,255,1.0)',
+       SparkRotation: 0.3,
+       RayColor: 'rgba(255,255,255,1.0)',
+       RingCount: 3,
+       RingRotation: 1.33,
+       StarCount: 5,
+       color0: 'rgba(233,249,0,1.0)',
+       color1: 'rgba(233,249,0,1.0)',
+       color2: 'rgba(91,255,0,1.0)',
+       color3: 'rgba(91,255,0,1.0)',
+       color4: 'rgba(0,240,236,1.0)',
+       color5: 'rgba(0,240,236,1.0)',
+     },
+     {
+       name:
+         _('The True North'),  // A patriotic palette of red, white
+       ScaleStyle: 1.0,
+       SparkCount: 4,
+       SparkColor: 'rgba(255,255,255,1.0)',
+       SparkRotation: 0.3,
+       RayColor: 'rgba(255,255,255,0.0)',
+       RingCount: 4,
+       RingRotation: 1.33,
+       StarCount: 5,
+       color0: 'rgba(216, 6, 33, 1.0)',
+       color1: 'rgba(255,255,255, 1.0)',
+       color2: 'rgba(216, 6, 33, 1.0)',
+       color3: 'rgba(255,255,255, 1.0)',
+       color4: 'rgba(216, 6, 33, 1.0)',
+       color5: 'rgba(255,255,255, 1.0)'
+     },
+     {
+       name:
+         _('Red White and Blue'),  // A patriotic palette of red, white, and blue
+       ScaleStyle: 1.0,
+       SparkCount: 4,
+       SparkColor: 'rgba(255,255,255,1.0)',
+       SparkRotation: 0.3,
+       RayColor: 'rgba(255,255,255,0.0)',
+       RingCount: 3,
+       RingRotation: 1.33,
+       StarCount: 5,
+       color0: 'rgba(179, 25, 66, 1.0)',
+       color1: 'rgba(179, 25, 66, 1.0)',
+       color2: 'rgba(255,255,255, 1.0)',
+       color3: 'rgba(255,255,255, 1.0)',
+       color4: 'rgba(10, 49, 97, 1.0)',
+       color5: 'rgba(10, 49, 97, 1.0)'
+     },
+     {
+       name: _('Rainbow'),  // A vivid rainbow spectrum of colors
+       ScaleStyle: 1.0,
+       SparkCount: 4,
+       SparkColor: 'rgba(255,255,255,1.0)',
+       SparkRotation: 0.3,
+       RayColor: 'rgba(255,255,255,0.0)',
+       RingCount: 3,
+       RingRotation: 2.0,
+       StarCount: 7,
+       color0: 'rgba(255, 69, 58, 1.0)',   // Bold Red
+       color1: 'rgba(255, 140, 0, 1.0)',   // Bold Orange
+       color2: 'rgba(255, 223, 0, 1.0)',   // Bold Yellow
+       color3: 'rgba(50, 205, 50, 1.0)',   // Bold Green
+       color4: 'rgba(30, 144, 255, 1.0)',  // Bold Blue
+       color5: 'rgba(148, 0, 211, 1.0)'    // Bold Purple
+     },
+     {
+       name: _('Cattuccino'),  // A soft pastel palette inspired by a
+                                  // cappuccino theme
+       ScaleStyle: 1.0,
+       SparkCount: 4,
+       SparkColor: 'rgba(255,255,255,1.0)',
+       SparkRotation: 0.3,
+       RayColor: 'rgba(255,255,255,0.0)',
+       RingCount: 3,
+       RingRotation: 2.0,
+       StarCount: 7,
+       color0: 'rgba(239, 146, 160, 1.0)',
+       color1: 'rgba(246, 178, 138, 1.0)',
+       color2: 'rgba(240, 217, 169, 1.0)',
+       color3: 'rgba(175, 223, 159, 1.0)',
+       color4: 'rgba(149, 182, 246, 1.0)',
+       color5: 'rgba(205, 170, 247, 1.0)'
+     },
+     {
+       name: _('Dracula'),  // A dark palette inspired by the Dracula theme
+       ScaleStyle: 1.0,
+       SparkCount: 0,
+       SparkColor: 'rgba(255,255,255,1.0)',
+       SparkRotation: 0.3,
+       RayColor: 'rgba(255,255,255,0.0)',
+       RingCount: 3,
+       RingRotation: 2.0,
+       StarCount: 7,
+       color0: 'rgba(40, 42, 54, 1.0)',   // Dark Grey
+       color1: 'rgba(68, 71, 90, 1.0)',   // Medium Grey
+       color2: 'rgba(90, 94, 119, 1.0)',  // Light Grey
+       color3: 'rgba(90, 94, 119, 1.0)',  // Light Grey
+       color4: 'rgba(68, 71, 90, 1.0)',   // Medium Grey
+       color5: 'rgba(40, 42, 54, 1.0)'    // Dark Grey
+     },
+     {
+       name: _('Sparkle'),  // A dark palette inspired by the Dracula theme
+       ScaleStyle: 1.0,
+       SparkCount: 25,
+       SparkColor: 'rgba(255,255,255,1.0)',
+       SparkRotation: 0.3,
+       RayColor: 'rgba(255,255,255,0.0)',
+       RingCount: 0,
+       RingRotation: 1.33,
+       StarCount: 7,
+       color0: 'rgba(255,255,255,0.0)',
+       color1: 'rgba(255,255,255,0.0)',
+       color2: 'rgba(255,255,255,0.0)',
+       color3: 'rgba(255,255,255,0.0)',
+       color4: 'rgba(255,255,255,0.0)',
+       color5: 'rgba(255,255,255,0.0)',
+     }
+    ];
+
+    let name = settings.getValue("mushroom-presets");
+    if (name == "Custom") {
+      settings.mushroomScaleStyle    = settings.getValue("mushroom-custom-scale-style");
+      settings.mushroomSparkCount    = settings.getValue("mushroom-custom-spark-count");
+      settings.mushroomSparkColor    = settings.getValue("mushroom-custom-spark-color");
+      settings.mushroomSparkRotation = settings.getValue("mushroom-custom-spark-rotation");
+      settings.mushroomRaysColor     = settings.getValue("mushroom-custom-rays-color");
+      settings.mushroomRingCount     = settings.getValue("mushroom-custom-ring-count");
+      settings.mushroomRingRotation  = settings.getValue("mushroom-custom-ring-rotation");
+      settings.mushroomStarCount     = settings.getValue("mushroom-custom-star-count");
+
+      settings.mushroomStarColors = [];
+      settings.mushroomStarColors.push(settings.getValue("mushroom-custom-star-color-0"));
+      settings.mushroomStarColors.push(settings.getValue("mushroom-custom-star-color-1"));
+      settings.mushroomStarColors.push(settings.getValue("mushroom-custom-star-color-2"));
+      settings.mushroomStarColors.push(settings.getValue("mushroom-custom-star-color-3"));
+      settings.mushroomStarColors.push(settings.getValue("mushroom-custom-star-color-4"));
+      settings.mushroomStarColors.push(settings.getValue("mushroom-custom-star-color-5"));
+    } else {
+      presets.find((preset, i) => {
+        if (preset.name == name) {
+          settings.mushroomScaleStyle    = preset.ScaleStyle;
+          settings.mushroomSparkCount    = preset.SparkCount;
+          settings.mushroomSparkColor    = preset.SparkColor;
+          settings.mushroomSparkRotation = preset.SparkRotation;
+          settings.mushroomRaysColor     = preset.RayColor;
+          settings.mushroomRingCount     = preset.RingCount;
+          settings.mushroomRingRotation  = preset.RingRotation;
+          settings.mushroomStarCount     = preset.StarCount;
+
+          settings.mushroomStarColors = [];
+          settings.mushroomStarColors.push(preset.color0);
+          settings.mushroomStarColors.push(preset.color1);
+          settings.mushroomStarColors.push(preset.color2);
+          settings.mushroomStarColors.push(preset.color3);
+          settings.mushroomStarColors.push(preset.color4);
+          settings.mushroomStarColors.push(preset.color5);
+          return(true);
+        }
+      });
+    }
+  }
+}

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/RGBWarp.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/RGBWarp.js
@@ -1,0 +1,114 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//          )                                                   (                       //
+//       ( /(   (  (               )    (       (  (  (         )\ )    (  (            //
+//       )\()) ))\ )(   (         (     )\ )    )\))( )\  (    (()/( (  )\))(  (        //
+//      ((_)\ /((_|()\  )\ )      )\  '(()/(   ((_)()((_) )\ )  ((_)))\((_)()\ )\       //
+//      | |(_|_))( ((_)_(_/(    _((_))  )(_))  _(()((_|_)_(_/(  _| |((_)(()((_|(_)      //
+//      | '_ \ || | '_| ' \))  | '  \()| || |  \ V  V / | ' \)) _` / _ \ V  V (_-<      //
+//      |_.__/\_,_|_| |_||_|   |_|_|_|  \_, |   \_/\_/|_|_||_|\__,_\___/\_/\_//__/      //
+//                                 |__/                                                 //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Justin Garza JGarza9788@gmail.com
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+'use strict';
+
+//import * as utils from '../utils.js';
+
+// We import the ShaderFactory only in the Shell process as it is not required in the
+// preferences process. The preferences process does not create any shader instances, it
+// only uses the static metadata of the effect.
+//const ShaderFactory = await utils.importInShellOnly('./ShaderFactory.js');
+const {ShaderFactory} = require('./ShaderFactory.js');
+
+//const _ = await utils.importGettext();
+const Gettext = imports.gettext;
+const GLib = imports.gi.GLib;
+const UUID = "CinnamonBurnMyWindows@klangman";
+
+Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
+
+function _(text) {
+  let locText = Gettext.dgettext(UUID, text);
+  if (locText == text) {
+    locText = window._(text);
+  }
+  return locText;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// This effect warps the Red Green Blue values                                          //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// The effect class can be used to get some metadata (like the effect's name or supported
+// GNOME Shell versions), to initialize the respective page of the settings dialog, as
+// well as to create the actual shader for the effect.
+var Effect = class Effect {
+  // The constructor creates a ShaderFactory which will be used by extension.js to create
+  // shader instances for this effect. The shaders will be automagically created using the
+  // GLSL file in resources/shaders/<nick>.glsl. The callback will be called for each
+  // newly created shader instance.
+  constructor() {
+    this.shaderFactory = new ShaderFactory(Effect.getNick(), (shader) => {
+      // Store uniform locations of newly created shaders.
+      shader._uBrightness = shader.get_uniform_location('uBrightness');
+      shader._uSpeedR     = shader.get_uniform_location('uSpeedR');
+      shader._uSpeedG     = shader.get_uniform_location('uSpeedG');
+      shader._uSpeedB     = shader.get_uniform_location('uSpeedB');
+
+      // Write all uniform values at the start of each animation.
+      shader.connect('begin-animation', (shader, settings) => {
+        // clang-format off
+        shader.set_uniform_float(shader._uBrightness, 1, [settings.getValue('rgbwarp-brightness')]);
+        shader.set_uniform_float(shader._uSpeedR,     1, [settings.getValue('rgbwarp-speed-r')]);
+        shader.set_uniform_float(shader._uSpeedG,     1, [settings.getValue('rgbwarp-speed-g')]);
+        shader.set_uniform_float(shader._uSpeedB,     1, [settings.getValue('rgbwarp-speed-b')]);
+        // clang-format on
+      });
+    });
+  }
+
+  // ---------------------------------------------------------------------------- metadata
+
+  // The effect is available on all GNOME Shell versions supported by this extension.
+  static getMinShellVersion() {
+    return [3, 36];
+  }
+
+  // This will be called in various places where a unique identifier for this effect is
+  // required. It should match the prefix of the settings keys which store whether the
+  // effect is enabled currently (e.g. '*-enable-effect'), and its animation time
+  // (e.g. '*-animation-time'). Also, the shader file and the settings UI files should be
+  // named likes this.
+  static getNick() {
+    return 'rgbwarp';
+  }
+
+  // This will be shown in the sidebar of the preferences dialog as well as in the
+  // drop-down menus where the user can choose the effect.
+  static getLabel() {
+    return _('RGB Warp');
+  }
+
+  // -------------------------------------------------------------------- API for prefs.js
+
+  // This is called by the preferences dialog whenever a new effect profile is loaded. It
+  // binds all user interface elements to the respective settings keys of the profile.
+  static bindPreferences(dialog) {
+    dialog.bindAdjustment('rgbwarp-animation-time');
+    dialog.bindAdjustment('rgbwarp-brightness');
+    dialog.bindAdjustment('rgbwarp-speed-r');
+    dialog.bindAdjustment('rgbwarp-speed-g');
+    dialog.bindAdjustment('rgbwarp-speed-b');
+  }
+
+  // ---------------------------------------------------------------- API for extension.js
+
+  // The getActorScale() is called from extension.js to adjust the actor's size during the
+  // animation. This is useful if the effect requires drawing something beyond the usual
+  // bounds of the actor. This only works for GNOME 3.38+.
+  static getActorScale(settings, forOpening, actor) {
+    return {x: 1.0, y: 1.0};
+  }
+}

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/TeamRocket.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/TeamRocket.js
@@ -1,0 +1,128 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//          )                                                   (                       //
+//       ( /(   (  (               )    (       (  (  (         )\ )    (  (            //
+//       )\()) ))\ )(   (         (     )\ )    )\))( )\  (    (()/( (  )\))(  (        //
+//      ((_)\ /((_|()\  )\ )      )\  '(()/(   ((_)()((_) )\ )  ((_)))\((_)()\ )\       //
+//      | |(_|_))( ((_)_(_/(    _((_))  )(_))  _(()((_|_)_(_/(  _| |((_)(()((_|(_)      //
+//      | '_ \ || | '_| ' \))  | '  \()| || |  \ V  V / | ' \)) _` / _ \ V  V (_-<      //
+//      |_.__/\_,_|_| |_||_|   |_|_|_|  \_, |   \_/\_/|_|_||_|\__,_\___/\_/\_//__/      //
+//                                 |__/                                                 //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Justin Garza JGarza9788@gmail.com
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+'use strict';
+
+//import * as utils from '../utils.js';
+
+// We import the ShaderFactory only in the Shell process as it is not required in the
+// preferences process. The preferences process does not create any shader instances, it
+// only uses the static metadata of the effect.
+//const ShaderFactory = await utils.importInShellOnly('./ShaderFactory.js');
+const {ShaderFactory} = require('./ShaderFactory.js');
+
+//const _ = await utils.importGettext();
+const Gettext = imports.gettext;
+const GLib = imports.gi.GLib;
+const UUID = "CinnamonBurnMyWindows@klangman";
+
+Gettext.bindtextdomain(UUID, GLib.get_home_dir() + "/.local/share/locale");
+
+function _(text) {
+  let locText = Gettext.dgettext(UUID, text);
+  if (locText == text) {
+    locText = window._(text);
+  }
+  return locText;
+}
+
+//////////////////////////////////////////////////////////////////////////////////////////
+// This effect was inspired by Team Rocket Blasting Off again!                          //
+// https://c.tenor.com/0ag0MVXUaQEAAAAd/tenor.gif                                       //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// The effect class can be used to get some metadata (like the effect's name or supported
+// GNOME Shell versions), to initialize the respective page of the settings dialog, as
+// well as to create the actual shader for the effect.
+var Effect = class Effect {
+  // The constructor creates a ShaderFactory which will be used by extension.js to create
+  // shader instances for this effect. The shaders will be automagically created using the
+  // GLSL file in resources/shaders/<nick>.glsl. The callback will be called for each
+  // newly created shader instance.
+  constructor() {
+    this.shaderFactory = new ShaderFactory(Effect.getNick(), (shader) => {
+      // Store uniform locations of newly created shaders.
+      shader._uAnimationSplit = shader.get_uniform_location('uAnimationSplit');
+      shader._uHorizontalSparklePosition =
+        shader.get_uniform_location('uHorizontalSparklePosition');
+      shader._uVerticalSparklePosition =
+        shader.get_uniform_location('uVerticalSparklePosition');
+      shader._uWindowRotation = shader.get_uniform_location('uWindowRotation');
+      shader._uSparkleRot     = shader.get_uniform_location('uSparkleRot');
+      shader._uSparkleSize    = shader.get_uniform_location('uSparkleSize');
+
+      shader._uSeed = shader.get_uniform_location('uSeed');
+
+      // Write all uniform values at the start of each animation.
+      shader.connect('begin-animation', (shader, settings) => {
+        // clang-format off
+        shader.set_uniform_float(shader._uAnimationSplit,            1, [settings.getValue('team-rocket-animation-split')]);
+        shader.set_uniform_float(shader._uHorizontalSparklePosition, 1, [settings.getValue('team-rocket-horizontal-sparkle-position')]);
+        shader.set_uniform_float(shader._uVerticalSparklePosition,   1, [settings.getValue('team-rocket-vertical-sparkle-position')]);
+        shader.set_uniform_float(shader._uWindowRotation,            1, [settings.getValue('team-rocket-window-rotation')]);
+        shader.set_uniform_float(shader._uSparkleRot,  1, [settings.getValue('team-rocket-sparkle-rot')]);
+        shader.set_uniform_float(shader._uSparkleSize, 1, [settings.getValue('team-rocket-sparkle-size')]);
+        // clang-format on
+
+        // This will be used with a hash function to get a random number.
+        shader.set_uniform_float(shader._uSeed, 2, [Math.random(), Math.random()]);
+      });
+    });
+  }
+
+  // ---------------------------------------------------------------------------- metadata
+
+  // The effect is available on all GNOME Shell versions supported by this extension.
+  static getMinShellVersion() {
+    return [3, 36];
+  }
+
+  // This will be called in various places where a unique identifier for this effect is
+  // required. It should match the prefix of the settings keys which store whether the
+  // effect is enabled currently (e.g. '*-enable-effect'), and its animation time
+  // (e.g. '*-animation-time'). Also, the shader file and the settings UI files should be
+  // named likes this.
+  static getNick() {
+    return 'team-rocket';
+  }
+
+  // This will be shown in the sidebar of the preferences dialog as well as in the
+  // drop-down menus where the user can choose the effect.
+  static getLabel() {
+    return _('Team Rocket');
+  }
+
+  // -------------------------------------------------------------------- API for prefs.js
+
+  // This is called by the preferences dialog whenever a new effect profile is loaded. It
+  // binds all user interface elements to the respective settings keys of the profile.
+  static bindPreferences(dialog) {
+    dialog.bindAdjustment('team-rocket-animation-time');
+    dialog.bindAdjustment('team-rocket-animation-split');
+    dialog.bindAdjustment('team-rocket-horizontal-sparkle-position');
+    dialog.bindAdjustment('team-rocket-vertical-sparkle-position');
+    dialog.bindSwitch('team-rocket-window-rotation');
+    dialog.bindAdjustment('team-rocket-sparkle-rot');
+    dialog.bindAdjustment('team-rocket-sparkle-size');
+  }
+
+  // ---------------------------------------------------------------- API for extension.js
+
+  // The getActorScale() is called from extension.js to adjust the actor's size during the
+  // animation. This is useful if the effect requires drawing something beyond the usual
+  // bounds of the actor. This only works for GNOME 3.38+.
+  static getActorScale(settings, forOpening, actor) {
+    return {x: 1.0, y: 1.0};
+  }
+}

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/metadata.json
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/metadata.json
@@ -1,8 +1,8 @@
 {
   "uuid": "CinnamonBurnMyWindows@klangman",
   "name": "Burn My Windows",
-  "version": "0.9.7",
-  "description": "Window open/close effects based on the Burn-My-Windows Gnome extension by Schneegans",
+  "version": "0.9.8",
+  "description": "Window open/close/minimize/unminimize effects based on the Burn-My-Windows Gnome extension by Schneegans",
   "url": "https://github.com/klangman/CinnamonBurnMyWindows",
   "website": "https://github.com/klangman/CinnamonBurnMyWindows",
   "cinnamon-version": ["6.2"]

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/CinnamonBurnMyWindows@klangman.pot
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/CinnamonBurnMyWindows@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.7\n"
+"Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.8\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 22:59-0500\n"
+"POT-Creation-Date: 2025-03-06 10:34-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,148 +17,183 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.2/extension.js:212 6.2/extension.js:450
+#. 6.2/extension.js:190 6.2/extension.js:266 6.2/extension.js:572
 msgid "Error"
 msgstr ""
 
-#. 6.2/extension.js:212
+#. 6.2/extension.js:190
 msgid "was NOT enabled"
 msgstr ""
 
-#. 6.2/extension.js:213
+#. 6.2/extension.js:191 6.2/extension.js:267
 msgid "The existing extension"
 msgstr ""
 
-#. 6.2/extension.js:213
+#. 6.2/extension.js:191
 msgid "conflicts with this extension."
 msgstr ""
 
-#. 6.2/extension.js:451
-msgid ""
-"The previously focused window is not backed by an application and therefore "
-"application specific effects can not be applied to that window"
+#. 6.2/extension.js:266
+msgid "minimize/unminimize effects can not be enabled"
 msgstr ""
 
-#. 6.2->settings-schema.json->apparition-random-include->description
+#. 6.2/extension.js:267
+msgid "already handles minimize/unminimize animation events."
+msgstr ""
+
+#. 6.2/extension.js:573
+msgid ""
+"Unable to determine the application or the WM_CLASS of the previously "
+"focused window, therefore application specific effects can not be applied to "
+"that window"
+msgstr ""
+
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Apparition.js:94
 msgid "Apparition"
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/AuraGlow.js:103
+msgid "Aura Glow"
 msgstr ""
 
 #. effects/BrokenGlass.js:152
 msgid "Broken Glass"
 msgstr ""
 
-#. 6.2->settings-schema.json->doom-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Doom.js:101
 msgid "Doom"
 msgstr ""
 
-#. 6.2->settings-schema.json->energize-a-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/EnergizeA.js:90
 msgid "Energize A"
 msgstr ""
 
-#. 6.2->settings-schema.json->energize-b-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/EnergizeB.js:92
 msgid "Energize B"
 msgstr ""
 
-#. 6.2->settings-schema.json->fire-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
-#. effects/Fire.js:114
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/Fire.js:122
 msgid "Fire"
 msgstr ""
 
-#. effects/Fire.js:168
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:175
 msgid "Default Fire"
 msgstr ""
 
-#. effects/Fire.js:178
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:185
 msgid "Hell Fire"
 msgstr ""
 
-#. effects/Fire.js:188
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:195
 msgid "Dark and Smutty"
 msgstr ""
 
-#. effects/Fire.js:198
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:205
 msgid "Cold Breeze"
 msgstr ""
 
-#. effects/Fire.js:208
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:215
 msgid "Santa is Coming"
 msgstr ""
 
-#. 6.2->settings-schema.json->focus-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Focus.js:91
 msgid "Focus"
 msgstr ""
 
-#. 6.2->settings-schema.json->glide-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Glide.js:93
 msgid "Glide"
 msgstr ""
 
-#. 6.2->settings-schema.json->glitch-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Glitch.js:97
 msgid "Glitch"
 msgstr ""
 
-#. 6.2->settings-schema.json->hexagon-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Hexagon.js:106
 msgid "Hexagon"
 msgstr ""
 
-#. 6.2->settings-schema.json->incinerate-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Incinerate.js:144
 msgid "Incinerate"
 msgstr ""
@@ -167,48 +202,114 @@ msgstr ""
 msgid "Matrix"
 msgstr ""
 
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/Mushroom.js:154
+msgid "Mushroom"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:227
+msgid "8Bit Plumber"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:244
+msgid "New Bros 2"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:262
+msgid "The True North"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:280
+msgid "Red White and Blue"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:297
+msgid "Rainbow"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:314
+msgid "Cattuccino"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:332
+msgid "Dracula"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:349
+msgid "Sparkle"
+msgstr ""
+
 #. effects/PaintBrush.js:114
 msgid "Paint Brush"
 msgstr ""
 
-#. 6.2->settings-schema.json->pixel-wheel-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/PixelWheel.js:88
 msgid "Pixel Wheel"
 msgstr ""
 
-#. 6.2->settings-schema.json->pixel-wipe-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/PixelWipe.js:114
 msgid "Pixel Wipe"
 msgstr ""
 
-#. 6.2->settings-schema.json->pixelate-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Pixelate.js:88
 msgid "Pixelate"
 msgstr ""
 
-#. 6.2->settings-schema.json->portal-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Portal.js:99
 msgid "Portal"
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/RGBWarp.js:91
+msgid "RGB Warp"
 msgstr ""
 
 #. effects/SnapOfDisintegration.js:124
@@ -219,32 +320,46 @@ msgstr ""
 msgid "T-Rex Attack"
 msgstr ""
 
-#. 6.2->settings-schema.json->tv-effect-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/TVEffect.js:90
 msgid "TV Effect"
 msgstr ""
 
-#. 6.2->settings-schema.json->tv-glitch-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/TVGlitch.js:99
 msgid "TV Glitch"
 msgstr ""
 
-#. 6.2->settings-schema.json->wisps-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/TeamRocket.js:103
+msgid "Team Rocket"
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Wisps.js:101
 msgid "Wisps"
 msgstr ""
@@ -255,8 +370,8 @@ msgstr ""
 
 #. metadata.json->description
 msgid ""
-"Window open/close effects based on the Burn-My-Windows Gnome extension by "
-"Schneegans"
+"Window open/close/minimize/unminimize effects based on the Burn-My-Windows "
+"Gnome extension by Schneegans"
 msgstr ""
 
 #. 6.2->settings-schema.json->general-page->title
@@ -267,8 +382,16 @@ msgstr ""
 msgid "Effect Settings"
 msgstr ""
 
+#. 6.2->settings-schema.json->application-page->title
+msgid "Application Specifics"
+msgstr ""
+
 #. 6.2->settings-schema.json->random-page->title
 msgid "Random Effects"
+msgstr ""
+
+#. 6.2->settings-schema.json->about-page->title
+msgid "About"
 msgstr ""
 
 #. 6.2->settings-schema.json->general-settings->title
@@ -287,8 +410,29 @@ msgstr ""
 msgid "Effect Specific Settings"
 msgstr ""
 
+#. 6.2->settings-schema.json->fire-custom-section->title
+#. 6.2->settings-schema.json->mushroom-custom-section->title
+msgid "Setting for the custom preset:"
+msgstr ""
+
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
+msgstr ""
+
+#. 6.2->settings-schema.json->about-section->title
+msgid "About Cinnamon Burn-My-Windows"
+msgstr ""
+
+#. 6.2->settings-schema.json->about-text->description
+msgid ""
+"Ported to Cinnamon by Kevin Langman\n"
+"Github: https://github.com/klangman/CinnamonBurnMyWindows\n"
+"\n"
+"Based on the Burn-My-Windows code by Schneegans and contributors\n"
+"Github: https://github.com/Schneegans/Burn-My-Windows\n"
+"\n"
+"The Magic Lamp Effect is ported from code by hermes83\n"
+"GitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
 msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->description
@@ -300,11 +444,19 @@ msgid "Enabled"
 msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->columns->title
-msgid "Open Effect"
+msgid "Open"
 msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->columns->title
-msgid "Close Effect"
+msgid "Close"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Minimize"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Unminimize"
 msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->columns->title
@@ -327,8 +479,45 @@ msgid ""
 "return here and press this button."
 msgstr ""
 
-#. 6.2->settings-schema.json->random-title->description
-msgid "Effect"
+#. 6.2->settings-schema.json->random-include->description
+msgid "Effects included in the randomized sets"
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->tooltip
+msgid ""
+"Defines which effects are included in the randomized sets for each window "
+"event type. When 'Randomized' is selected for any event on the General tab "
+"these sets are used."
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "Effect Name         "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "      Open        "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "      Close       "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "     Minimize     "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "    Unminimize    "
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+msgid "Magic Lamp"
 msgstr ""
 
 #. 6.2->settings-schema.json->effect-selector->description
@@ -339,6 +528,8 @@ msgstr ""
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 msgid "Randomized"
 msgstr ""
 
@@ -346,6 +537,8 @@ msgstr ""
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 msgid "None"
 msgstr ""
 
@@ -376,6 +569,14 @@ msgstr ""
 msgid "Close dialog window effect"
 msgstr ""
 
+#. 6.2->settings-schema.json->minimize-effect->description
+msgid "Minimize window effect"
+msgstr ""
+
+#. 6.2->settings-schema.json->unminimize-effect->description
+msgid "Unminimize window effect"
+msgstr ""
+
 #. 6.2->settings-schema.json->apparition-shake-intensity->description
 msgid "Shake Intensity"
 msgstr ""
@@ -393,6 +594,7 @@ msgid "Randomness"
 msgstr ""
 
 #. 6.2->settings-schema.json->apparition-animation-time->description
+#. 6.2->settings-schema.json->aura-glow-animation-time->description
 #. 6.2->settings-schema.json->doom-animation-time->description
 #. 6.2->settings-schema.json->energize-a-animation-time->description
 #. 6.2->settings-schema.json->energize-b-animation-time->description
@@ -402,14 +604,49 @@ msgstr ""
 #. 6.2->settings-schema.json->glitch-animation-time->description
 #. 6.2->settings-schema.json->hexagon-animation-time->description
 #. 6.2->settings-schema.json->incinerate-animation-time->description
+#. 6.2->settings-schema.json->magiclamp-animation-time->description
+#. 6.2->settings-schema.json->mushroom-animation-time->description
 #. 6.2->settings-schema.json->pixelate-animation-time->description
 #. 6.2->settings-schema.json->pixel-wheel-animation-time->description
 #. 6.2->settings-schema.json->pixel-wipe-animation-time->description
 #. 6.2->settings-schema.json->portal-animation-time->description
+#. 6.2->settings-schema.json->rgbwarp-animation-time->description
+#. 6.2->settings-schema.json->team-rocket-animation-time->description
 #. 6.2->settings-schema.json->tv-animation-time->description
 #. 6.2->settings-schema.json->tv-glitch-animation-time->description
 #. 6.2->settings-schema.json->wisps-animation-time->description
 msgid "Effect Duration (milliseconds)"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-random-color->description
+msgid "Random Color"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-start-hue->description
+msgid "Start Hue"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-speed->description
+#. 6.2->settings-schema.json->glitch-speed->description
+#. 6.2->settings-schema.json->tv-glitch-speed->description
+msgid "Speed"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-saturation->description
+msgid "Saturation"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-edge-size->description
+msgid "Edge Size"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-edge-hardness->description
+msgid "Edge Hardness"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-blur->description
+#. 6.2->settings-schema.json->focus-blur-amount->description
+msgid "Blur Amount"
 msgstr ""
 
 #. 6.2->settings-schema.json->doom-horizontal-scale->description
@@ -429,7 +666,7 @@ msgstr ""
 
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
-#. 6.2->settings-schema.json->fire-scale->description
+#. 6.2->settings-schema.json->fire-custom-scale->description
 #. 6.2->settings-schema.json->glide-scale->description
 #. 6.2->settings-schema.json->glitch-scale->description
 #. 6.2->settings-schema.json->hexagon-scale->description
@@ -449,7 +686,16 @@ msgstr ""
 msgid "Color"
 msgstr ""
 
-#. 6.2->settings-schema.json->fire-movement-speed->description
+#. 6.2->settings-schema.json->fire-presets->options
+#. 6.2->settings-schema.json->mushroom-presets->options
+msgid "Custom"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-presets->description
+msgid "Fire preset"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-custom-movement-speed->description
 msgid "Fire Movement Speed"
 msgstr ""
 
@@ -461,31 +707,8 @@ msgstr ""
 msgid "Creates a more dynamic fire but requires more GPU power."
 msgstr ""
 
-#. 6.2->settings-schema.json->fire-color-1->description
-#. 6.2->settings-schema.json->wisps-color-1->description
-msgid "Color #1"
-msgstr ""
-
-#. 6.2->settings-schema.json->fire-color-2->description
-#. 6.2->settings-schema.json->wisps-color-2->description
-msgid "Color #2"
-msgstr ""
-
-#. 6.2->settings-schema.json->fire-color-3->description
-#. 6.2->settings-schema.json->wisps-color-3->description
-msgid "Color #3"
-msgstr ""
-
-#. 6.2->settings-schema.json->fire-color-4->description
-msgid "Color #4"
-msgstr ""
-
-#. 6.2->settings-schema.json->fire-color-5->description
-msgid "Color #5"
-msgstr ""
-
-#. 6.2->settings-schema.json->focus-blur-amount->description
-msgid "Blur Amount"
+#. 6.2->settings-schema.json->fire-colors->description
+msgid "Colors 1-5"
 msgstr ""
 
 #. 6.2->settings-schema.json->focus-blur-quality->description
@@ -513,11 +736,6 @@ msgstr ""
 #. 6.2->settings-schema.json->glitch-strength->description
 #. 6.2->settings-schema.json->tv-glitch-strength->description
 msgid "Strength"
-msgstr ""
-
-#. 6.2->settings-schema.json->glitch-speed->description
-#. 6.2->settings-schema.json->tv-glitch-speed->description
-msgid "Speed"
 msgstr ""
 
 #. 6.2->settings-schema.json->hexagon-line-width->description
@@ -552,6 +770,92 @@ msgstr ""
 msgid "If disabled, a random location will be chosen."
 msgstr ""
 
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "default"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "sine"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "random"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "Minimize: Default - Unminimize: Sine"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "Minimize: Sine - Unminimize: Default"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->description
+msgid "The type of effect"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->tooltip
+msgid ""
+"Using 'default' will result in a curved effect where using 'sine' will "
+"result in a more wavy effect"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-x-tiles->description
+msgid "X Tiles"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-x-tiles->tooltip
+msgid "This effects the quality and the cost of the animation"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-y-tiles->description
+msgid "Y Tiles"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-y-tiles->tooltip
+msgid "This effects the quality and the costs of the animation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->description
+msgid "Mushroom preset"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-scale-style->description
+msgid "Scale Style"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-count->description
+msgid "Spark Count"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-color->description
+msgid "Spark Color"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-rotation->description
+msgid "Spark Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-rays-color->description
+msgid "Rays Color"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-ring-count->description
+msgid "Star Rings Count"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-ring-rotation->description
+msgid "Star Ring Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-star-count->description
+msgid "Stars Count Per Ring"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-star-colors->description
+msgid "Colors 1-6"
+msgstr ""
+
 #. 6.2->settings-schema.json->pixelate-noise->description
 msgid "Noise"
 msgstr ""
@@ -570,4 +874,58 @@ msgstr ""
 
 #. 6.2->settings-schema.json->portal-details->description
 msgid "Details"
+msgstr ""
+
+#. 6.2->settings-schema.json->rgbwarp-brightness->description
+msgid "Brightness"
+msgstr ""
+
+#. 6.2->settings-schema.json->rgbwarp-speed-r->description
+msgid "Red Speed"
+msgstr ""
+
+#. 6.2->settings-schema.json->rgbwarp-speed-g->description
+msgid "Green Speed"
+msgstr ""
+
+#. 6.2->settings-schema.json->rgbwarp-speed-b->description
+msgid "Blue Speed"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-animation-split->description
+msgid "Animation Split"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-horizontal-sparkle-
+#. position->description
+msgid "Horizontal Sparkle Position"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-vertical-sparkle-
+#. position->description
+msgid "Vertical Sparkle Position"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-window-rotation->description
+msgid "Rotate Window"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-sparkle-rot->description
+msgid "Sparkle Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-sparkle-size->description
+msgid "Sparkle Size"
+msgstr ""
+
+#. 6.2->settings-schema.json->wisps-color-1->description
+msgid "Color #1"
+msgstr ""
+
+#. 6.2->settings-schema.json->wisps-color-2->description
+msgid "Color #2"
+msgstr ""
+
+#. 6.2->settings-schema.json->wisps-color-3->description
+msgid "Color #3"
 msgstr ""

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/ca.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 22:59-0500\n"
+"POT-Creation-Date: 2025-03-06 10:34-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,150 +18,186 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.2/extension.js:212 6.2/extension.js:450
+#. 6.2/extension.js:190 6.2/extension.js:266 6.2/extension.js:572
 msgid "Error"
 msgstr "Error"
 
-#. 6.2/extension.js:212
+#. 6.2/extension.js:190
 msgid "was NOT enabled"
 msgstr "no s'ha activat"
 
-#. 6.2/extension.js:213
+#. 6.2/extension.js:191 6.2/extension.js:267
 msgid "The existing extension"
 msgstr "L'extensió existent"
 
-#. 6.2/extension.js:213
+#. 6.2/extension.js:191
 msgid "conflicts with this extension."
 msgstr "conflictivitza amb aquesta extensió."
 
-#. 6.2/extension.js:451
+#. 6.2/extension.js:266
+msgid "minimize/unminimize effects can not be enabled"
+msgstr ""
+
+#. 6.2/extension.js:267
+msgid "already handles minimize/unminimize animation events."
+msgstr ""
+
+#. 6.2/extension.js:573
+#, fuzzy
 msgid ""
-"The previously focused window is not backed by an application and therefore "
-"application specific effects can not be applied to that window"
+"Unable to determine the application or the WM_CLASS of the previously "
+"focused window, therefore application specific effects can not be applied to "
+"that window"
 msgstr ""
 "La finestra enfocada prèviament no pertany a una aplicació, per tant no se "
 "li poden aplicar els efectes específics d'aplicació"
 
-#. 6.2->settings-schema.json->apparition-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Apparition.js:94
 msgid "Apparition"
 msgstr "Aparició"
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/AuraGlow.js:103
+msgid "Aura Glow"
+msgstr ""
 
 #. effects/BrokenGlass.js:152
 msgid "Broken Glass"
 msgstr "Vidre trencat"
 
-#. 6.2->settings-schema.json->doom-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Doom.js:101
 msgid "Doom"
 msgstr "Perdició"
 
-#. 6.2->settings-schema.json->energize-a-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/EnergizeA.js:90
 msgid "Energize A"
 msgstr "Energitzar A"
 
-#. 6.2->settings-schema.json->energize-b-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/EnergizeB.js:92
 msgid "Energize B"
 msgstr "Energitzar B"
 
-#. 6.2->settings-schema.json->fire-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
-#. effects/Fire.js:114
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/Fire.js:122
 msgid "Fire"
 msgstr "Foc"
 
-#. effects/Fire.js:168
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:175
 msgid "Default Fire"
 msgstr "Foc per defecte"
 
-#. effects/Fire.js:178
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:185
 msgid "Hell Fire"
 msgstr "Foc infernal"
 
-#. effects/Fire.js:188
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:195
 msgid "Dark and Smutty"
 msgstr "Fosc i brut"
 
-#. effects/Fire.js:198
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:205
 msgid "Cold Breeze"
 msgstr "Brisa freda"
 
-#. effects/Fire.js:208
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:215
 msgid "Santa is Coming"
 msgstr "Ja arriba el Pare Noel"
 
-#. 6.2->settings-schema.json->focus-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Focus.js:91
 msgid "Focus"
 msgstr "Focus"
 
-#. 6.2->settings-schema.json->glide-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Glide.js:93
 msgid "Glide"
 msgstr "Planeig"
 
-#. 6.2->settings-schema.json->glitch-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Glitch.js:97
 msgid "Glitch"
 msgstr "Glitch"
 
-#. 6.2->settings-schema.json->hexagon-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Hexagon.js:106
 msgid "Hexagon"
 msgstr "Hexàgon"
 
-#. 6.2->settings-schema.json->incinerate-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Incinerate.js:144
 msgid "Incinerate"
 msgstr "Incinerar"
@@ -170,49 +206,115 @@ msgstr "Incinerar"
 msgid "Matrix"
 msgstr "Matrix"
 
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/Mushroom.js:154
+msgid "Mushroom"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:227
+msgid "8Bit Plumber"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:244
+msgid "New Bros 2"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:262
+msgid "The True North"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:280
+msgid "Red White and Blue"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:297
+msgid "Rainbow"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:314
+msgid "Cattuccino"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:332
+msgid "Dracula"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:349
+msgid "Sparkle"
+msgstr ""
+
 #. effects/PaintBrush.js:114
 msgid "Paint Brush"
 msgstr "Pinzell"
 
-#. 6.2->settings-schema.json->pixel-wheel-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/PixelWheel.js:88
 msgid "Pixel Wheel"
 msgstr "Roda de píxels"
 
-#. 6.2->settings-schema.json->pixel-wipe-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/PixelWipe.js:114
 msgid "Pixel Wipe"
 msgstr "Neteja de píxels"
 
-#. 6.2->settings-schema.json->pixelate-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Pixelate.js:88
 msgid "Pixelate"
 msgstr "Pixelat"
 
-#. 6.2->settings-schema.json->portal-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Portal.js:99
 msgid "Portal"
 msgstr "Portal"
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/RGBWarp.js:91
+msgid "RGB Warp"
+msgstr ""
 
 #. effects/SnapOfDisintegration.js:124
 msgid "Snap of Disintegration"
@@ -222,32 +324,46 @@ msgstr "Fase de desintegració"
 msgid "T-Rex Attack"
 msgstr "Atac de T-Rex"
 
-#. 6.2->settings-schema.json->tv-effect-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/TVEffect.js:90
 msgid "TV Effect"
 msgstr "Efecte de TV"
 
-#. 6.2->settings-schema.json->tv-glitch-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/TVGlitch.js:99
 msgid "TV Glitch"
 msgstr "Error de senyal de TV"
 
-#. 6.2->settings-schema.json->wisps-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/TeamRocket.js:103
+msgid "Team Rocket"
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Wisps.js:101
 msgid "Wisps"
 msgstr "Motes"
@@ -257,9 +373,10 @@ msgid "Burn My Windows"
 msgstr "Crema les meves finestres (Burn My Windows)"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Window open/close effects based on the Burn-My-Windows Gnome extension by "
-"Schneegans"
+"Window open/close/minimize/unminimize effects based on the Burn-My-Windows "
+"Gnome extension by Schneegans"
 msgstr ""
 "Efectes d'obertura i tancament de finestres basats en l'extensió de gnome "
 "Burn-My-Windows per Schneegans"
@@ -272,9 +389,18 @@ msgstr "General"
 msgid "Effect Settings"
 msgstr "Configuració d'efectes"
 
+#. 6.2->settings-schema.json->application-page->title
+#, fuzzy
+msgid "Application Specifics"
+msgstr "Regles específiques per aplicació"
+
 #. 6.2->settings-schema.json->random-page->title
 msgid "Random Effects"
 msgstr "Efectes aleatoris"
+
+#. 6.2->settings-schema.json->about-page->title
+msgid "About"
+msgstr ""
 
 #. 6.2->settings-schema.json->general-settings->title
 msgid "Burn My Windows General Settings"
@@ -292,9 +418,30 @@ msgstr "Selector d'efecte"
 msgid "Effect Specific Settings"
 msgstr "Opcions específiques d'efectes"
 
+#. 6.2->settings-schema.json->fire-custom-section->title
+#. 6.2->settings-schema.json->mushroom-custom-section->title
+msgid "Setting for the custom preset:"
+msgstr ""
+
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
 msgstr "Efectes inclosos als conjunts aleatoris:"
+
+#. 6.2->settings-schema.json->about-section->title
+msgid "About Cinnamon Burn-My-Windows"
+msgstr ""
+
+#. 6.2->settings-schema.json->about-text->description
+msgid ""
+"Ported to Cinnamon by Kevin Langman\n"
+"Github: https://github.com/klangman/CinnamonBurnMyWindows\n"
+"\n"
+"Based on the Burn-My-Windows code by Schneegans and contributors\n"
+"Github: https://github.com/Schneegans/Burn-My-Windows\n"
+"\n"
+"The Magic Lamp Effect is ported from code by hermes83\n"
+"GitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->description
 msgid "Application Specific Rules"
@@ -305,12 +452,20 @@ msgid "Enabled"
 msgstr "Activat"
 
 #. 6.2->settings-schema.json->app-rules->columns->title
-msgid "Open Effect"
-msgstr "Efecte d'obertura"
+msgid "Open"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->columns->title
-msgid "Close Effect"
-msgstr "Efecte de tancament"
+msgid "Close"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Minimize"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Unminimize"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->columns->title
 msgid "Application"
@@ -336,9 +491,47 @@ msgstr ""
 "Enfoqueu una finestra per a la qual vulgueu activar un ajust específic per a "
 "l'aplicació, torneu aquí i polseu aquest botó."
 
-#. 6.2->settings-schema.json->random-title->description
-msgid "Effect"
-msgstr "Efecte"
+#. 6.2->settings-schema.json->random-include->description
+#, fuzzy
+msgid "Effects included in the randomized sets"
+msgstr "Efectes inclosos als conjunts aleatoris:"
+
+#. 6.2->settings-schema.json->random-include->tooltip
+msgid ""
+"Defines which effects are included in the randomized sets for each window "
+"event type. When 'Randomized' is selected for any event on the General tab "
+"these sets are used."
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "Effect Name         "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "      Open        "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "      Close       "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "     Minimize     "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "    Unminimize    "
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+msgid "Magic Lamp"
+msgstr ""
 
 #. 6.2->settings-schema.json->effect-selector->description
 msgid "Show settings for effect:"
@@ -348,6 +541,8 @@ msgstr "Mostrar les opcions per efecte:"
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 msgid "Randomized"
 msgstr "Aleatori"
 
@@ -355,6 +550,8 @@ msgstr "Aleatori"
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 msgid "None"
 msgstr "Cap"
 
@@ -388,6 +585,16 @@ msgstr "Efecte d'obertura de finestra de diàleg"
 msgid "Close dialog window effect"
 msgstr "Efecte de tancament de finestra de diàleg"
 
+#. 6.2->settings-schema.json->minimize-effect->description
+#, fuzzy
+msgid "Minimize window effect"
+msgstr "Efecte d'obertura de finestra"
+
+#. 6.2->settings-schema.json->unminimize-effect->description
+#, fuzzy
+msgid "Unminimize window effect"
+msgstr "Efecte d'obertura de finestra"
+
 #. 6.2->settings-schema.json->apparition-shake-intensity->description
 msgid "Shake Intensity"
 msgstr "Intensitat de la vibració"
@@ -405,6 +612,7 @@ msgid "Randomness"
 msgstr "Aleatorietat"
 
 #. 6.2->settings-schema.json->apparition-animation-time->description
+#. 6.2->settings-schema.json->aura-glow-animation-time->description
 #. 6.2->settings-schema.json->doom-animation-time->description
 #. 6.2->settings-schema.json->energize-a-animation-time->description
 #. 6.2->settings-schema.json->energize-b-animation-time->description
@@ -414,15 +622,53 @@ msgstr "Aleatorietat"
 #. 6.2->settings-schema.json->glitch-animation-time->description
 #. 6.2->settings-schema.json->hexagon-animation-time->description
 #. 6.2->settings-schema.json->incinerate-animation-time->description
+#. 6.2->settings-schema.json->magiclamp-animation-time->description
+#. 6.2->settings-schema.json->mushroom-animation-time->description
 #. 6.2->settings-schema.json->pixelate-animation-time->description
 #. 6.2->settings-schema.json->pixel-wheel-animation-time->description
 #. 6.2->settings-schema.json->pixel-wipe-animation-time->description
 #. 6.2->settings-schema.json->portal-animation-time->description
+#. 6.2->settings-schema.json->rgbwarp-animation-time->description
+#. 6.2->settings-schema.json->team-rocket-animation-time->description
 #. 6.2->settings-schema.json->tv-animation-time->description
 #. 6.2->settings-schema.json->tv-glitch-animation-time->description
 #. 6.2->settings-schema.json->wisps-animation-time->description
 msgid "Effect Duration (milliseconds)"
 msgstr "Duració de l'efecte (mil·lisegons)"
+
+#. 6.2->settings-schema.json->aura-glow-random-color->description
+#, fuzzy
+msgid "Random Color"
+msgstr "Color de la línia"
+
+#. 6.2->settings-schema.json->aura-glow-start-hue->description
+msgid "Start Hue"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-speed->description
+#. 6.2->settings-schema.json->glitch-speed->description
+#. 6.2->settings-schema.json->tv-glitch-speed->description
+msgid "Speed"
+msgstr "Velocitat"
+
+#. 6.2->settings-schema.json->aura-glow-saturation->description
+#, fuzzy
+msgid "Saturation"
+msgstr "Aparició"
+
+#. 6.2->settings-schema.json->aura-glow-edge-size->description
+#, fuzzy
+msgid "Edge Size"
+msgstr "Mida del píxel"
+
+#. 6.2->settings-schema.json->aura-glow-edge-hardness->description
+msgid "Edge Hardness"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-blur->description
+#. 6.2->settings-schema.json->focus-blur-amount->description
+msgid "Blur Amount"
+msgstr "Quantitat del desenfocament"
 
 #. 6.2->settings-schema.json->doom-horizontal-scale->description
 msgid "Horizontal Scale"
@@ -441,7 +687,7 @@ msgstr "Mida del píxel"
 
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
-#. 6.2->settings-schema.json->fire-scale->description
+#. 6.2->settings-schema.json->fire-custom-scale->description
 #. 6.2->settings-schema.json->glide-scale->description
 #. 6.2->settings-schema.json->glitch-scale->description
 #. 6.2->settings-schema.json->hexagon-scale->description
@@ -461,7 +707,16 @@ msgstr "Escala"
 msgid "Color"
 msgstr "Color"
 
-#. 6.2->settings-schema.json->fire-movement-speed->description
+#. 6.2->settings-schema.json->fire-presets->options
+#. 6.2->settings-schema.json->mushroom-presets->options
+msgid "Custom"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-presets->description
+msgid "Fire preset"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-custom-movement-speed->description
 msgid "Fire Movement Speed"
 msgstr "Velocitat de moviment del foc"
 
@@ -473,32 +728,10 @@ msgstr "Soroll 3D del foc"
 msgid "Creates a more dynamic fire but requires more GPU power."
 msgstr "Crea un foc més dinàmic a costa de consumir més potència gràfica"
 
-#. 6.2->settings-schema.json->fire-color-1->description
-#. 6.2->settings-schema.json->wisps-color-1->description
-msgid "Color #1"
+#. 6.2->settings-schema.json->fire-colors->description
+#, fuzzy
+msgid "Colors 1-5"
 msgstr "Color #1"
-
-#. 6.2->settings-schema.json->fire-color-2->description
-#. 6.2->settings-schema.json->wisps-color-2->description
-msgid "Color #2"
-msgstr "Color #2"
-
-#. 6.2->settings-schema.json->fire-color-3->description
-#. 6.2->settings-schema.json->wisps-color-3->description
-msgid "Color #3"
-msgstr "Color #3"
-
-#. 6.2->settings-schema.json->fire-color-4->description
-msgid "Color #4"
-msgstr "Color #4"
-
-#. 6.2->settings-schema.json->fire-color-5->description
-msgid "Color #5"
-msgstr "Color #5"
-
-#. 6.2->settings-schema.json->focus-blur-amount->description
-msgid "Blur Amount"
-msgstr "Quantitat del desenfocament"
 
 #. 6.2->settings-schema.json->focus-blur-quality->description
 msgid "Blur Quality"
@@ -528,11 +761,6 @@ msgstr "Canvi"
 #. 6.2->settings-schema.json->tv-glitch-strength->description
 msgid "Strength"
 msgstr "Força"
-
-#. 6.2->settings-schema.json->glitch-speed->description
-#. 6.2->settings-schema.json->tv-glitch-speed->description
-msgid "Speed"
-msgstr "Velocitat"
 
 #. 6.2->settings-schema.json->hexagon-line-width->description
 msgid "Mesh Line Width"
@@ -566,6 +794,101 @@ msgstr "Començar al cursor"
 msgid "If disabled, a random location will be chosen."
 msgstr "Si es desactiva, es triarà una ubicació aleatòria."
 
+#. 6.2->settings-schema.json->magiclamp-effect->options
+#, fuzzy
+msgid "default"
+msgstr "Foc per defecte"
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "sine"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+#, fuzzy
+msgid "random"
+msgstr "Aleatori"
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "Minimize: Default - Unminimize: Sine"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "Minimize: Sine - Unminimize: Default"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->description
+#, fuzzy
+msgid "The type of effect"
+msgstr "Efecte d'obertura de finestra"
+
+#. 6.2->settings-schema.json->magiclamp-effect->tooltip
+msgid ""
+"Using 'default' will result in a curved effect where using 'sine' will "
+"result in a more wavy effect"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-x-tiles->description
+msgid "X Tiles"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-x-tiles->tooltip
+msgid "This effects the quality and the cost of the animation"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-y-tiles->description
+msgid "Y Tiles"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-y-tiles->tooltip
+msgid "This effects the quality and the costs of the animation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->description
+msgid "Mushroom preset"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-scale-style->description
+#, fuzzy
+msgid "Scale Style"
+msgstr "Escala"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-count->description
+#, fuzzy
+msgid "Spark Count"
+msgstr "Número de radis"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-color->description
+#, fuzzy
+msgid "Spark Color"
+msgstr "Color"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-rotation->description
+msgid "Spark Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-rays-color->description
+#, fuzzy
+msgid "Rays Color"
+msgstr "Color"
+
+#. 6.2->settings-schema.json->mushroom-custom-ring-count->description
+#, fuzzy
+msgid "Star Rings Count"
+msgstr "Ja arriba el Pare Noel"
+
+#. 6.2->settings-schema.json->mushroom-custom-ring-rotation->description
+msgid "Star Ring Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-star-count->description
+msgid "Stars Count Per Ring"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-star-colors->description
+#, fuzzy
+msgid "Colors 1-6"
+msgstr "Color #1"
+
 #. 6.2->settings-schema.json->pixelate-noise->description
 msgid "Noise"
 msgstr "Soroll"
@@ -585,3 +908,62 @@ msgstr "Remolí"
 #. 6.2->settings-schema.json->portal-details->description
 msgid "Details"
 msgstr "Detalls"
+
+#. 6.2->settings-schema.json->rgbwarp-brightness->description
+msgid "Brightness"
+msgstr ""
+
+#. 6.2->settings-schema.json->rgbwarp-speed-r->description
+#, fuzzy
+msgid "Red Speed"
+msgstr "Velocitat"
+
+#. 6.2->settings-schema.json->rgbwarp-speed-g->description
+#, fuzzy
+msgid "Green Speed"
+msgstr "Velocitat de moviment del foc"
+
+#. 6.2->settings-schema.json->rgbwarp-speed-b->description
+#, fuzzy
+msgid "Blue Speed"
+msgstr "Velocitat"
+
+#. 6.2->settings-schema.json->team-rocket-animation-split->description
+msgid "Animation Split"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-horizontal-sparkle-
+#. position->description
+#, fuzzy
+msgid "Horizontal Sparkle Position"
+msgstr "Escala horitzontal"
+
+#. 6.2->settings-schema.json->team-rocket-vertical-sparkle-
+#. position->description
+#, fuzzy
+msgid "Vertical Sparkle Position"
+msgstr "Escala vertical"
+
+#. 6.2->settings-schema.json->team-rocket-window-rotation->description
+msgid "Rotate Window"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-sparkle-rot->description
+msgid "Sparkle Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-sparkle-size->description
+msgid "Sparkle Size"
+msgstr ""
+
+#. 6.2->settings-schema.json->wisps-color-1->description
+msgid "Color #1"
+msgstr "Color #1"
+
+#. 6.2->settings-schema.json->wisps-color-2->description
+msgid "Color #2"
+msgstr "Color #2"
+
+#. 6.2->settings-schema.json->wisps-color-3->description
+msgid "Color #3"
+msgstr "Color #3"

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/es.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 22:59-0500\n"
+"POT-Creation-Date: 2025-03-06 10:34-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,151 +17,187 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. 6.2/extension.js:212 6.2/extension.js:450
+#. 6.2/extension.js:190 6.2/extension.js:266 6.2/extension.js:572
 msgid "Error"
 msgstr "Error"
 
-#. 6.2/extension.js:212
+#. 6.2/extension.js:190
 msgid "was NOT enabled"
 msgstr "no estaba habilitado"
 
-#. 6.2/extension.js:213
+#. 6.2/extension.js:191 6.2/extension.js:267
 msgid "The existing extension"
 msgstr "La extensión existente"
 
-#. 6.2/extension.js:213
+#. 6.2/extension.js:191
 msgid "conflicts with this extension."
 msgstr "entra en conflicto con esta extensión."
 
-#. 6.2/extension.js:451
+#. 6.2/extension.js:266
+msgid "minimize/unminimize effects can not be enabled"
+msgstr ""
+
+#. 6.2/extension.js:267
+msgid "already handles minimize/unminimize animation events."
+msgstr ""
+
+#. 6.2/extension.js:573
+#, fuzzy
 msgid ""
-"The previously focused window is not backed by an application and therefore "
-"application specific effects can not be applied to that window"
+"Unable to determine the application or the WM_CLASS of the previously "
+"focused window, therefore application specific effects can not be applied to "
+"that window"
 msgstr ""
 "La ventana enfocada anteriormente no está respaldada por una aplicación y, "
 "por lo tanto, no se pueden aplicar efectos específicos de la aplicación a "
 "esa ventana"
 
-#. 6.2->settings-schema.json->apparition-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Apparition.js:94
 msgid "Apparition"
 msgstr "Aparición"
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/AuraGlow.js:103
+msgid "Aura Glow"
+msgstr ""
 
 #. effects/BrokenGlass.js:152
 msgid "Broken Glass"
 msgstr "Vidrio roto"
 
-#. 6.2->settings-schema.json->doom-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Doom.js:101
 msgid "Doom"
 msgstr "Perdición"
 
-#. 6.2->settings-schema.json->energize-a-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/EnergizeA.js:90
 msgid "Energize A"
 msgstr "Energizar A"
 
-#. 6.2->settings-schema.json->energize-b-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/EnergizeB.js:92
 msgid "Energize B"
 msgstr "Energizar B"
 
-#. 6.2->settings-schema.json->fire-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
-#. effects/Fire.js:114
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/Fire.js:122
 msgid "Fire"
 msgstr "Fuego"
 
-#. effects/Fire.js:168
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:175
 msgid "Default Fire"
 msgstr "Fuego predeterminado"
 
-#. effects/Fire.js:178
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:185
 msgid "Hell Fire"
 msgstr "Fuego infernal"
 
-#. effects/Fire.js:188
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:195
 msgid "Dark and Smutty"
 msgstr "Oscuro y sucio"
 
-#. effects/Fire.js:198
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:205
 msgid "Cold Breeze"
 msgstr "Brisa fría"
 
-#. effects/Fire.js:208
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:215
 msgid "Santa is Coming"
 msgstr "Papá Noel ya viene"
 
-#. 6.2->settings-schema.json->focus-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Focus.js:91
 msgid "Focus"
 msgstr "Enfoque"
 
-#. 6.2->settings-schema.json->glide-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Glide.js:93
 msgid "Glide"
 msgstr "Planeo"
 
-#. 6.2->settings-schema.json->glitch-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Glitch.js:97
 msgid "Glitch"
 msgstr "Glitch"
 
-#. 6.2->settings-schema.json->hexagon-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Hexagon.js:106
 msgid "Hexagon"
 msgstr "Hexágono"
 
-#. 6.2->settings-schema.json->incinerate-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Incinerate.js:144
 msgid "Incinerate"
 msgstr "Incinerar"
@@ -170,49 +206,115 @@ msgstr "Incinerar"
 msgid "Matrix"
 msgstr "Matrix"
 
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/Mushroom.js:154
+msgid "Mushroom"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:227
+msgid "8Bit Plumber"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:244
+msgid "New Bros 2"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:262
+msgid "The True North"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:280
+msgid "Red White and Blue"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:297
+msgid "Rainbow"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:314
+msgid "Cattuccino"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:332
+msgid "Dracula"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:349
+msgid "Sparkle"
+msgstr ""
+
 #. effects/PaintBrush.js:114
 msgid "Paint Brush"
 msgstr "Pincel"
 
-#. 6.2->settings-schema.json->pixel-wheel-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/PixelWheel.js:88
 msgid "Pixel Wheel"
 msgstr "Rueda de píxeles"
 
-#. 6.2->settings-schema.json->pixel-wipe-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/PixelWipe.js:114
 msgid "Pixel Wipe"
 msgstr "Limpieza de píxeles"
 
-#. 6.2->settings-schema.json->pixelate-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Pixelate.js:88
 msgid "Pixelate"
 msgstr "Pixelado"
 
-#. 6.2->settings-schema.json->portal-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Portal.js:99
 msgid "Portal"
 msgstr "Portal"
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/RGBWarp.js:91
+msgid "RGB Warp"
+msgstr ""
 
 #. effects/SnapOfDisintegration.js:124
 msgid "Snap of Disintegration"
@@ -222,32 +324,46 @@ msgstr "Chasquido de desintegración"
 msgid "T-Rex Attack"
 msgstr "Ataque del T-Rex"
 
-#. 6.2->settings-schema.json->tv-effect-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/TVEffect.js:90
 msgid "TV Effect"
 msgstr "Efecto de TV"
 
-#. 6.2->settings-schema.json->tv-glitch-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/TVGlitch.js:99
 msgid "TV Glitch"
 msgstr "Fallo de TV"
 
-#. 6.2->settings-schema.json->wisps-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/TeamRocket.js:103
+msgid "Team Rocket"
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Wisps.js:101
 msgid "Wisps"
 msgstr "Motas"
@@ -257,9 +373,10 @@ msgid "Burn My Windows"
 msgstr "Burn My Windows"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Window open/close effects based on the Burn-My-Windows Gnome extension by "
-"Schneegans"
+"Window open/close/minimize/unminimize effects based on the Burn-My-Windows "
+"Gnome extension by Schneegans"
 msgstr ""
 "Efectos de apertura y cierre de ventanas basados en la extensión Burn-My-"
 "Windows Gnome de Schneegans"
@@ -272,9 +389,18 @@ msgstr "General"
 msgid "Effect Settings"
 msgstr "Ajustes de efectos"
 
+#. 6.2->settings-schema.json->application-page->title
+#, fuzzy
+msgid "Application Specifics"
+msgstr "Reglas específicas de la aplicación"
+
 #. 6.2->settings-schema.json->random-page->title
 msgid "Random Effects"
 msgstr "Efectos aleatorios"
+
+#. 6.2->settings-schema.json->about-page->title
+msgid "About"
+msgstr ""
 
 #. 6.2->settings-schema.json->general-settings->title
 msgid "Burn My Windows General Settings"
@@ -292,9 +418,30 @@ msgstr "Selector de efecto"
 msgid "Effect Specific Settings"
 msgstr "Ajustes específicos del efecto"
 
+#. 6.2->settings-schema.json->fire-custom-section->title
+#. 6.2->settings-schema.json->mushroom-custom-section->title
+msgid "Setting for the custom preset:"
+msgstr ""
+
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
 msgstr "Efectos incluidos en las series aleatorias:"
+
+#. 6.2->settings-schema.json->about-section->title
+msgid "About Cinnamon Burn-My-Windows"
+msgstr ""
+
+#. 6.2->settings-schema.json->about-text->description
+msgid ""
+"Ported to Cinnamon by Kevin Langman\n"
+"Github: https://github.com/klangman/CinnamonBurnMyWindows\n"
+"\n"
+"Based on the Burn-My-Windows code by Schneegans and contributors\n"
+"Github: https://github.com/Schneegans/Burn-My-Windows\n"
+"\n"
+"The Magic Lamp Effect is ported from code by hermes83\n"
+"GitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->description
 msgid "Application Specific Rules"
@@ -305,12 +452,20 @@ msgid "Enabled"
 msgstr "Habilitado"
 
 #. 6.2->settings-schema.json->app-rules->columns->title
-msgid "Open Effect"
-msgstr "Efecto de apertura"
+msgid "Open"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->columns->title
-msgid "Close Effect"
-msgstr "Efecto de cierre"
+msgid "Close"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Minimize"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Unminimize"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->columns->title
 msgid "Application"
@@ -337,9 +492,47 @@ msgstr ""
 "Enfoque una ventana para la que desee activar un ajuste específico de la "
 "aplicación y, a continuación, vuelva aquí y pulse este botón."
 
-#. 6.2->settings-schema.json->random-title->description
-msgid "Effect"
-msgstr "Efecto"
+#. 6.2->settings-schema.json->random-include->description
+#, fuzzy
+msgid "Effects included in the randomized sets"
+msgstr "Efectos incluidos en las series aleatorias:"
+
+#. 6.2->settings-schema.json->random-include->tooltip
+msgid ""
+"Defines which effects are included in the randomized sets for each window "
+"event type. When 'Randomized' is selected for any event on the General tab "
+"these sets are used."
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "Effect Name         "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "      Open        "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "      Close       "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "     Minimize     "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "    Unminimize    "
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+msgid "Magic Lamp"
+msgstr ""
 
 #. 6.2->settings-schema.json->effect-selector->description
 msgid "Show settings for effect:"
@@ -349,6 +542,8 @@ msgstr "Muestra la configuración del efecto:"
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 msgid "Randomized"
 msgstr "Aleatorio"
 
@@ -356,6 +551,8 @@ msgstr "Aleatorio"
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 msgid "None"
 msgstr "Ninguno"
 
@@ -390,6 +587,16 @@ msgstr "Efecto de apertura"
 msgid "Close dialog window effect"
 msgstr "Efecto de cierre"
 
+#. 6.2->settings-schema.json->minimize-effect->description
+#, fuzzy
+msgid "Minimize window effect"
+msgstr "Efecto para abrir ventana"
+
+#. 6.2->settings-schema.json->unminimize-effect->description
+#, fuzzy
+msgid "Unminimize window effect"
+msgstr "Efecto para abrir ventana"
+
 #. 6.2->settings-schema.json->apparition-shake-intensity->description
 msgid "Shake Intensity"
 msgstr "Intensidad de la sacudida"
@@ -407,6 +614,7 @@ msgid "Randomness"
 msgstr "Aleatoriedad"
 
 #. 6.2->settings-schema.json->apparition-animation-time->description
+#. 6.2->settings-schema.json->aura-glow-animation-time->description
 #. 6.2->settings-schema.json->doom-animation-time->description
 #. 6.2->settings-schema.json->energize-a-animation-time->description
 #. 6.2->settings-schema.json->energize-b-animation-time->description
@@ -416,15 +624,53 @@ msgstr "Aleatoriedad"
 #. 6.2->settings-schema.json->glitch-animation-time->description
 #. 6.2->settings-schema.json->hexagon-animation-time->description
 #. 6.2->settings-schema.json->incinerate-animation-time->description
+#. 6.2->settings-schema.json->magiclamp-animation-time->description
+#. 6.2->settings-schema.json->mushroom-animation-time->description
 #. 6.2->settings-schema.json->pixelate-animation-time->description
 #. 6.2->settings-schema.json->pixel-wheel-animation-time->description
 #. 6.2->settings-schema.json->pixel-wipe-animation-time->description
 #. 6.2->settings-schema.json->portal-animation-time->description
+#. 6.2->settings-schema.json->rgbwarp-animation-time->description
+#. 6.2->settings-schema.json->team-rocket-animation-time->description
 #. 6.2->settings-schema.json->tv-animation-time->description
 #. 6.2->settings-schema.json->tv-glitch-animation-time->description
 #. 6.2->settings-schema.json->wisps-animation-time->description
 msgid "Effect Duration (milliseconds)"
 msgstr "Duración del efecto (milisegundos)"
+
+#. 6.2->settings-schema.json->aura-glow-random-color->description
+#, fuzzy
+msgid "Random Color"
+msgstr "Color de línea"
+
+#. 6.2->settings-schema.json->aura-glow-start-hue->description
+msgid "Start Hue"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-speed->description
+#. 6.2->settings-schema.json->glitch-speed->description
+#. 6.2->settings-schema.json->tv-glitch-speed->description
+msgid "Speed"
+msgstr "Velocidad"
+
+#. 6.2->settings-schema.json->aura-glow-saturation->description
+#, fuzzy
+msgid "Saturation"
+msgstr "Aparición"
+
+#. 6.2->settings-schema.json->aura-glow-edge-size->description
+#, fuzzy
+msgid "Edge Size"
+msgstr "Tamaño de píxel"
+
+#. 6.2->settings-schema.json->aura-glow-edge-hardness->description
+msgid "Edge Hardness"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-blur->description
+#. 6.2->settings-schema.json->focus-blur-amount->description
+msgid "Blur Amount"
+msgstr "Cantidad de desenfoque"
 
 #. 6.2->settings-schema.json->doom-horizontal-scale->description
 msgid "Horizontal Scale"
@@ -443,7 +689,7 @@ msgstr "Tamaño de píxel"
 
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
-#. 6.2->settings-schema.json->fire-scale->description
+#. 6.2->settings-schema.json->fire-custom-scale->description
 #. 6.2->settings-schema.json->glide-scale->description
 #. 6.2->settings-schema.json->glitch-scale->description
 #. 6.2->settings-schema.json->hexagon-scale->description
@@ -463,7 +709,16 @@ msgstr "Escala"
 msgid "Color"
 msgstr "Color"
 
-#. 6.2->settings-schema.json->fire-movement-speed->description
+#. 6.2->settings-schema.json->fire-presets->options
+#. 6.2->settings-schema.json->mushroom-presets->options
+msgid "Custom"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-presets->description
+msgid "Fire preset"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-custom-movement-speed->description
 msgid "Fire Movement Speed"
 msgstr "Velocidad de movimiento del fuego"
 
@@ -475,32 +730,10 @@ msgstr "Ruido 3D del fuego"
 msgid "Creates a more dynamic fire but requires more GPU power."
 msgstr "Crea un fuego más dinámico pero requiere más potencia de GPU."
 
-#. 6.2->settings-schema.json->fire-color-1->description
-#. 6.2->settings-schema.json->wisps-color-1->description
-msgid "Color #1"
+#. 6.2->settings-schema.json->fire-colors->description
+#, fuzzy
+msgid "Colors 1-5"
 msgstr "Color #1"
-
-#. 6.2->settings-schema.json->fire-color-2->description
-#. 6.2->settings-schema.json->wisps-color-2->description
-msgid "Color #2"
-msgstr "Color #2"
-
-#. 6.2->settings-schema.json->fire-color-3->description
-#. 6.2->settings-schema.json->wisps-color-3->description
-msgid "Color #3"
-msgstr "Color #3"
-
-#. 6.2->settings-schema.json->fire-color-4->description
-msgid "Color #4"
-msgstr "Color #4"
-
-#. 6.2->settings-schema.json->fire-color-5->description
-msgid "Color #5"
-msgstr "Color #5"
-
-#. 6.2->settings-schema.json->focus-blur-amount->description
-msgid "Blur Amount"
-msgstr "Cantidad de desenfoque"
 
 #. 6.2->settings-schema.json->focus-blur-quality->description
 msgid "Blur Quality"
@@ -530,11 +763,6 @@ msgstr "Cambio"
 #. 6.2->settings-schema.json->tv-glitch-strength->description
 msgid "Strength"
 msgstr "Fuerza"
-
-#. 6.2->settings-schema.json->glitch-speed->description
-#. 6.2->settings-schema.json->tv-glitch-speed->description
-msgid "Speed"
-msgstr "Velocidad"
 
 #. 6.2->settings-schema.json->hexagon-line-width->description
 msgid "Mesh Line Width"
@@ -569,6 +797,101 @@ msgstr "Inicio en el puntero"
 msgid "If disabled, a random location will be chosen."
 msgstr "Si se desactiva, se elegirá una ubicación aleatoria."
 
+#. 6.2->settings-schema.json->magiclamp-effect->options
+#, fuzzy
+msgid "default"
+msgstr "Fuego predeterminado"
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "sine"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+#, fuzzy
+msgid "random"
+msgstr "Aleatorio"
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "Minimize: Default - Unminimize: Sine"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "Minimize: Sine - Unminimize: Default"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->description
+#, fuzzy
+msgid "The type of effect"
+msgstr "Efecto para abrir ventana"
+
+#. 6.2->settings-schema.json->magiclamp-effect->tooltip
+msgid ""
+"Using 'default' will result in a curved effect where using 'sine' will "
+"result in a more wavy effect"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-x-tiles->description
+msgid "X Tiles"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-x-tiles->tooltip
+msgid "This effects the quality and the cost of the animation"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-y-tiles->description
+msgid "Y Tiles"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-y-tiles->tooltip
+msgid "This effects the quality and the costs of the animation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->description
+msgid "Mushroom preset"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-scale-style->description
+#, fuzzy
+msgid "Scale Style"
+msgstr "Escala"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-count->description
+#, fuzzy
+msgid "Spark Count"
+msgstr "Conteo de radios"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-color->description
+#, fuzzy
+msgid "Spark Color"
+msgstr "Color"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-rotation->description
+msgid "Spark Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-rays-color->description
+#, fuzzy
+msgid "Rays Color"
+msgstr "Color"
+
+#. 6.2->settings-schema.json->mushroom-custom-ring-count->description
+#, fuzzy
+msgid "Star Rings Count"
+msgstr "Papá Noel ya viene"
+
+#. 6.2->settings-schema.json->mushroom-custom-ring-rotation->description
+msgid "Star Ring Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-star-count->description
+msgid "Stars Count Per Ring"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-star-colors->description
+#, fuzzy
+msgid "Colors 1-6"
+msgstr "Color #1"
+
 #. 6.2->settings-schema.json->pixelate-noise->description
 msgid "Noise"
 msgstr "Ruido"
@@ -588,3 +911,62 @@ msgstr "Remolino"
 #. 6.2->settings-schema.json->portal-details->description
 msgid "Details"
 msgstr "Detalles"
+
+#. 6.2->settings-schema.json->rgbwarp-brightness->description
+msgid "Brightness"
+msgstr ""
+
+#. 6.2->settings-schema.json->rgbwarp-speed-r->description
+#, fuzzy
+msgid "Red Speed"
+msgstr "Velocidad"
+
+#. 6.2->settings-schema.json->rgbwarp-speed-g->description
+#, fuzzy
+msgid "Green Speed"
+msgstr "Velocidad de movimiento del fuego"
+
+#. 6.2->settings-schema.json->rgbwarp-speed-b->description
+#, fuzzy
+msgid "Blue Speed"
+msgstr "Velocidad"
+
+#. 6.2->settings-schema.json->team-rocket-animation-split->description
+msgid "Animation Split"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-horizontal-sparkle-
+#. position->description
+#, fuzzy
+msgid "Horizontal Sparkle Position"
+msgstr "Escala horizontal"
+
+#. 6.2->settings-schema.json->team-rocket-vertical-sparkle-
+#. position->description
+#, fuzzy
+msgid "Vertical Sparkle Position"
+msgstr "Escala vertical"
+
+#. 6.2->settings-schema.json->team-rocket-window-rotation->description
+msgid "Rotate Window"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-sparkle-rot->description
+msgid "Sparkle Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-sparkle-size->description
+msgid "Sparkle Size"
+msgstr ""
+
+#. 6.2->settings-schema.json->wisps-color-1->description
+msgid "Color #1"
+msgstr "Color #1"
+
+#. 6.2->settings-schema.json->wisps-color-2->description
+msgid "Color #2"
+msgstr "Color #2"
+
+#. 6.2->settings-schema.json->wisps-color-3->description
+msgid "Color #3"
+msgstr "Color #3"

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/fi.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/fi.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 22:59-0500\n"
+"POT-Creation-Date: 2025-03-06 10:34-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -18,150 +18,186 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#. 6.2/extension.js:212 6.2/extension.js:450
+#. 6.2/extension.js:190 6.2/extension.js:266 6.2/extension.js:572
 msgid "Error"
 msgstr "Virhe"
 
-#. 6.2/extension.js:212
+#. 6.2/extension.js:190
 msgid "was NOT enabled"
 msgstr "eI ollut käytössä"
 
-#. 6.2/extension.js:213
+#. 6.2/extension.js:191 6.2/extension.js:267
 msgid "The existing extension"
 msgstr "Nykyinen laajennus"
 
-#. 6.2/extension.js:213
+#. 6.2/extension.js:191
 msgid "conflicts with this extension."
 msgstr "on ristiriidassa tämän laajennuksen kanssa."
 
-#. 6.2/extension.js:451
+#. 6.2/extension.js:266
+msgid "minimize/unminimize effects can not be enabled"
+msgstr ""
+
+#. 6.2/extension.js:267
+msgid "already handles minimize/unminimize animation events."
+msgstr ""
+
+#. 6.2/extension.js:573
+#, fuzzy
 msgid ""
-"The previously focused window is not backed by an application and therefore "
-"application specific effects can not be applied to that window"
+"Unable to determine the application or the WM_CLASS of the previously "
+"focused window, therefore application specific effects can not be applied to "
+"that window"
 msgstr ""
 "Osoitettua ikkunaa ei tueta sovelluksella, joten sovelluskohtaisia ​​"
 "tehosteita ei voi käyttää kyseiseen ikkunaan"
 
-#. 6.2->settings-schema.json->apparition-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Apparition.js:94
 msgid "Apparition"
 msgstr "Ilmestys"
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/AuraGlow.js:103
+msgid "Aura Glow"
+msgstr ""
 
 #. effects/BrokenGlass.js:152
 msgid "Broken Glass"
 msgstr "Särkynyt lasi"
 
-#. 6.2->settings-schema.json->doom-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Doom.js:101
 msgid "Doom"
 msgstr "Tuoho"
 
-#. 6.2->settings-schema.json->energize-a-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/EnergizeA.js:90
 msgid "Energize A"
 msgstr "Energia A"
 
-#. 6.2->settings-schema.json->energize-b-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/EnergizeB.js:92
 msgid "Energize B"
 msgstr "Energia B"
 
-#. 6.2->settings-schema.json->fire-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
-#. effects/Fire.js:114
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/Fire.js:122
 msgid "Fire"
 msgstr "Tuli"
 
-#. effects/Fire.js:168
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:175
 msgid "Default Fire"
 msgstr "Oletus tuli"
 
-#. effects/Fire.js:178
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:185
 msgid "Hell Fire"
 msgstr "Helvetin tuli"
 
-#. effects/Fire.js:188
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:195
 msgid "Dark and Smutty"
 msgstr "Tumma tahra"
 
-#. effects/Fire.js:198
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:205
 msgid "Cold Breeze"
 msgstr "Kylmää tuulta"
 
-#. effects/Fire.js:208
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:215
 msgid "Santa is Coming"
 msgstr "Joulupukki tulee"
 
-#. 6.2->settings-schema.json->focus-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Focus.js:91
 msgid "Focus"
 msgstr "Tarkennus"
 
-#. 6.2->settings-schema.json->glide-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Glide.js:93
 msgid "Glide"
 msgstr "Liuku"
 
-#. 6.2->settings-schema.json->glitch-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Glitch.js:97
 msgid "Glitch"
 msgstr "Häiriö"
 
-#. 6.2->settings-schema.json->hexagon-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Hexagon.js:106
 msgid "Hexagon"
 msgstr "Kuusikulmio"
 
-#. 6.2->settings-schema.json->incinerate-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Incinerate.js:144
 msgid "Incinerate"
 msgstr "Poltto"
@@ -170,49 +206,115 @@ msgstr "Poltto"
 msgid "Matrix"
 msgstr "Matrix"
 
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/Mushroom.js:154
+msgid "Mushroom"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:227
+msgid "8Bit Plumber"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:244
+msgid "New Bros 2"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:262
+msgid "The True North"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:280
+msgid "Red White and Blue"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:297
+msgid "Rainbow"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:314
+msgid "Cattuccino"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:332
+msgid "Dracula"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:349
+msgid "Sparkle"
+msgstr ""
+
 #. effects/PaintBrush.js:114
 msgid "Paint Brush"
 msgstr "Sivellin"
 
-#. 6.2->settings-schema.json->pixel-wheel-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/PixelWheel.js:88
 msgid "Pixel Wheel"
 msgstr "Pikselipyörä"
 
-#. 6.2->settings-schema.json->pixel-wipe-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/PixelWipe.js:114
 msgid "Pixel Wipe"
 msgstr "Pikselipyyhintä"
 
-#. 6.2->settings-schema.json->pixelate-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Pixelate.js:88
 msgid "Pixelate"
 msgstr "Pikselöinti"
 
-#. 6.2->settings-schema.json->portal-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Portal.js:99
 msgid "Portal"
 msgstr "Teleportti"
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/RGBWarp.js:91
+msgid "RGB Warp"
+msgstr ""
 
 #. effects/SnapOfDisintegration.js:124
 msgid "Snap of Disintegration"
@@ -222,32 +324,46 @@ msgstr "Hajoaminen"
 msgid "T-Rex Attack"
 msgstr "T-Rexin hyökkäys"
 
-#. 6.2->settings-schema.json->tv-effect-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/TVEffect.js:90
 msgid "TV Effect"
 msgstr "TV pois"
 
-#. 6.2->settings-schema.json->tv-glitch-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/TVGlitch.js:99
 msgid "TV Glitch"
 msgstr "TV päälle"
 
-#. 6.2->settings-schema.json->wisps-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/TeamRocket.js:103
+msgid "Team Rocket"
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Wisps.js:101
 msgid "Wisps"
 msgstr "Hikkaset"
@@ -257,9 +373,10 @@ msgid "Burn My Windows"
 msgstr "Burn My Windows"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Window open/close effects based on the Burn-My-Windows Gnome extension by "
-"Schneegans"
+"Window open/close/minimize/unminimize effects based on the Burn-My-Windows "
+"Gnome extension by Schneegans"
 msgstr ""
 "Ikkunoiden tehosteet perustuvat Schneegansin Burn-My-Windows Gnome "
 "laajennukseen"
@@ -272,9 +389,18 @@ msgstr "Yleinen"
 msgid "Effect Settings"
 msgstr "Asetukset"
 
+#. 6.2->settings-schema.json->application-page->title
+#, fuzzy
+msgid "Application Specifics"
+msgstr "Sovelluskohtaiset säännöt"
+
 #. 6.2->settings-schema.json->random-page->title
 msgid "Random Effects"
 msgstr "Satunnaisuus"
+
+#. 6.2->settings-schema.json->about-page->title
+msgid "About"
+msgstr ""
 
 #. 6.2->settings-schema.json->general-settings->title
 msgid "Burn My Windows General Settings"
@@ -292,9 +418,30 @@ msgstr "Tehosteen valinta"
 msgid "Effect Specific Settings"
 msgstr "Tehostekohtaiset asetukset"
 
+#. 6.2->settings-schema.json->fire-custom-section->title
+#. 6.2->settings-schema.json->mushroom-custom-section->title
+msgid "Setting for the custom preset:"
+msgstr ""
+
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
 msgstr "Satunnaisiin sisältyvät tehosteet:"
+
+#. 6.2->settings-schema.json->about-section->title
+msgid "About Cinnamon Burn-My-Windows"
+msgstr ""
+
+#. 6.2->settings-schema.json->about-text->description
+msgid ""
+"Ported to Cinnamon by Kevin Langman\n"
+"Github: https://github.com/klangman/CinnamonBurnMyWindows\n"
+"\n"
+"Based on the Burn-My-Windows code by Schneegans and contributors\n"
+"Github: https://github.com/Schneegans/Burn-My-Windows\n"
+"\n"
+"The Magic Lamp Effect is ported from code by hermes83\n"
+"GitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->description
 msgid "Application Specific Rules"
@@ -305,12 +452,20 @@ msgid "Enabled"
 msgstr "Käytössä"
 
 #. 6.2->settings-schema.json->app-rules->columns->title
-msgid "Open Effect"
-msgstr "Avaa tehosteella"
+msgid "Open"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->columns->title
-msgid "Close Effect"
-msgstr "Sulje tehosteella"
+msgid "Close"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Minimize"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Unminimize"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->columns->title
 msgid "Application"
@@ -335,9 +490,47 @@ msgstr ""
 "Osoita ikkuna, johon haluat ottaa sovelluskohtaisen asetuksen käyttöön. "
 "Palaa tähän ja paina tätä painiketta."
 
-#. 6.2->settings-schema.json->random-title->description
-msgid "Effect"
-msgstr "Tehoste"
+#. 6.2->settings-schema.json->random-include->description
+#, fuzzy
+msgid "Effects included in the randomized sets"
+msgstr "Satunnaisiin sisältyvät tehosteet:"
+
+#. 6.2->settings-schema.json->random-include->tooltip
+msgid ""
+"Defines which effects are included in the randomized sets for each window "
+"event type. When 'Randomized' is selected for any event on the General tab "
+"these sets are used."
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "Effect Name         "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "      Open        "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "      Close       "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "     Minimize     "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "    Unminimize    "
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+msgid "Magic Lamp"
+msgstr ""
 
 #. 6.2->settings-schema.json->effect-selector->description
 msgid "Show settings for effect:"
@@ -347,6 +540,8 @@ msgstr "Näytä asetukset tehosteelle:"
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 msgid "Randomized"
 msgstr "Satunnainen"
 
@@ -354,6 +549,8 @@ msgstr "Satunnainen"
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 msgid "None"
 msgstr "Ei mikään"
 
@@ -386,6 +583,16 @@ msgstr "Tehoste Ikkunan avaamiselle"
 msgid "Close dialog window effect"
 msgstr "Tehoste Ikkunan sulkemiselle"
 
+#. 6.2->settings-schema.json->minimize-effect->description
+#, fuzzy
+msgid "Minimize window effect"
+msgstr "Tehoste Ikkunan avaamiselle"
+
+#. 6.2->settings-schema.json->unminimize-effect->description
+#, fuzzy
+msgid "Unminimize window effect"
+msgstr "Tehoste Ikkunan avaamiselle"
+
 #. 6.2->settings-schema.json->apparition-shake-intensity->description
 msgid "Shake Intensity"
 msgstr "Ravistusvoima"
@@ -403,6 +610,7 @@ msgid "Randomness"
 msgstr "Satunnaisuus"
 
 #. 6.2->settings-schema.json->apparition-animation-time->description
+#. 6.2->settings-schema.json->aura-glow-animation-time->description
 #. 6.2->settings-schema.json->doom-animation-time->description
 #. 6.2->settings-schema.json->energize-a-animation-time->description
 #. 6.2->settings-schema.json->energize-b-animation-time->description
@@ -412,15 +620,53 @@ msgstr "Satunnaisuus"
 #. 6.2->settings-schema.json->glitch-animation-time->description
 #. 6.2->settings-schema.json->hexagon-animation-time->description
 #. 6.2->settings-schema.json->incinerate-animation-time->description
+#. 6.2->settings-schema.json->magiclamp-animation-time->description
+#. 6.2->settings-schema.json->mushroom-animation-time->description
 #. 6.2->settings-schema.json->pixelate-animation-time->description
 #. 6.2->settings-schema.json->pixel-wheel-animation-time->description
 #. 6.2->settings-schema.json->pixel-wipe-animation-time->description
 #. 6.2->settings-schema.json->portal-animation-time->description
+#. 6.2->settings-schema.json->rgbwarp-animation-time->description
+#. 6.2->settings-schema.json->team-rocket-animation-time->description
 #. 6.2->settings-schema.json->tv-animation-time->description
 #. 6.2->settings-schema.json->tv-glitch-animation-time->description
 #. 6.2->settings-schema.json->wisps-animation-time->description
 msgid "Effect Duration (milliseconds)"
 msgstr "Tehosteen kesto (ms)"
+
+#. 6.2->settings-schema.json->aura-glow-random-color->description
+#, fuzzy
+msgid "Random Color"
+msgstr "Viivan väri"
+
+#. 6.2->settings-schema.json->aura-glow-start-hue->description
+msgid "Start Hue"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-speed->description
+#. 6.2->settings-schema.json->glitch-speed->description
+#. 6.2->settings-schema.json->tv-glitch-speed->description
+msgid "Speed"
+msgstr "Nopeus"
+
+#. 6.2->settings-schema.json->aura-glow-saturation->description
+#, fuzzy
+msgid "Saturation"
+msgstr "Ilmestys"
+
+#. 6.2->settings-schema.json->aura-glow-edge-size->description
+#, fuzzy
+msgid "Edge Size"
+msgstr "Pikselikoko"
+
+#. 6.2->settings-schema.json->aura-glow-edge-hardness->description
+msgid "Edge Hardness"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-blur->description
+#. 6.2->settings-schema.json->focus-blur-amount->description
+msgid "Blur Amount"
+msgstr "Sumennuksen määrä"
 
 #. 6.2->settings-schema.json->doom-horizontal-scale->description
 msgid "Horizontal Scale"
@@ -439,7 +685,7 @@ msgstr "Pikselikoko"
 
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
-#. 6.2->settings-schema.json->fire-scale->description
+#. 6.2->settings-schema.json->fire-custom-scale->description
 #. 6.2->settings-schema.json->glide-scale->description
 #. 6.2->settings-schema.json->glitch-scale->description
 #. 6.2->settings-schema.json->hexagon-scale->description
@@ -459,7 +705,16 @@ msgstr "Skaalaus"
 msgid "Color"
 msgstr "Väri"
 
-#. 6.2->settings-schema.json->fire-movement-speed->description
+#. 6.2->settings-schema.json->fire-presets->options
+#. 6.2->settings-schema.json->mushroom-presets->options
+msgid "Custom"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-presets->description
+msgid "Fire preset"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-custom-movement-speed->description
 msgid "Fire Movement Speed"
 msgstr ""
 
@@ -471,34 +726,10 @@ msgstr ""
 msgid "Creates a more dynamic fire but requires more GPU power."
 msgstr ""
 
-#. 6.2->settings-schema.json->fire-color-1->description
-#. 6.2->settings-schema.json->wisps-color-1->description
-msgid "Color #1"
-msgstr "Väri #1"
-
-#. 6.2->settings-schema.json->fire-color-2->description
-#. 6.2->settings-schema.json->wisps-color-2->description
-msgid "Color #2"
-msgstr "Väri #2"
-
-#. 6.2->settings-schema.json->fire-color-3->description
-#. 6.2->settings-schema.json->wisps-color-3->description
-msgid "Color #3"
-msgstr "Väri #3"
-
-#. 6.2->settings-schema.json->fire-color-4->description
+#. 6.2->settings-schema.json->fire-colors->description
 #, fuzzy
-msgid "Color #4"
+msgid "Colors 1-5"
 msgstr "Väri #1"
-
-#. 6.2->settings-schema.json->fire-color-5->description
-#, fuzzy
-msgid "Color #5"
-msgstr "Väri #1"
-
-#. 6.2->settings-schema.json->focus-blur-amount->description
-msgid "Blur Amount"
-msgstr "Sumennuksen määrä"
 
 #. 6.2->settings-schema.json->focus-blur-quality->description
 msgid "Blur Quality"
@@ -526,11 +757,6 @@ msgstr "Vaihto"
 #. 6.2->settings-schema.json->tv-glitch-strength->description
 msgid "Strength"
 msgstr "Voima"
-
-#. 6.2->settings-schema.json->glitch-speed->description
-#. 6.2->settings-schema.json->tv-glitch-speed->description
-msgid "Speed"
-msgstr "Nopeus"
 
 #. 6.2->settings-schema.json->hexagon-line-width->description
 msgid "Mesh Line Width"
@@ -564,6 +790,101 @@ msgstr "Alkaa osoittimesta"
 msgid "If disabled, a random location will be chosen."
 msgstr "Jos ei ole käytössä, valitaan satunnainen sijainti."
 
+#. 6.2->settings-schema.json->magiclamp-effect->options
+#, fuzzy
+msgid "default"
+msgstr "Oletus tuli"
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "sine"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+#, fuzzy
+msgid "random"
+msgstr "Satunnainen"
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "Minimize: Default - Unminimize: Sine"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "Minimize: Sine - Unminimize: Default"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->description
+#, fuzzy
+msgid "The type of effect"
+msgstr "Tehoste Ikkunan avaamiselle"
+
+#. 6.2->settings-schema.json->magiclamp-effect->tooltip
+msgid ""
+"Using 'default' will result in a curved effect where using 'sine' will "
+"result in a more wavy effect"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-x-tiles->description
+msgid "X Tiles"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-x-tiles->tooltip
+msgid "This effects the quality and the cost of the animation"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-y-tiles->description
+msgid "Y Tiles"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-y-tiles->tooltip
+msgid "This effects the quality and the costs of the animation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->description
+msgid "Mushroom preset"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-scale-style->description
+#, fuzzy
+msgid "Scale Style"
+msgstr "Skaalaus"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-count->description
+#, fuzzy
+msgid "Spark Count"
+msgstr "Pinnojen määrä"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-color->description
+#, fuzzy
+msgid "Spark Color"
+msgstr "Väri"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-rotation->description
+msgid "Spark Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-rays-color->description
+#, fuzzy
+msgid "Rays Color"
+msgstr "Väri"
+
+#. 6.2->settings-schema.json->mushroom-custom-ring-count->description
+#, fuzzy
+msgid "Star Rings Count"
+msgstr "Joulupukki tulee"
+
+#. 6.2->settings-schema.json->mushroom-custom-ring-rotation->description
+msgid "Star Ring Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-star-count->description
+msgid "Stars Count Per Ring"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-star-colors->description
+#, fuzzy
+msgid "Colors 1-6"
+msgstr "Väri #1"
+
 #. 6.2->settings-schema.json->pixelate-noise->description
 msgid "Noise"
 msgstr "Kohina"
@@ -583,3 +904,62 @@ msgstr "Pyörivä"
 #. 6.2->settings-schema.json->portal-details->description
 msgid "Details"
 msgstr "Tiedot"
+
+#. 6.2->settings-schema.json->rgbwarp-brightness->description
+msgid "Brightness"
+msgstr ""
+
+#. 6.2->settings-schema.json->rgbwarp-speed-r->description
+#, fuzzy
+msgid "Red Speed"
+msgstr "Nopeus"
+
+#. 6.2->settings-schema.json->rgbwarp-speed-g->description
+#, fuzzy
+msgid "Green Speed"
+msgstr "Nopeus"
+
+#. 6.2->settings-schema.json->rgbwarp-speed-b->description
+#, fuzzy
+msgid "Blue Speed"
+msgstr "Nopeus"
+
+#. 6.2->settings-schema.json->team-rocket-animation-split->description
+msgid "Animation Split"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-horizontal-sparkle-
+#. position->description
+#, fuzzy
+msgid "Horizontal Sparkle Position"
+msgstr "Vaakasuora skaalaus"
+
+#. 6.2->settings-schema.json->team-rocket-vertical-sparkle-
+#. position->description
+#, fuzzy
+msgid "Vertical Sparkle Position"
+msgstr "Pystysuora skaalaus"
+
+#. 6.2->settings-schema.json->team-rocket-window-rotation->description
+msgid "Rotate Window"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-sparkle-rot->description
+msgid "Sparkle Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-sparkle-size->description
+msgid "Sparkle Size"
+msgstr ""
+
+#. 6.2->settings-schema.json->wisps-color-1->description
+msgid "Color #1"
+msgstr "Väri #1"
+
+#. 6.2->settings-schema.json->wisps-color-2->description
+msgid "Color #2"
+msgstr "Väri #2"
+
+#. 6.2->settings-schema.json->wisps-color-3->description
+msgid "Color #3"
+msgstr "Väri #3"

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/fr.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 22:59-0500\n"
+"POT-Creation-Date: 2025-03-06 10:34-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -18,151 +18,187 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.2/extension.js:212 6.2/extension.js:450
+#. 6.2/extension.js:190 6.2/extension.js:266 6.2/extension.js:572
 msgid "Error"
 msgstr "Erreur"
 
-#. 6.2/extension.js:212
+#. 6.2/extension.js:190
 msgid "was NOT enabled"
 msgstr "n'a PAS été activée"
 
-#. 6.2/extension.js:213
+#. 6.2/extension.js:191 6.2/extension.js:267
 msgid "The existing extension"
 msgstr "L'extension existante"
 
-#. 6.2/extension.js:213
+#. 6.2/extension.js:191
 msgid "conflicts with this extension."
 msgstr "est en conflit avec cette extension."
 
-#. 6.2/extension.js:451
+#. 6.2/extension.js:266
+msgid "minimize/unminimize effects can not be enabled"
+msgstr ""
+
+#. 6.2/extension.js:267
+msgid "already handles minimize/unminimize animation events."
+msgstr ""
+
+#. 6.2/extension.js:573
+#, fuzzy
 msgid ""
-"The previously focused window is not backed by an application and therefore "
-"application specific effects can not be applied to that window"
+"Unable to determine the application or the WM_CLASS of the previously "
+"focused window, therefore application specific effects can not be applied to "
+"that window"
 msgstr ""
 "La fenêtre précédemment sélectionnée n'est pas liée à une application et, "
 "par conséquent, les effets spécifiques à l'application ne peuvent pas être "
 "appliqués à cette fenêtre"
 
-#. 6.2->settings-schema.json->apparition-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Apparition.js:94
 msgid "Apparition"
 msgstr "Apparition"
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/AuraGlow.js:103
+msgid "Aura Glow"
+msgstr ""
 
 #. effects/BrokenGlass.js:152
 msgid "Broken Glass"
 msgstr "Broken Glass (Verre brisé)"
 
-#. 6.2->settings-schema.json->doom-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Doom.js:101
 msgid "Doom"
 msgstr "Doom (Cascade)"
 
-#. 6.2->settings-schema.json->energize-a-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/EnergizeA.js:90
 msgid "Energize A"
 msgstr "Energize A (Énergie A)"
 
-#. 6.2->settings-schema.json->energize-b-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/EnergizeB.js:92
 msgid "Energize B"
 msgstr "Energize B (Énergie B)"
 
-#. 6.2->settings-schema.json->fire-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
-#. effects/Fire.js:114
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/Fire.js:122
 msgid "Fire"
 msgstr "Fire (Feu)"
 
-#. effects/Fire.js:168
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:175
 msgid "Default Fire"
 msgstr "Default Fire (Feu par défaut)"
 
-#. effects/Fire.js:178
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:185
 msgid "Hell Fire"
 msgstr "Hell Fire (Feu d'Enfer)"
 
-#. effects/Fire.js:188
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:195
 msgid "Dark and Smutty"
 msgstr "Dark and Smutty (Sombre et coquin)"
 
-#. effects/Fire.js:198
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:205
 msgid "Cold Breeze"
 msgstr "Cold Breeze (Brise fraîche)"
 
-#. effects/Fire.js:208
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:215
 msgid "Santa is Coming"
 msgstr "Santa is Coming (Le Père Noël arrive)"
 
-#. 6.2->settings-schema.json->focus-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Focus.js:91
 msgid "Focus"
 msgstr "Focus"
 
-#. 6.2->settings-schema.json->glide-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Glide.js:93
 msgid "Glide"
 msgstr "Glide (Glissement)"
 
-#. 6.2->settings-schema.json->glitch-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Glitch.js:97
 msgid "Glitch"
 msgstr "Glitch (Déhanchement)"
 
-#. 6.2->settings-schema.json->hexagon-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Hexagon.js:106
 msgid "Hexagon"
 msgstr "Hexagon (Hexagone)"
 
-#. 6.2->settings-schema.json->incinerate-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Incinerate.js:144
 msgid "Incinerate"
 msgstr "Incinerate (Incinération)"
@@ -171,49 +207,115 @@ msgstr "Incinerate (Incinération)"
 msgid "Matrix"
 msgstr "Matrix (Matrice)"
 
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/Mushroom.js:154
+msgid "Mushroom"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:227
+msgid "8Bit Plumber"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:244
+msgid "New Bros 2"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:262
+msgid "The True North"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:280
+msgid "Red White and Blue"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:297
+msgid "Rainbow"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:314
+msgid "Cattuccino"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:332
+msgid "Dracula"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:349
+msgid "Sparkle"
+msgstr ""
+
 #. effects/PaintBrush.js:114
 msgid "Paint Brush"
 msgstr "Brosse à peindre"
 
-#. 6.2->settings-schema.json->pixel-wheel-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/PixelWheel.js:88
 msgid "Pixel Wheel"
 msgstr "Pixel Wheel (Roue de pixels)"
 
-#. 6.2->settings-schema.json->pixel-wipe-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/PixelWipe.js:114
 msgid "Pixel Wipe"
 msgstr "Pixel Wipe (Pixel par pixel)"
 
-#. 6.2->settings-schema.json->pixelate-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Pixelate.js:88
 msgid "Pixelate"
 msgstr "Pixelate (Pixellisation)"
 
-#. 6.2->settings-schema.json->portal-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Portal.js:99
 msgid "Portal"
 msgstr "Portal (Portail magique)"
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/RGBWarp.js:91
+msgid "RGB Warp"
+msgstr ""
 
 #. effects/SnapOfDisintegration.js:124
 msgid "Snap of Disintegration"
@@ -223,32 +325,46 @@ msgstr "Vitesse de désintégration"
 msgid "T-Rex Attack"
 msgstr "T-Rex Attack (Attaque de T-Rex)"
 
-#. 6.2->settings-schema.json->tv-effect-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/TVEffect.js:90
 msgid "TV Effect"
 msgstr "TV Effect (Allumage de TV)"
 
-#. 6.2->settings-schema.json->tv-glitch-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/TVGlitch.js:99
 msgid "TV Glitch"
 msgstr "TV Glitch (Arrêt de TV)"
 
-#. 6.2->settings-schema.json->wisps-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/TeamRocket.js:103
+msgid "Team Rocket"
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Wisps.js:101
 msgid "Wisps"
 msgstr "Wisps (Sillages de bulles)"
@@ -258,9 +374,10 @@ msgid "Burn My Windows"
 msgstr "Brûle mes fenêtres"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Window open/close effects based on the Burn-My-Windows Gnome extension by "
-"Schneegans"
+"Window open/close/minimize/unminimize effects based on the Burn-My-Windows "
+"Gnome extension by Schneegans"
 msgstr ""
 "Effets d'ouverture/fermeture de fenêtres basés sur l'extension Gnome Burn-My-"
 "Windows de Schneegans"
@@ -273,9 +390,18 @@ msgstr "Général"
 msgid "Effect Settings"
 msgstr "Paramétrage des effets"
 
+#. 6.2->settings-schema.json->application-page->title
+#, fuzzy
+msgid "Application Specifics"
+msgstr "Règles propres à l'application"
+
 #. 6.2->settings-schema.json->random-page->title
 msgid "Random Effects"
 msgstr "Effets aléatoires"
+
+#. 6.2->settings-schema.json->about-page->title
+msgid "About"
+msgstr ""
 
 #. 6.2->settings-schema.json->general-settings->title
 msgid "Burn My Windows General Settings"
@@ -293,9 +419,30 @@ msgstr "Sélecteur d'effet"
 msgid "Effect Specific Settings"
 msgstr "Paramètres propres à l'effet"
 
+#. 6.2->settings-schema.json->fire-custom-section->title
+#. 6.2->settings-schema.json->mushroom-custom-section->title
+msgid "Setting for the custom preset:"
+msgstr ""
+
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
 msgstr "Effets compris dans les effets aléatoires :"
+
+#. 6.2->settings-schema.json->about-section->title
+msgid "About Cinnamon Burn-My-Windows"
+msgstr ""
+
+#. 6.2->settings-schema.json->about-text->description
+msgid ""
+"Ported to Cinnamon by Kevin Langman\n"
+"Github: https://github.com/klangman/CinnamonBurnMyWindows\n"
+"\n"
+"Based on the Burn-My-Windows code by Schneegans and contributors\n"
+"Github: https://github.com/Schneegans/Burn-My-Windows\n"
+"\n"
+"The Magic Lamp Effect is ported from code by hermes83\n"
+"GitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->description
 msgid "Application Specific Rules"
@@ -306,12 +453,20 @@ msgid "Enabled"
 msgstr "Activé"
 
 #. 6.2->settings-schema.json->app-rules->columns->title
-msgid "Open Effect"
-msgstr "Ouverture"
+msgid "Open"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->columns->title
-msgid "Close Effect"
-msgstr "Fermeture"
+msgid "Close"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Minimize"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Unminimize"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->columns->title
 msgid "Application"
@@ -339,9 +494,47 @@ msgstr ""
 "Sélectionnez une fenêtre pour laquelle vous souhaitez activer un paramètre "
 "spécifique à l'application, puis revenez ici et appuyez sur ce bouton."
 
-#. 6.2->settings-schema.json->random-title->description
-msgid "Effect"
-msgstr "Effet"
+#. 6.2->settings-schema.json->random-include->description
+#, fuzzy
+msgid "Effects included in the randomized sets"
+msgstr "Effets compris dans les effets aléatoires :"
+
+#. 6.2->settings-schema.json->random-include->tooltip
+msgid ""
+"Defines which effects are included in the randomized sets for each window "
+"event type. When 'Randomized' is selected for any event on the General tab "
+"these sets are used."
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "Effect Name         "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "      Open        "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "      Close       "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "     Minimize     "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "    Unminimize    "
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+msgid "Magic Lamp"
+msgstr ""
 
 #. 6.2->settings-schema.json->effect-selector->description
 msgid "Show settings for effect:"
@@ -351,6 +544,8 @@ msgstr "Afficher les paramètres de l'effet :"
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 msgid "Randomized"
 msgstr "Aléatoire"
 
@@ -358,6 +553,8 @@ msgstr "Aléatoire"
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 msgid "None"
 msgstr "Aucun"
 
@@ -392,6 +589,16 @@ msgstr "Effet d'ouverture d'une fenêtre de dialogue"
 msgid "Close dialog window effect"
 msgstr "Effet de fermeture d'une fenêtre de dialogue"
 
+#. 6.2->settings-schema.json->minimize-effect->description
+#, fuzzy
+msgid "Minimize window effect"
+msgstr "Effet d'ouverture"
+
+#. 6.2->settings-schema.json->unminimize-effect->description
+#, fuzzy
+msgid "Unminimize window effect"
+msgstr "Effet d'ouverture"
+
 #. 6.2->settings-schema.json->apparition-shake-intensity->description
 msgid "Shake Intensity"
 msgstr "Intensité des secousses"
@@ -409,6 +616,7 @@ msgid "Randomness"
 msgstr "Aléatoire"
 
 #. 6.2->settings-schema.json->apparition-animation-time->description
+#. 6.2->settings-schema.json->aura-glow-animation-time->description
 #. 6.2->settings-schema.json->doom-animation-time->description
 #. 6.2->settings-schema.json->energize-a-animation-time->description
 #. 6.2->settings-schema.json->energize-b-animation-time->description
@@ -418,15 +626,53 @@ msgstr "Aléatoire"
 #. 6.2->settings-schema.json->glitch-animation-time->description
 #. 6.2->settings-schema.json->hexagon-animation-time->description
 #. 6.2->settings-schema.json->incinerate-animation-time->description
+#. 6.2->settings-schema.json->magiclamp-animation-time->description
+#. 6.2->settings-schema.json->mushroom-animation-time->description
 #. 6.2->settings-schema.json->pixelate-animation-time->description
 #. 6.2->settings-schema.json->pixel-wheel-animation-time->description
 #. 6.2->settings-schema.json->pixel-wipe-animation-time->description
 #. 6.2->settings-schema.json->portal-animation-time->description
+#. 6.2->settings-schema.json->rgbwarp-animation-time->description
+#. 6.2->settings-schema.json->team-rocket-animation-time->description
 #. 6.2->settings-schema.json->tv-animation-time->description
 #. 6.2->settings-schema.json->tv-glitch-animation-time->description
 #. 6.2->settings-schema.json->wisps-animation-time->description
 msgid "Effect Duration (milliseconds)"
 msgstr "Durée de l'effet (millisecondes)"
+
+#. 6.2->settings-schema.json->aura-glow-random-color->description
+#, fuzzy
+msgid "Random Color"
+msgstr "Couleur du trait"
+
+#. 6.2->settings-schema.json->aura-glow-start-hue->description
+msgid "Start Hue"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-speed->description
+#. 6.2->settings-schema.json->glitch-speed->description
+#. 6.2->settings-schema.json->tv-glitch-speed->description
+msgid "Speed"
+msgstr "Vitesse"
+
+#. 6.2->settings-schema.json->aura-glow-saturation->description
+#, fuzzy
+msgid "Saturation"
+msgstr "Apparition"
+
+#. 6.2->settings-schema.json->aura-glow-edge-size->description
+#, fuzzy
+msgid "Edge Size"
+msgstr "Taille d'un pixel"
+
+#. 6.2->settings-schema.json->aura-glow-edge-hardness->description
+msgid "Edge Hardness"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-blur->description
+#. 6.2->settings-schema.json->focus-blur-amount->description
+msgid "Blur Amount"
+msgstr "Niveau de flou"
 
 #. 6.2->settings-schema.json->doom-horizontal-scale->description
 msgid "Horizontal Scale"
@@ -445,7 +691,7 @@ msgstr "Taille d'un pixel"
 
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
-#. 6.2->settings-schema.json->fire-scale->description
+#. 6.2->settings-schema.json->fire-custom-scale->description
 #. 6.2->settings-schema.json->glide-scale->description
 #. 6.2->settings-schema.json->glitch-scale->description
 #. 6.2->settings-schema.json->hexagon-scale->description
@@ -465,7 +711,16 @@ msgstr "Échelle"
 msgid "Color"
 msgstr "Couleur"
 
-#. 6.2->settings-schema.json->fire-movement-speed->description
+#. 6.2->settings-schema.json->fire-presets->options
+#. 6.2->settings-schema.json->mushroom-presets->options
+msgid "Custom"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-presets->description
+msgid "Fire preset"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-custom-movement-speed->description
 msgid "Fire Movement Speed"
 msgstr "Vitesse de déplacement du feu"
 
@@ -477,32 +732,10 @@ msgstr "Perturbation 3D du feu"
 msgid "Creates a more dynamic fire but requires more GPU power."
 msgstr "Crée un feu plus dynamique mais nécessite plus de puissance GPU."
 
-#. 6.2->settings-schema.json->fire-color-1->description
-#. 6.2->settings-schema.json->wisps-color-1->description
-msgid "Color #1"
+#. 6.2->settings-schema.json->fire-colors->description
+#, fuzzy
+msgid "Colors 1-5"
 msgstr "Couleur n°1"
-
-#. 6.2->settings-schema.json->fire-color-2->description
-#. 6.2->settings-schema.json->wisps-color-2->description
-msgid "Color #2"
-msgstr "Couleur n°2"
-
-#. 6.2->settings-schema.json->fire-color-3->description
-#. 6.2->settings-schema.json->wisps-color-3->description
-msgid "Color #3"
-msgstr "Couleur n°3"
-
-#. 6.2->settings-schema.json->fire-color-4->description
-msgid "Color #4"
-msgstr "Couleur n°4"
-
-#. 6.2->settings-schema.json->fire-color-5->description
-msgid "Color #5"
-msgstr "Couleur n°5"
-
-#. 6.2->settings-schema.json->focus-blur-amount->description
-msgid "Blur Amount"
-msgstr "Niveau de flou"
 
 #. 6.2->settings-schema.json->focus-blur-quality->description
 msgid "Blur Quality"
@@ -532,11 +765,6 @@ msgstr "Maj"
 #. 6.2->settings-schema.json->tv-glitch-strength->description
 msgid "Strength"
 msgstr "Force"
-
-#. 6.2->settings-schema.json->glitch-speed->description
-#. 6.2->settings-schema.json->tv-glitch-speed->description
-msgid "Speed"
-msgstr "Vitesse"
 
 #. 6.2->settings-schema.json->hexagon-line-width->description
 msgid "Mesh Line Width"
@@ -570,6 +798,101 @@ msgstr "Commencer au curseur"
 msgid "If disabled, a random location will be chosen."
 msgstr "S'il est désactivé, un emplacement aléatoire sera choisi."
 
+#. 6.2->settings-schema.json->magiclamp-effect->options
+#, fuzzy
+msgid "default"
+msgstr "Default Fire (Feu par défaut)"
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "sine"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+#, fuzzy
+msgid "random"
+msgstr "Aléatoire"
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "Minimize: Default - Unminimize: Sine"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "Minimize: Sine - Unminimize: Default"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->description
+#, fuzzy
+msgid "The type of effect"
+msgstr "Effet d'ouverture"
+
+#. 6.2->settings-schema.json->magiclamp-effect->tooltip
+msgid ""
+"Using 'default' will result in a curved effect where using 'sine' will "
+"result in a more wavy effect"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-x-tiles->description
+msgid "X Tiles"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-x-tiles->tooltip
+msgid "This effects the quality and the cost of the animation"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-y-tiles->description
+msgid "Y Tiles"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-y-tiles->tooltip
+msgid "This effects the quality and the costs of the animation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->description
+msgid "Mushroom preset"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-scale-style->description
+#, fuzzy
+msgid "Scale Style"
+msgstr "Échelle"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-count->description
+#, fuzzy
+msgid "Spark Count"
+msgstr "Nombre de rayons"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-color->description
+#, fuzzy
+msgid "Spark Color"
+msgstr "Couleur"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-rotation->description
+msgid "Spark Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-rays-color->description
+#, fuzzy
+msgid "Rays Color"
+msgstr "Couleur"
+
+#. 6.2->settings-schema.json->mushroom-custom-ring-count->description
+#, fuzzy
+msgid "Star Rings Count"
+msgstr "Santa is Coming (Le Père Noël arrive)"
+
+#. 6.2->settings-schema.json->mushroom-custom-ring-rotation->description
+msgid "Star Ring Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-star-count->description
+msgid "Stars Count Per Ring"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-star-colors->description
+#, fuzzy
+msgid "Colors 1-6"
+msgstr "Couleur n°1"
+
 #. 6.2->settings-schema.json->pixelate-noise->description
 msgid "Noise"
 msgstr "Bruit"
@@ -589,3 +912,62 @@ msgstr "Whirling (Tourbillon)"
 #. 6.2->settings-schema.json->portal-details->description
 msgid "Details"
 msgstr "Détails"
+
+#. 6.2->settings-schema.json->rgbwarp-brightness->description
+msgid "Brightness"
+msgstr ""
+
+#. 6.2->settings-schema.json->rgbwarp-speed-r->description
+#, fuzzy
+msgid "Red Speed"
+msgstr "Vitesse"
+
+#. 6.2->settings-schema.json->rgbwarp-speed-g->description
+#, fuzzy
+msgid "Green Speed"
+msgstr "Vitesse de déplacement du feu"
+
+#. 6.2->settings-schema.json->rgbwarp-speed-b->description
+#, fuzzy
+msgid "Blue Speed"
+msgstr "Vitesse"
+
+#. 6.2->settings-schema.json->team-rocket-animation-split->description
+msgid "Animation Split"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-horizontal-sparkle-
+#. position->description
+#, fuzzy
+msgid "Horizontal Sparkle Position"
+msgstr "Échelle horizontale"
+
+#. 6.2->settings-schema.json->team-rocket-vertical-sparkle-
+#. position->description
+#, fuzzy
+msgid "Vertical Sparkle Position"
+msgstr "Échelle verticale"
+
+#. 6.2->settings-schema.json->team-rocket-window-rotation->description
+msgid "Rotate Window"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-sparkle-rot->description
+msgid "Sparkle Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-sparkle-size->description
+msgid "Sparkle Size"
+msgstr ""
+
+#. 6.2->settings-schema.json->wisps-color-1->description
+msgid "Color #1"
+msgstr "Couleur n°1"
+
+#. 6.2->settings-schema.json->wisps-color-2->description
+msgid "Color #2"
+msgstr "Couleur n°2"
+
+#. 6.2->settings-schema.json->wisps-color-3->description
+msgid "Color #3"
+msgstr "Couleur n°3"

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/hu.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 22:59-0500\n"
+"POT-Creation-Date: 2025-03-06 10:34-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,150 +18,186 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.2/extension.js:212 6.2/extension.js:450
+#. 6.2/extension.js:190 6.2/extension.js:266 6.2/extension.js:572
 msgid "Error"
 msgstr "Hiba"
 
-#. 6.2/extension.js:212
+#. 6.2/extension.js:190
 msgid "was NOT enabled"
 msgstr "NEM volt engedélyezve"
 
-#. 6.2/extension.js:213
+#. 6.2/extension.js:191 6.2/extension.js:267
 msgid "The existing extension"
 msgstr "A meglévő bővítmény"
 
-#. 6.2/extension.js:213
+#. 6.2/extension.js:191
 msgid "conflicts with this extension."
 msgstr "ütközik ezzel a bővitménnyel."
 
-#. 6.2/extension.js:451
+#. 6.2/extension.js:266
+msgid "minimize/unminimize effects can not be enabled"
+msgstr ""
+
+#. 6.2/extension.js:267
+msgid "already handles minimize/unminimize animation events."
+msgstr ""
+
+#. 6.2/extension.js:573
+#, fuzzy
 msgid ""
-"The previously focused window is not backed by an application and therefore "
-"application specific effects can not be applied to that window"
+"Unable to determine the application or the WM_CLASS of the previously "
+"focused window, therefore application specific effects can not be applied to "
+"that window"
 msgstr ""
 "Az előzőleg fókuszált ablakot nem támogatja alkalmazás, ezért "
 "alkalmazásspecifikus effektusok nem alkalmazhatók arra az ablakra"
 
-#. 6.2->settings-schema.json->apparition-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Apparition.js:94
 msgid "Apparition"
 msgstr "Megjelenik"
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/AuraGlow.js:103
+msgid "Aura Glow"
+msgstr ""
 
 #. effects/BrokenGlass.js:152
 msgid "Broken Glass"
 msgstr "Törött üveg"
 
-#. 6.2->settings-schema.json->doom-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Doom.js:101
 msgid "Doom"
 msgstr "Doom"
 
-#. 6.2->settings-schema.json->energize-a-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/EnergizeA.js:90
 msgid "Energize A"
 msgstr "Energizálja A"
 
-#. 6.2->settings-schema.json->energize-b-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/EnergizeB.js:92
 msgid "Energize B"
 msgstr "Energizálja B"
 
-#. 6.2->settings-schema.json->fire-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
-#. effects/Fire.js:114
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/Fire.js:122
 msgid "Fire"
 msgstr "Tűz"
 
-#. effects/Fire.js:168
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:175
 msgid "Default Fire"
 msgstr "Alapértelmezett Tűz"
 
-#. effects/Fire.js:178
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:185
 msgid "Hell Fire"
 msgstr "Pokol Tüze"
 
-#. effects/Fire.js:188
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:195
 msgid "Dark and Smutty"
 msgstr "Sötét és piszkos"
 
-#. effects/Fire.js:198
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:205
 msgid "Cold Breeze"
 msgstr "Hideg szellő"
 
-#. effects/Fire.js:208
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:215
 msgid "Santa is Coming"
 msgstr "Jön a Mikulás"
 
-#. 6.2->settings-schema.json->focus-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Focus.js:91
 msgid "Focus"
 msgstr "Fókusz"
 
-#. 6.2->settings-schema.json->glide-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Glide.js:93
 msgid "Glide"
 msgstr "Siklik"
 
-#. 6.2->settings-schema.json->glitch-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Glitch.js:97
 msgid "Glitch"
 msgstr "Glitch"
 
-#. 6.2->settings-schema.json->hexagon-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Hexagon.js:106
 msgid "Hexagon"
 msgstr "Hatszög"
 
-#. 6.2->settings-schema.json->incinerate-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Incinerate.js:144
 msgid "Incinerate"
 msgstr "Felgyújt"
@@ -170,49 +206,115 @@ msgstr "Felgyújt"
 msgid "Matrix"
 msgstr "Mátrix"
 
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/Mushroom.js:154
+msgid "Mushroom"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:227
+msgid "8Bit Plumber"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:244
+msgid "New Bros 2"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:262
+msgid "The True North"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:280
+msgid "Red White and Blue"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:297
+msgid "Rainbow"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:314
+msgid "Cattuccino"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:332
+msgid "Dracula"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:349
+msgid "Sparkle"
+msgstr ""
+
 #. effects/PaintBrush.js:114
 msgid "Paint Brush"
 msgstr "Ecset"
 
-#. 6.2->settings-schema.json->pixel-wheel-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/PixelWheel.js:88
 msgid "Pixel Wheel"
 msgstr "Pixeles Kerék"
 
-#. 6.2->settings-schema.json->pixel-wipe-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/PixelWipe.js:114
 msgid "Pixel Wipe"
 msgstr "Pixeles Törlés"
 
-#. 6.2->settings-schema.json->pixelate-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Pixelate.js:88
 msgid "Pixelate"
 msgstr "Pixelesít"
 
-#. 6.2->settings-schema.json->portal-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Portal.js:99
 msgid "Portal"
 msgstr "Portál"
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/RGBWarp.js:91
+msgid "RGB Warp"
+msgstr ""
 
 #. effects/SnapOfDisintegration.js:124
 msgid "Snap of Disintegration"
@@ -222,32 +324,46 @@ msgstr "Szétesés pillanata"
 msgid "T-Rex Attack"
 msgstr "T-Rex támadás"
 
-#. 6.2->settings-schema.json->tv-effect-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/TVEffect.js:90
 msgid "TV Effect"
 msgstr "TV effektus"
 
-#. 6.2->settings-schema.json->tv-glitch-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/TVGlitch.js:99
 msgid "TV Glitch"
 msgstr "TV Glitch"
 
-#. 6.2->settings-schema.json->wisps-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/TeamRocket.js:103
+msgid "Team Rocket"
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Wisps.js:101
 msgid "Wisps"
 msgstr "Foszlányok"
@@ -257,9 +373,10 @@ msgid "Burn My Windows"
 msgstr "Égjenek el az ablakaim"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Window open/close effects based on the Burn-My-Windows Gnome extension by "
-"Schneegans"
+"Window open/close/minimize/unminimize effects based on the Burn-My-Windows "
+"Gnome extension by Schneegans"
 msgstr ""
 "A Schneegans által készített Burn-My-Windows Gnome bővítményen alapuló ablak "
 "nyitási/zárási effektek"
@@ -272,9 +389,18 @@ msgstr "Általános"
 msgid "Effect Settings"
 msgstr "Effekt beállítások"
 
+#. 6.2->settings-schema.json->application-page->title
+#, fuzzy
+msgid "Application Specifics"
+msgstr "Alkalmazásspecifikus szabályok"
+
 #. 6.2->settings-schema.json->random-page->title
 msgid "Random Effects"
 msgstr "Véletlen effektusok"
+
+#. 6.2->settings-schema.json->about-page->title
+msgid "About"
+msgstr ""
 
 #. 6.2->settings-schema.json->general-settings->title
 msgid "Burn My Windows General Settings"
@@ -292,9 +418,30 @@ msgstr "Effektus választó"
 msgid "Effect Specific Settings"
 msgstr "Effekt specifikus beállítások"
 
+#. 6.2->settings-schema.json->fire-custom-section->title
+#. 6.2->settings-schema.json->mushroom-custom-section->title
+msgid "Setting for the custom preset:"
+msgstr ""
+
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
 msgstr "A véletlenszerű készletekben szereplő effektusok:"
+
+#. 6.2->settings-schema.json->about-section->title
+msgid "About Cinnamon Burn-My-Windows"
+msgstr ""
+
+#. 6.2->settings-schema.json->about-text->description
+msgid ""
+"Ported to Cinnamon by Kevin Langman\n"
+"Github: https://github.com/klangman/CinnamonBurnMyWindows\n"
+"\n"
+"Based on the Burn-My-Windows code by Schneegans and contributors\n"
+"Github: https://github.com/Schneegans/Burn-My-Windows\n"
+"\n"
+"The Magic Lamp Effect is ported from code by hermes83\n"
+"GitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->description
 msgid "Application Specific Rules"
@@ -305,12 +452,20 @@ msgid "Enabled"
 msgstr "Engedélyezve"
 
 #. 6.2->settings-schema.json->app-rules->columns->title
-msgid "Open Effect"
-msgstr "Megnyitási effektus"
+msgid "Open"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->columns->title
-msgid "Close Effect"
-msgstr "Bezárási effektus"
+msgid "Close"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Minimize"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Unminimize"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->columns->title
 msgid "Application"
@@ -336,9 +491,47 @@ msgstr ""
 "alkalmazásspecifikus beállításokat, majd térjen vissza ide, és nyomja meg "
 "ezt a gombot."
 
-#. 6.2->settings-schema.json->random-title->description
-msgid "Effect"
-msgstr "Effektus"
+#. 6.2->settings-schema.json->random-include->description
+#, fuzzy
+msgid "Effects included in the randomized sets"
+msgstr "A véletlenszerű készletekben szereplő effektusok:"
+
+#. 6.2->settings-schema.json->random-include->tooltip
+msgid ""
+"Defines which effects are included in the randomized sets for each window "
+"event type. When 'Randomized' is selected for any event on the General tab "
+"these sets are used."
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "Effect Name         "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "      Open        "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "      Close       "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "     Minimize     "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "    Unminimize    "
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+msgid "Magic Lamp"
+msgstr ""
 
 #. 6.2->settings-schema.json->effect-selector->description
 msgid "Show settings for effect:"
@@ -348,6 +541,8 @@ msgstr "A hatás beállításainak megjelenítése:"
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 msgid "Randomized"
 msgstr "Véletlenszerű"
 
@@ -355,6 +550,8 @@ msgstr "Véletlenszerű"
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 msgid "None"
 msgstr "Semmi"
 
@@ -387,6 +584,16 @@ msgstr "Megnyitás ablak effektusa"
 msgid "Close dialog window effect"
 msgstr "Bezárás ablak effektusa"
 
+#. 6.2->settings-schema.json->minimize-effect->description
+#, fuzzy
+msgid "Minimize window effect"
+msgstr "Megnyitás ablak effektusa"
+
+#. 6.2->settings-schema.json->unminimize-effect->description
+#, fuzzy
+msgid "Unminimize window effect"
+msgstr "Megnyitás ablak effektusa"
+
 #. 6.2->settings-schema.json->apparition-shake-intensity->description
 msgid "Shake Intensity"
 msgstr "Rázkódás intenzitása"
@@ -404,6 +611,7 @@ msgid "Randomness"
 msgstr "Véletlenszerűség"
 
 #. 6.2->settings-schema.json->apparition-animation-time->description
+#. 6.2->settings-schema.json->aura-glow-animation-time->description
 #. 6.2->settings-schema.json->doom-animation-time->description
 #. 6.2->settings-schema.json->energize-a-animation-time->description
 #. 6.2->settings-schema.json->energize-b-animation-time->description
@@ -413,15 +621,53 @@ msgstr "Véletlenszerűség"
 #. 6.2->settings-schema.json->glitch-animation-time->description
 #. 6.2->settings-schema.json->hexagon-animation-time->description
 #. 6.2->settings-schema.json->incinerate-animation-time->description
+#. 6.2->settings-schema.json->magiclamp-animation-time->description
+#. 6.2->settings-schema.json->mushroom-animation-time->description
 #. 6.2->settings-schema.json->pixelate-animation-time->description
 #. 6.2->settings-schema.json->pixel-wheel-animation-time->description
 #. 6.2->settings-schema.json->pixel-wipe-animation-time->description
 #. 6.2->settings-schema.json->portal-animation-time->description
+#. 6.2->settings-schema.json->rgbwarp-animation-time->description
+#. 6.2->settings-schema.json->team-rocket-animation-time->description
 #. 6.2->settings-schema.json->tv-animation-time->description
 #. 6.2->settings-schema.json->tv-glitch-animation-time->description
 #. 6.2->settings-schema.json->wisps-animation-time->description
 msgid "Effect Duration (milliseconds)"
 msgstr "Effektus időtartama (ezredmásodperc)"
+
+#. 6.2->settings-schema.json->aura-glow-random-color->description
+#, fuzzy
+msgid "Random Color"
+msgstr "Vonal színe"
+
+#. 6.2->settings-schema.json->aura-glow-start-hue->description
+msgid "Start Hue"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-speed->description
+#. 6.2->settings-schema.json->glitch-speed->description
+#. 6.2->settings-schema.json->tv-glitch-speed->description
+msgid "Speed"
+msgstr "Sebesség"
+
+#. 6.2->settings-schema.json->aura-glow-saturation->description
+#, fuzzy
+msgid "Saturation"
+msgstr "Megjelenik"
+
+#. 6.2->settings-schema.json->aura-glow-edge-size->description
+#, fuzzy
+msgid "Edge Size"
+msgstr "Képpont méret"
+
+#. 6.2->settings-schema.json->aura-glow-edge-hardness->description
+msgid "Edge Hardness"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-blur->description
+#. 6.2->settings-schema.json->focus-blur-amount->description
+msgid "Blur Amount"
+msgstr "Elmosás mennyisége"
 
 #. 6.2->settings-schema.json->doom-horizontal-scale->description
 msgid "Horizontal Scale"
@@ -440,7 +686,7 @@ msgstr "Képpont méret"
 
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
-#. 6.2->settings-schema.json->fire-scale->description
+#. 6.2->settings-schema.json->fire-custom-scale->description
 #. 6.2->settings-schema.json->glide-scale->description
 #. 6.2->settings-schema.json->glitch-scale->description
 #. 6.2->settings-schema.json->hexagon-scale->description
@@ -460,7 +706,16 @@ msgstr "Skála"
 msgid "Color"
 msgstr "Szín"
 
-#. 6.2->settings-schema.json->fire-movement-speed->description
+#. 6.2->settings-schema.json->fire-presets->options
+#. 6.2->settings-schema.json->mushroom-presets->options
+msgid "Custom"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-presets->description
+msgid "Fire preset"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-custom-movement-speed->description
 msgid "Fire Movement Speed"
 msgstr ""
 
@@ -472,34 +727,10 @@ msgstr ""
 msgid "Creates a more dynamic fire but requires more GPU power."
 msgstr ""
 
-#. 6.2->settings-schema.json->fire-color-1->description
-#. 6.2->settings-schema.json->wisps-color-1->description
-msgid "Color #1"
-msgstr "Szín #1"
-
-#. 6.2->settings-schema.json->fire-color-2->description
-#. 6.2->settings-schema.json->wisps-color-2->description
-msgid "Color #2"
-msgstr "Szín #2"
-
-#. 6.2->settings-schema.json->fire-color-3->description
-#. 6.2->settings-schema.json->wisps-color-3->description
-msgid "Color #3"
-msgstr "Szín #3"
-
-#. 6.2->settings-schema.json->fire-color-4->description
+#. 6.2->settings-schema.json->fire-colors->description
 #, fuzzy
-msgid "Color #4"
+msgid "Colors 1-5"
 msgstr "Szín #1"
-
-#. 6.2->settings-schema.json->fire-color-5->description
-#, fuzzy
-msgid "Color #5"
-msgstr "Szín #1"
-
-#. 6.2->settings-schema.json->focus-blur-amount->description
-msgid "Blur Amount"
-msgstr "Elmosás mennyisége"
 
 #. 6.2->settings-schema.json->focus-blur-quality->description
 msgid "Blur Quality"
@@ -529,11 +760,6 @@ msgstr "Eltolás"
 #. 6.2->settings-schema.json->tv-glitch-strength->description
 msgid "Strength"
 msgstr "Erő"
-
-#. 6.2->settings-schema.json->glitch-speed->description
-#. 6.2->settings-schema.json->tv-glitch-speed->description
-msgid "Speed"
-msgstr "Sebesség"
 
 #. 6.2->settings-schema.json->hexagon-line-width->description
 msgid "Mesh Line Width"
@@ -567,6 +793,101 @@ msgstr "Az egérmutatónál induljon"
 msgid "If disabled, a random location will be chosen."
 msgstr "Ha le van tiltva, akkor egy véletlenszerű hely kerül kiválasztásra."
 
+#. 6.2->settings-schema.json->magiclamp-effect->options
+#, fuzzy
+msgid "default"
+msgstr "Alapértelmezett Tűz"
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "sine"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+#, fuzzy
+msgid "random"
+msgstr "Véletlenszerű"
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "Minimize: Default - Unminimize: Sine"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "Minimize: Sine - Unminimize: Default"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->description
+#, fuzzy
+msgid "The type of effect"
+msgstr "Megnyitás ablak effektusa"
+
+#. 6.2->settings-schema.json->magiclamp-effect->tooltip
+msgid ""
+"Using 'default' will result in a curved effect where using 'sine' will "
+"result in a more wavy effect"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-x-tiles->description
+msgid "X Tiles"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-x-tiles->tooltip
+msgid "This effects the quality and the cost of the animation"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-y-tiles->description
+msgid "Y Tiles"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-y-tiles->tooltip
+msgid "This effects the quality and the costs of the animation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->description
+msgid "Mushroom preset"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-scale-style->description
+#, fuzzy
+msgid "Scale Style"
+msgstr "Skála"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-count->description
+#, fuzzy
+msgid "Spark Count"
+msgstr "Küllők száma"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-color->description
+#, fuzzy
+msgid "Spark Color"
+msgstr "Szín"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-rotation->description
+msgid "Spark Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-rays-color->description
+#, fuzzy
+msgid "Rays Color"
+msgstr "Szín"
+
+#. 6.2->settings-schema.json->mushroom-custom-ring-count->description
+#, fuzzy
+msgid "Star Rings Count"
+msgstr "Jön a Mikulás"
+
+#. 6.2->settings-schema.json->mushroom-custom-ring-rotation->description
+msgid "Star Ring Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-star-count->description
+msgid "Stars Count Per Ring"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-star-colors->description
+#, fuzzy
+msgid "Colors 1-6"
+msgstr "Szín #1"
+
 #. 6.2->settings-schema.json->pixelate-noise->description
 msgid "Noise"
 msgstr "Zaj"
@@ -586,3 +907,62 @@ msgstr "Örvénylő"
 #. 6.2->settings-schema.json->portal-details->description
 msgid "Details"
 msgstr "Részletek"
+
+#. 6.2->settings-schema.json->rgbwarp-brightness->description
+msgid "Brightness"
+msgstr ""
+
+#. 6.2->settings-schema.json->rgbwarp-speed-r->description
+#, fuzzy
+msgid "Red Speed"
+msgstr "Sebesség"
+
+#. 6.2->settings-schema.json->rgbwarp-speed-g->description
+#, fuzzy
+msgid "Green Speed"
+msgstr "Sebesség"
+
+#. 6.2->settings-schema.json->rgbwarp-speed-b->description
+#, fuzzy
+msgid "Blue Speed"
+msgstr "Sebesség"
+
+#. 6.2->settings-schema.json->team-rocket-animation-split->description
+msgid "Animation Split"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-horizontal-sparkle-
+#. position->description
+#, fuzzy
+msgid "Horizontal Sparkle Position"
+msgstr "Vízszintes skála"
+
+#. 6.2->settings-schema.json->team-rocket-vertical-sparkle-
+#. position->description
+#, fuzzy
+msgid "Vertical Sparkle Position"
+msgstr "Függőleges skála"
+
+#. 6.2->settings-schema.json->team-rocket-window-rotation->description
+msgid "Rotate Window"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-sparkle-rot->description
+msgid "Sparkle Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-sparkle-size->description
+msgid "Sparkle Size"
+msgstr ""
+
+#. 6.2->settings-schema.json->wisps-color-1->description
+msgid "Color #1"
+msgstr "Szín #1"
+
+#. 6.2->settings-schema.json->wisps-color-2->description
+msgid "Color #2"
+msgstr "Szín #2"
+
+#. 6.2->settings-schema.json->wisps-color-3->description
+msgid "Color #3"
+msgstr "Szín #3"

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/nl.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 22:59-0500\n"
+"POT-Creation-Date: 2025-03-06 10:34-0500\n"
 "PO-Revision-Date: 2025-02-21 10:10+0100\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,151 +16,187 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.2/extension.js:212 6.2/extension.js:450
+#. 6.2/extension.js:190 6.2/extension.js:266 6.2/extension.js:572
 msgid "Error"
 msgstr "Fout"
 
-#. 6.2/extension.js:212
+#. 6.2/extension.js:190
 msgid "was NOT enabled"
 msgstr "was NIET ingeschakeld"
 
-#. 6.2/extension.js:213
+#. 6.2/extension.js:191 6.2/extension.js:267
 msgid "The existing extension"
 msgstr "De bestaande extensie"
 
-#. 6.2/extension.js:213
+#. 6.2/extension.js:191
 msgid "conflicts with this extension."
 msgstr "conflicteert met deze extensie."
 
-#. 6.2/extension.js:451
+#. 6.2/extension.js:266
+msgid "minimize/unminimize effects can not be enabled"
+msgstr ""
+
+#. 6.2/extension.js:267
+msgid "already handles minimize/unminimize animation events."
+msgstr ""
+
+#. 6.2/extension.js:573
+#, fuzzy
 msgid ""
-"The previously focused window is not backed by an application and therefore "
-"application specific effects can not be applied to that window"
+"Unable to determine the application or the WM_CLASS of the previously "
+"focused window, therefore application specific effects can not be applied to "
+"that window"
 msgstr ""
 "Het eerder gefocuste venster wordt niet ondersteund door een toepassing en "
 "daarom kunnen toepassing-specifieke effecten niet op dat venster worden "
 "toegepast"
 
-#. 6.2->settings-schema.json->apparition-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Apparition.js:94
 msgid "Apparition"
 msgstr "Verschijning"
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/AuraGlow.js:103
+msgid "Aura Glow"
+msgstr ""
 
 #. effects/BrokenGlass.js:152
 msgid "Broken Glass"
 msgstr "Gebroken Glas"
 
-#. 6.2->settings-schema.json->doom-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Doom.js:101
 msgid "Doom"
 msgstr "Doom"
 
-#. 6.2->settings-schema.json->energize-a-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/EnergizeA.js:90
 msgid "Energize A"
 msgstr "Energize A"
 
-#. 6.2->settings-schema.json->energize-b-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/EnergizeB.js:92
 msgid "Energize B"
 msgstr "Energize B"
 
-#. 6.2->settings-schema.json->fire-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
-#. effects/Fire.js:114
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/Fire.js:122
 msgid "Fire"
 msgstr "Vuur"
 
-#. effects/Fire.js:168
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:175
 msgid "Default Fire"
 msgstr "Standaard Vuur"
 
-#. effects/Fire.js:178
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:185
 msgid "Hell Fire"
 msgstr "Hel Vuur"
 
-#. effects/Fire.js:188
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:195
 msgid "Dark and Smutty"
 msgstr "Donker en Smerig"
 
-#. effects/Fire.js:198
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:205
 msgid "Cold Breeze"
 msgstr "Koude Bries"
 
-#. effects/Fire.js:208
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:215
 msgid "Santa is Coming"
 msgstr "Kerstman komt eraan"
 
-#. 6.2->settings-schema.json->focus-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Focus.js:91
 msgid "Focus"
 msgstr "Focus"
 
-#. 6.2->settings-schema.json->glide-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Glide.js:93
 msgid "Glide"
 msgstr "Glijden"
 
-#. 6.2->settings-schema.json->glitch-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Glitch.js:97
 msgid "Glitch"
 msgstr "Storing"
 
-#. 6.2->settings-schema.json->hexagon-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Hexagon.js:106
 msgid "Hexagon"
 msgstr "Zeshoek"
 
-#. 6.2->settings-schema.json->incinerate-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Incinerate.js:144
 msgid "Incinerate"
 msgstr "Verbranden"
@@ -169,49 +205,115 @@ msgstr "Verbranden"
 msgid "Matrix"
 msgstr "Matrix"
 
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/Mushroom.js:154
+msgid "Mushroom"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:227
+msgid "8Bit Plumber"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:244
+msgid "New Bros 2"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:262
+msgid "The True North"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:280
+msgid "Red White and Blue"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:297
+msgid "Rainbow"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:314
+msgid "Cattuccino"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:332
+msgid "Dracula"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:349
+msgid "Sparkle"
+msgstr ""
+
 #. effects/PaintBrush.js:114
 msgid "Paint Brush"
 msgstr "Verfkwast"
 
-#. 6.2->settings-schema.json->pixel-wheel-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/PixelWheel.js:88
 msgid "Pixel Wheel"
 msgstr "Pixelwiel"
 
-#. 6.2->settings-schema.json->pixel-wipe-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/PixelWipe.js:114
 msgid "Pixel Wipe"
 msgstr "Pixel Veeg"
 
-#. 6.2->settings-schema.json->pixelate-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Pixelate.js:88
 msgid "Pixelate"
 msgstr "Pixeleren"
 
-#. 6.2->settings-schema.json->portal-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Portal.js:99
 msgid "Portal"
 msgstr "Portaal"
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/RGBWarp.js:91
+msgid "RGB Warp"
+msgstr ""
 
 #. effects/SnapOfDisintegration.js:124
 msgid "Snap of Disintegration"
@@ -221,32 +323,46 @@ msgstr "Knip van Desintegratie"
 msgid "T-Rex Attack"
 msgstr "T-Rex Aanval"
 
-#. 6.2->settings-schema.json->tv-effect-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/TVEffect.js:90
 msgid "TV Effect"
 msgstr "TV Effect"
 
-#. 6.2->settings-schema.json->tv-glitch-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/TVGlitch.js:99
 msgid "TV Glitch"
 msgstr "TV Storing"
 
-#. 6.2->settings-schema.json->wisps-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/TeamRocket.js:103
+msgid "Team Rocket"
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Wisps.js:101
 msgid "Wisps"
 msgstr "Slierten"
@@ -256,9 +372,10 @@ msgid "Burn My Windows"
 msgstr "Verbrand Mijn Vensters"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Window open/close effects based on the Burn-My-Windows Gnome extension by "
-"Schneegans"
+"Window open/close/minimize/unminimize effects based on the Burn-My-Windows "
+"Gnome extension by Schneegans"
 msgstr ""
 "Venster open/sluit effecten gebaseerd op de Burn-My-Windows Gnome-extensie "
 "van Schneegans"
@@ -271,9 +388,18 @@ msgstr "Algemeen"
 msgid "Effect Settings"
 msgstr "Effectinstellingen"
 
+#. 6.2->settings-schema.json->application-page->title
+#, fuzzy
+msgid "Application Specifics"
+msgstr "Toepassingsspecifieke Regels"
+
 #. 6.2->settings-schema.json->random-page->title
 msgid "Random Effects"
 msgstr "Willekeurige Effecten"
+
+#. 6.2->settings-schema.json->about-page->title
+msgid "About"
+msgstr ""
 
 #. 6.2->settings-schema.json->general-settings->title
 msgid "Burn My Windows General Settings"
@@ -291,9 +417,30 @@ msgstr "Effect Selector"
 msgid "Effect Specific Settings"
 msgstr "Effect Specifieke Instellingen"
 
+#. 6.2->settings-schema.json->fire-custom-section->title
+#. 6.2->settings-schema.json->mushroom-custom-section->title
+msgid "Setting for the custom preset:"
+msgstr ""
+
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
 msgstr "Effecten opgenomen in de willekeurige sets:"
+
+#. 6.2->settings-schema.json->about-section->title
+msgid "About Cinnamon Burn-My-Windows"
+msgstr ""
+
+#. 6.2->settings-schema.json->about-text->description
+msgid ""
+"Ported to Cinnamon by Kevin Langman\n"
+"Github: https://github.com/klangman/CinnamonBurnMyWindows\n"
+"\n"
+"Based on the Burn-My-Windows code by Schneegans and contributors\n"
+"Github: https://github.com/Schneegans/Burn-My-Windows\n"
+"\n"
+"The Magic Lamp Effect is ported from code by hermes83\n"
+"GitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->description
 msgid "Application Specific Rules"
@@ -304,12 +451,20 @@ msgid "Enabled"
 msgstr "Ingeschakeld"
 
 #. 6.2->settings-schema.json->app-rules->columns->title
-msgid "Open Effect"
-msgstr "Open-effect"
+msgid "Open"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->columns->title
-msgid "Close Effect"
-msgstr "Sluit-effect"
+msgid "Close"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Minimize"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Unminimize"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->columns->title
 msgid "Application"
@@ -336,9 +491,47 @@ msgstr ""
 "Focus een venster waarvoor je toepassingsspecifieke instellingen wilt "
 "inschakelen en keer dan hier terug en druk op deze knop."
 
-#. 6.2->settings-schema.json->random-title->description
-msgid "Effect"
-msgstr "Effect"
+#. 6.2->settings-schema.json->random-include->description
+#, fuzzy
+msgid "Effects included in the randomized sets"
+msgstr "Effecten opgenomen in de willekeurige sets:"
+
+#. 6.2->settings-schema.json->random-include->tooltip
+msgid ""
+"Defines which effects are included in the randomized sets for each window "
+"event type. When 'Randomized' is selected for any event on the General tab "
+"these sets are used."
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "Effect Name         "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "      Open        "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "      Close       "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "     Minimize     "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "    Unminimize    "
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+msgid "Magic Lamp"
+msgstr ""
 
 #. 6.2->settings-schema.json->effect-selector->description
 msgid "Show settings for effect:"
@@ -348,6 +541,8 @@ msgstr "Toon instellingen voor effect:"
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 msgid "Randomized"
 msgstr "Willekeurig"
 
@@ -355,6 +550,8 @@ msgstr "Willekeurig"
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 msgid "None"
 msgstr "Geen"
 
@@ -389,6 +586,16 @@ msgstr "Open dialoogvenster effect"
 msgid "Close dialog window effect"
 msgstr "Sluit dialoogvenster effect"
 
+#. 6.2->settings-schema.json->minimize-effect->description
+#, fuzzy
+msgid "Minimize window effect"
+msgstr "Open venster effect"
+
+#. 6.2->settings-schema.json->unminimize-effect->description
+#, fuzzy
+msgid "Unminimize window effect"
+msgstr "Open venster effect"
+
 #. 6.2->settings-schema.json->apparition-shake-intensity->description
 msgid "Shake Intensity"
 msgstr "Schud Intensiteit"
@@ -406,6 +613,7 @@ msgid "Randomness"
 msgstr "Willekeurigheid"
 
 #. 6.2->settings-schema.json->apparition-animation-time->description
+#. 6.2->settings-schema.json->aura-glow-animation-time->description
 #. 6.2->settings-schema.json->doom-animation-time->description
 #. 6.2->settings-schema.json->energize-a-animation-time->description
 #. 6.2->settings-schema.json->energize-b-animation-time->description
@@ -415,15 +623,53 @@ msgstr "Willekeurigheid"
 #. 6.2->settings-schema.json->glitch-animation-time->description
 #. 6.2->settings-schema.json->hexagon-animation-time->description
 #. 6.2->settings-schema.json->incinerate-animation-time->description
+#. 6.2->settings-schema.json->magiclamp-animation-time->description
+#. 6.2->settings-schema.json->mushroom-animation-time->description
 #. 6.2->settings-schema.json->pixelate-animation-time->description
 #. 6.2->settings-schema.json->pixel-wheel-animation-time->description
 #. 6.2->settings-schema.json->pixel-wipe-animation-time->description
 #. 6.2->settings-schema.json->portal-animation-time->description
+#. 6.2->settings-schema.json->rgbwarp-animation-time->description
+#. 6.2->settings-schema.json->team-rocket-animation-time->description
 #. 6.2->settings-schema.json->tv-animation-time->description
 #. 6.2->settings-schema.json->tv-glitch-animation-time->description
 #. 6.2->settings-schema.json->wisps-animation-time->description
 msgid "Effect Duration (milliseconds)"
 msgstr "Effect Duur (milliseconden)"
+
+#. 6.2->settings-schema.json->aura-glow-random-color->description
+#, fuzzy
+msgid "Random Color"
+msgstr "Lijn Kleur"
+
+#. 6.2->settings-schema.json->aura-glow-start-hue->description
+msgid "Start Hue"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-speed->description
+#. 6.2->settings-schema.json->glitch-speed->description
+#. 6.2->settings-schema.json->tv-glitch-speed->description
+msgid "Speed"
+msgstr "Snelheid"
+
+#. 6.2->settings-schema.json->aura-glow-saturation->description
+#, fuzzy
+msgid "Saturation"
+msgstr "Verschijning"
+
+#. 6.2->settings-schema.json->aura-glow-edge-size->description
+#, fuzzy
+msgid "Edge Size"
+msgstr "Pixel Grootte"
+
+#. 6.2->settings-schema.json->aura-glow-edge-hardness->description
+msgid "Edge Hardness"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-blur->description
+#. 6.2->settings-schema.json->focus-blur-amount->description
+msgid "Blur Amount"
+msgstr "Vervaginghoeveelheid"
 
 #. 6.2->settings-schema.json->doom-horizontal-scale->description
 msgid "Horizontal Scale"
@@ -442,7 +688,7 @@ msgstr "Pixel Grootte"
 
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
-#. 6.2->settings-schema.json->fire-scale->description
+#. 6.2->settings-schema.json->fire-custom-scale->description
 #. 6.2->settings-schema.json->glide-scale->description
 #. 6.2->settings-schema.json->glitch-scale->description
 #. 6.2->settings-schema.json->hexagon-scale->description
@@ -462,7 +708,16 @@ msgstr "Schaal"
 msgid "Color"
 msgstr "Kleur"
 
-#. 6.2->settings-schema.json->fire-movement-speed->description
+#. 6.2->settings-schema.json->fire-presets->options
+#. 6.2->settings-schema.json->mushroom-presets->options
+msgid "Custom"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-presets->description
+msgid "Fire preset"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-custom-movement-speed->description
 msgid "Fire Movement Speed"
 msgstr "Vuur bewegingssnelheid"
 
@@ -474,32 +729,10 @@ msgstr "Vuur 3D-ruis"
 msgid "Creates a more dynamic fire but requires more GPU power."
 msgstr "Creëert een dynamischer vuur, maar vereist meer GPU-kracht."
 
-#. 6.2->settings-schema.json->fire-color-1->description
-#. 6.2->settings-schema.json->wisps-color-1->description
-msgid "Color #1"
+#. 6.2->settings-schema.json->fire-colors->description
+#, fuzzy
+msgid "Colors 1-5"
 msgstr "Kleur #1"
-
-#. 6.2->settings-schema.json->fire-color-2->description
-#. 6.2->settings-schema.json->wisps-color-2->description
-msgid "Color #2"
-msgstr "Kleur #2"
-
-#. 6.2->settings-schema.json->fire-color-3->description
-#. 6.2->settings-schema.json->wisps-color-3->description
-msgid "Color #3"
-msgstr "Kleur #3"
-
-#. 6.2->settings-schema.json->fire-color-4->description
-msgid "Color #4"
-msgstr "Kleur #4"
-
-#. 6.2->settings-schema.json->fire-color-5->description
-msgid "Color #5"
-msgstr "Kleur #5"
-
-#. 6.2->settings-schema.json->focus-blur-amount->description
-msgid "Blur Amount"
-msgstr "Vervaginghoeveelheid"
 
 #. 6.2->settings-schema.json->focus-blur-quality->description
 msgid "Blur Quality"
@@ -529,11 +762,6 @@ msgstr "Verschuiven"
 #. 6.2->settings-schema.json->tv-glitch-strength->description
 msgid "Strength"
 msgstr "Sterkte"
-
-#. 6.2->settings-schema.json->glitch-speed->description
-#. 6.2->settings-schema.json->tv-glitch-speed->description
-msgid "Speed"
-msgstr "Snelheid"
 
 #. 6.2->settings-schema.json->hexagon-line-width->description
 msgid "Mesh Line Width"
@@ -567,6 +795,101 @@ msgstr "Begin bij Cursor"
 msgid "If disabled, a random location will be chosen."
 msgstr "Indien uitgeschakeld wordt een willekeurige locatie gekozen."
 
+#. 6.2->settings-schema.json->magiclamp-effect->options
+#, fuzzy
+msgid "default"
+msgstr "Standaard Vuur"
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "sine"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+#, fuzzy
+msgid "random"
+msgstr "Willekeurig"
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "Minimize: Default - Unminimize: Sine"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "Minimize: Sine - Unminimize: Default"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->description
+#, fuzzy
+msgid "The type of effect"
+msgstr "Open venster effect"
+
+#. 6.2->settings-schema.json->magiclamp-effect->tooltip
+msgid ""
+"Using 'default' will result in a curved effect where using 'sine' will "
+"result in a more wavy effect"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-x-tiles->description
+msgid "X Tiles"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-x-tiles->tooltip
+msgid "This effects the quality and the cost of the animation"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-y-tiles->description
+msgid "Y Tiles"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-y-tiles->tooltip
+msgid "This effects the quality and the costs of the animation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->description
+msgid "Mushroom preset"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-scale-style->description
+#, fuzzy
+msgid "Scale Style"
+msgstr "Schaal"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-count->description
+#, fuzzy
+msgid "Spark Count"
+msgstr "Spaak Aantal"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-color->description
+#, fuzzy
+msgid "Spark Color"
+msgstr "Kleur"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-rotation->description
+msgid "Spark Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-rays-color->description
+#, fuzzy
+msgid "Rays Color"
+msgstr "Kleur"
+
+#. 6.2->settings-schema.json->mushroom-custom-ring-count->description
+#, fuzzy
+msgid "Star Rings Count"
+msgstr "Kerstman komt eraan"
+
+#. 6.2->settings-schema.json->mushroom-custom-ring-rotation->description
+msgid "Star Ring Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-star-count->description
+msgid "Stars Count Per Ring"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-star-colors->description
+#, fuzzy
+msgid "Colors 1-6"
+msgstr "Kleur #1"
+
 #. 6.2->settings-schema.json->pixelate-noise->description
 msgid "Noise"
 msgstr "Ruis"
@@ -586,3 +909,62 @@ msgstr "Draaien"
 #. 6.2->settings-schema.json->portal-details->description
 msgid "Details"
 msgstr "Details"
+
+#. 6.2->settings-schema.json->rgbwarp-brightness->description
+msgid "Brightness"
+msgstr ""
+
+#. 6.2->settings-schema.json->rgbwarp-speed-r->description
+#, fuzzy
+msgid "Red Speed"
+msgstr "Snelheid"
+
+#. 6.2->settings-schema.json->rgbwarp-speed-g->description
+#, fuzzy
+msgid "Green Speed"
+msgstr "Vuur bewegingssnelheid"
+
+#. 6.2->settings-schema.json->rgbwarp-speed-b->description
+#, fuzzy
+msgid "Blue Speed"
+msgstr "Snelheid"
+
+#. 6.2->settings-schema.json->team-rocket-animation-split->description
+msgid "Animation Split"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-horizontal-sparkle-
+#. position->description
+#, fuzzy
+msgid "Horizontal Sparkle Position"
+msgstr "Horizontale Schaal"
+
+#. 6.2->settings-schema.json->team-rocket-vertical-sparkle-
+#. position->description
+#, fuzzy
+msgid "Vertical Sparkle Position"
+msgstr "Verticale Schaal"
+
+#. 6.2->settings-schema.json->team-rocket-window-rotation->description
+msgid "Rotate Window"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-sparkle-rot->description
+msgid "Sparkle Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-sparkle-size->description
+msgid "Sparkle Size"
+msgstr ""
+
+#. 6.2->settings-schema.json->wisps-color-1->description
+msgid "Color #1"
+msgstr "Kleur #1"
+
+#. 6.2->settings-schema.json->wisps-color-2->description
+msgid "Color #2"
+msgstr "Kleur #2"
+
+#. 6.2->settings-schema.json->wisps-color-3->description
+msgid "Color #3"
+msgstr "Kleur #3"

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/pt.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/pt.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 22:59-0500\n"
+"POT-Creation-Date: 2025-03-06 10:34-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,151 +18,187 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. 6.2/extension.js:212 6.2/extension.js:450
+#. 6.2/extension.js:190 6.2/extension.js:266 6.2/extension.js:572
 msgid "Error"
 msgstr "Erro"
 
-#. 6.2/extension.js:212
+#. 6.2/extension.js:190
 msgid "was NOT enabled"
 msgstr "não foi ativo"
 
-#. 6.2/extension.js:213
+#. 6.2/extension.js:191 6.2/extension.js:267
 msgid "The existing extension"
 msgstr "A extensão existente"
 
-#. 6.2/extension.js:213
+#. 6.2/extension.js:191
 msgid "conflicts with this extension."
 msgstr "conflita com esta extensão."
 
-#. 6.2/extension.js:451
+#. 6.2/extension.js:266
+msgid "minimize/unminimize effects can not be enabled"
+msgstr ""
+
+#. 6.2/extension.js:267
+msgid "already handles minimize/unminimize animation events."
+msgstr ""
+
+#. 6.2/extension.js:573
+#, fuzzy
 msgid ""
-"The previously focused window is not backed by an application and therefore "
-"application specific effects can not be applied to that window"
+"Unable to determine the application or the WM_CLASS of the previously "
+"focused window, therefore application specific effects can not be applied to "
+"that window"
 msgstr ""
 "A janela em foco previamente não é parte de uma aplicação específica, "
 "portanto efeitos específicos para aplicações não podem ser aplicadas a essa "
 "janela"
 
-#. 6.2->settings-schema.json->apparition-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Apparition.js:94
 msgid "Apparition"
 msgstr "Aparição"
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/AuraGlow.js:103
+msgid "Aura Glow"
+msgstr ""
 
 #. effects/BrokenGlass.js:152
 msgid "Broken Glass"
 msgstr "Vidro Quebrado"
 
-#. 6.2->settings-schema.json->doom-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Doom.js:101
 msgid "Doom"
 msgstr "Ruína"
 
-#. 6.2->settings-schema.json->energize-a-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/EnergizeA.js:90
 msgid "Energize A"
 msgstr "Energizar A"
 
-#. 6.2->settings-schema.json->energize-b-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/EnergizeB.js:92
 msgid "Energize B"
 msgstr "Energizar B"
 
-#. 6.2->settings-schema.json->fire-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
-#. effects/Fire.js:114
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/Fire.js:122
 msgid "Fire"
 msgstr "Fogo"
 
-#. effects/Fire.js:168
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:175
 msgid "Default Fire"
 msgstr "Fogo Padrão"
 
-#. effects/Fire.js:178
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:185
 msgid "Hell Fire"
 msgstr "Fogo do Inferno"
 
-#. effects/Fire.js:188
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:195
 msgid "Dark and Smutty"
 msgstr "Escuro e Sujo"
 
-#. effects/Fire.js:198
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:205
 msgid "Cold Breeze"
 msgstr "Briza Fria"
 
-#. effects/Fire.js:208
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:215
 msgid "Santa is Coming"
 msgstr "O Pai Natal está Vindo"
 
-#. 6.2->settings-schema.json->focus-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Focus.js:91
 msgid "Focus"
 msgstr ""
 
-#. 6.2->settings-schema.json->glide-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Glide.js:93
 msgid "Glide"
 msgstr "Deslizar"
 
-#. 6.2->settings-schema.json->glitch-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Glitch.js:97
 msgid "Glitch"
 msgstr "Falha Gráfica"
 
-#. 6.2->settings-schema.json->hexagon-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Hexagon.js:106
 msgid "Hexagon"
 msgstr "Hexágono"
 
-#. 6.2->settings-schema.json->incinerate-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Incinerate.js:144
 msgid "Incinerate"
 msgstr "Incenerar"
@@ -171,49 +207,115 @@ msgstr "Incenerar"
 msgid "Matrix"
 msgstr "Matriz"
 
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/Mushroom.js:154
+msgid "Mushroom"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:227
+msgid "8Bit Plumber"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:244
+msgid "New Bros 2"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:262
+msgid "The True North"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:280
+msgid "Red White and Blue"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:297
+msgid "Rainbow"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:314
+msgid "Cattuccino"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:332
+msgid "Dracula"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->options
+#. effects/Mushroom.js:349
+msgid "Sparkle"
+msgstr ""
+
 #. effects/PaintBrush.js:114
 msgid "Paint Brush"
 msgstr "Pincel"
 
-#. 6.2->settings-schema.json->pixel-wheel-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/PixelWheel.js:88
 msgid "Pixel Wheel"
 msgstr "Roda de Pixeis"
 
-#. 6.2->settings-schema.json->pixel-wipe-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/PixelWipe.js:114
 msgid "Pixel Wipe"
 msgstr "Limpeza de Pixeis"
 
-#. 6.2->settings-schema.json->pixelate-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Pixelate.js:88
 msgid "Pixelate"
 msgstr "Pixelizar"
 
-#. 6.2->settings-schema.json->portal-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Portal.js:99
 msgid "Portal"
 msgstr "Portal"
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/RGBWarp.js:91
+msgid "RGB Warp"
+msgstr ""
 
 #. effects/SnapOfDisintegration.js:124
 msgid "Snap of Disintegration"
@@ -223,32 +325,46 @@ msgstr "Estalo de Desintegração"
 msgid "T-Rex Attack"
 msgstr "Ataque do T-Rex"
 
-#. 6.2->settings-schema.json->tv-effect-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/TVEffect.js:90
 msgid "TV Effect"
 msgstr "Efeito de TV"
 
-#. 6.2->settings-schema.json->tv-glitch-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/TVGlitch.js:99
 msgid "TV Glitch"
 msgstr "Falha Gráfica de TV"
 
-#. 6.2->settings-schema.json->wisps-random-include->description
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+#. effects/TeamRocket.js:103
+msgid "Team Rocket"
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Wisps.js:101
 msgid "Wisps"
 msgstr "Fogos-Fátuos"
@@ -258,9 +374,10 @@ msgid "Burn My Windows"
 msgstr "Queime Minha Janela"
 
 #. metadata.json->description
+#, fuzzy
 msgid ""
-"Window open/close effects based on the Burn-My-Windows Gnome extension by "
-"Schneegans"
+"Window open/close/minimize/unminimize effects based on the Burn-My-Windows "
+"Gnome extension by Schneegans"
 msgstr ""
 "Efeitos de abertura/fecho de janelas baseados na extensão GNOME 'Burn-My-"
 "Windows' do Schneegans"
@@ -273,9 +390,18 @@ msgstr "Geral"
 msgid "Effect Settings"
 msgstr "Definições de Efeitos"
 
+#. 6.2->settings-schema.json->application-page->title
+#, fuzzy
+msgid "Application Specifics"
+msgstr "Regras para Aplicações Específicas"
+
 #. 6.2->settings-schema.json->random-page->title
 msgid "Random Effects"
 msgstr "Efeitos Aleatórios"
+
+#. 6.2->settings-schema.json->about-page->title
+msgid "About"
+msgstr ""
 
 #. 6.2->settings-schema.json->general-settings->title
 msgid "Burn My Windows General Settings"
@@ -293,9 +419,30 @@ msgstr "Selecionador de Efeitos"
 msgid "Effect Specific Settings"
 msgstr "Definições Específicas do Efeito"
 
+#. 6.2->settings-schema.json->fire-custom-section->title
+#. 6.2->settings-schema.json->mushroom-custom-section->title
+msgid "Setting for the custom preset:"
+msgstr ""
+
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
 msgstr "Efeitos incluídos no grupo randomizado:"
+
+#. 6.2->settings-schema.json->about-section->title
+msgid "About Cinnamon Burn-My-Windows"
+msgstr ""
+
+#. 6.2->settings-schema.json->about-text->description
+msgid ""
+"Ported to Cinnamon by Kevin Langman\n"
+"Github: https://github.com/klangman/CinnamonBurnMyWindows\n"
+"\n"
+"Based on the Burn-My-Windows code by Schneegans and contributors\n"
+"Github: https://github.com/Schneegans/Burn-My-Windows\n"
+"\n"
+"The Magic Lamp Effect is ported from code by hermes83\n"
+"GitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->description
 msgid "Application Specific Rules"
@@ -306,12 +453,20 @@ msgid "Enabled"
 msgstr "Ativo"
 
 #. 6.2->settings-schema.json->app-rules->columns->title
-msgid "Open Effect"
-msgstr "Efeito de Abertura"
+msgid "Open"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->columns->title
-msgid "Close Effect"
-msgstr "Efeito de Fechamento"
+msgid "Close"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Minimize"
+msgstr ""
+
+#. 6.2->settings-schema.json->app-rules->columns->title
+msgid "Unminimize"
+msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->columns->title
 msgid "Application"
@@ -336,9 +491,47 @@ msgstr ""
 "Foque uma janela para a qual pretende ativar a configuração específica da "
 "aplicação, volte aqui e pressione este botão."
 
-#. 6.2->settings-schema.json->random-title->description
-msgid "Effect"
-msgstr "Efeito"
+#. 6.2->settings-schema.json->random-include->description
+#, fuzzy
+msgid "Effects included in the randomized sets"
+msgstr "Efeitos incluídos no grupo randomizado:"
+
+#. 6.2->settings-schema.json->random-include->tooltip
+msgid ""
+"Defines which effects are included in the randomized sets for each window "
+"event type. When 'Randomized' is selected for any event on the General tab "
+"these sets are used."
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "Effect Name         "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "      Open        "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "      Close       "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "     Minimize     "
+msgstr ""
+
+#. 6.2->settings-schema.json->random-include->columns->title
+msgid "    Unminimize    "
+msgstr ""
+
+#. 6.2->settings-schema.json->effect-selector->options
+#. 6.2->settings-schema.json->open-window-effect->options
+#. 6.2->settings-schema.json->close-window-effect->options
+#. 6.2->settings-schema.json->dialog-open-effect->options
+#. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
+msgid "Magic Lamp"
+msgstr ""
 
 #. 6.2->settings-schema.json->effect-selector->description
 msgid "Show settings for effect:"
@@ -348,6 +541,8 @@ msgstr "Mostrar definições para o efeito:"
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 msgid "Randomized"
 msgstr "Randomizado"
 
@@ -355,6 +550,8 @@ msgstr "Randomizado"
 #. 6.2->settings-schema.json->close-window-effect->options
 #. 6.2->settings-schema.json->dialog-open-effect->options
 #. 6.2->settings-schema.json->dialog-close-effect->options
+#. 6.2->settings-schema.json->minimize-effect->options
+#. 6.2->settings-schema.json->unminimize-effect->options
 msgid "None"
 msgstr "Nenhum"
 
@@ -387,6 +584,16 @@ msgstr "Efeito de abertura da janela"
 msgid "Close dialog window effect"
 msgstr "Efeito de fechamento da janela"
 
+#. 6.2->settings-schema.json->minimize-effect->description
+#, fuzzy
+msgid "Minimize window effect"
+msgstr "Efeito de abertura da janela"
+
+#. 6.2->settings-schema.json->unminimize-effect->description
+#, fuzzy
+msgid "Unminimize window effect"
+msgstr "Efeito de abertura da janela"
+
 #. 6.2->settings-schema.json->apparition-shake-intensity->description
 msgid "Shake Intensity"
 msgstr "Intensidade da Agitação"
@@ -404,6 +611,7 @@ msgid "Randomness"
 msgstr "Aleatoriedade"
 
 #. 6.2->settings-schema.json->apparition-animation-time->description
+#. 6.2->settings-schema.json->aura-glow-animation-time->description
 #. 6.2->settings-schema.json->doom-animation-time->description
 #. 6.2->settings-schema.json->energize-a-animation-time->description
 #. 6.2->settings-schema.json->energize-b-animation-time->description
@@ -413,15 +621,53 @@ msgstr "Aleatoriedade"
 #. 6.2->settings-schema.json->glitch-animation-time->description
 #. 6.2->settings-schema.json->hexagon-animation-time->description
 #. 6.2->settings-schema.json->incinerate-animation-time->description
+#. 6.2->settings-schema.json->magiclamp-animation-time->description
+#. 6.2->settings-schema.json->mushroom-animation-time->description
 #. 6.2->settings-schema.json->pixelate-animation-time->description
 #. 6.2->settings-schema.json->pixel-wheel-animation-time->description
 #. 6.2->settings-schema.json->pixel-wipe-animation-time->description
 #. 6.2->settings-schema.json->portal-animation-time->description
+#. 6.2->settings-schema.json->rgbwarp-animation-time->description
+#. 6.2->settings-schema.json->team-rocket-animation-time->description
 #. 6.2->settings-schema.json->tv-animation-time->description
 #. 6.2->settings-schema.json->tv-glitch-animation-time->description
 #. 6.2->settings-schema.json->wisps-animation-time->description
 msgid "Effect Duration (milliseconds)"
 msgstr "Duração do Efeito (milissegundos)"
+
+#. 6.2->settings-schema.json->aura-glow-random-color->description
+#, fuzzy
+msgid "Random Color"
+msgstr "Cor da Linha"
+
+#. 6.2->settings-schema.json->aura-glow-start-hue->description
+msgid "Start Hue"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-speed->description
+#. 6.2->settings-schema.json->glitch-speed->description
+#. 6.2->settings-schema.json->tv-glitch-speed->description
+msgid "Speed"
+msgstr "Velocidade"
+
+#. 6.2->settings-schema.json->aura-glow-saturation->description
+#, fuzzy
+msgid "Saturation"
+msgstr "Aparição"
+
+#. 6.2->settings-schema.json->aura-glow-edge-size->description
+#, fuzzy
+msgid "Edge Size"
+msgstr "Tamanho do Pixel"
+
+#. 6.2->settings-schema.json->aura-glow-edge-hardness->description
+msgid "Edge Hardness"
+msgstr ""
+
+#. 6.2->settings-schema.json->aura-glow-blur->description
+#. 6.2->settings-schema.json->focus-blur-amount->description
+msgid "Blur Amount"
+msgstr ""
 
 #. 6.2->settings-schema.json->doom-horizontal-scale->description
 msgid "Horizontal Scale"
@@ -440,7 +686,7 @@ msgstr "Tamanho do Pixel"
 
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
-#. 6.2->settings-schema.json->fire-scale->description
+#. 6.2->settings-schema.json->fire-custom-scale->description
 #. 6.2->settings-schema.json->glide-scale->description
 #. 6.2->settings-schema.json->glitch-scale->description
 #. 6.2->settings-schema.json->hexagon-scale->description
@@ -460,7 +706,16 @@ msgstr "Escala"
 msgid "Color"
 msgstr "Cor"
 
-#. 6.2->settings-schema.json->fire-movement-speed->description
+#. 6.2->settings-schema.json->fire-presets->options
+#. 6.2->settings-schema.json->mushroom-presets->options
+msgid "Custom"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-presets->description
+msgid "Fire preset"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-custom-movement-speed->description
 msgid "Fire Movement Speed"
 msgstr ""
 
@@ -472,34 +727,10 @@ msgstr ""
 msgid "Creates a more dynamic fire but requires more GPU power."
 msgstr ""
 
-#. 6.2->settings-schema.json->fire-color-1->description
-#. 6.2->settings-schema.json->wisps-color-1->description
-msgid "Color #1"
-msgstr "Cor #1"
-
-#. 6.2->settings-schema.json->fire-color-2->description
-#. 6.2->settings-schema.json->wisps-color-2->description
-msgid "Color #2"
-msgstr "Cor #2"
-
-#. 6.2->settings-schema.json->fire-color-3->description
-#. 6.2->settings-schema.json->wisps-color-3->description
-msgid "Color #3"
-msgstr "Cor #3"
-
-#. 6.2->settings-schema.json->fire-color-4->description
+#. 6.2->settings-schema.json->fire-colors->description
 #, fuzzy
-msgid "Color #4"
+msgid "Colors 1-5"
 msgstr "Cor #1"
-
-#. 6.2->settings-schema.json->fire-color-5->description
-#, fuzzy
-msgid "Color #5"
-msgstr "Cor #1"
-
-#. 6.2->settings-schema.json->focus-blur-amount->description
-msgid "Blur Amount"
-msgstr ""
 
 #. 6.2->settings-schema.json->focus-blur-quality->description
 msgid "Blur Quality"
@@ -527,11 +758,6 @@ msgstr "Desvio"
 #. 6.2->settings-schema.json->tv-glitch-strength->description
 msgid "Strength"
 msgstr "Força"
-
-#. 6.2->settings-schema.json->glitch-speed->description
-#. 6.2->settings-schema.json->tv-glitch-speed->description
-msgid "Speed"
-msgstr "Velocidade"
 
 #. 6.2->settings-schema.json->hexagon-line-width->description
 msgid "Mesh Line Width"
@@ -565,6 +791,101 @@ msgstr "Iniciar a Partir do Ponteiro"
 msgid "If disabled, a random location will be chosen."
 msgstr "Caso desativado, uma localização aleatória será escolhida."
 
+#. 6.2->settings-schema.json->magiclamp-effect->options
+#, fuzzy
+msgid "default"
+msgstr "Fogo Padrão"
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "sine"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+#, fuzzy
+msgid "random"
+msgstr "Randomizado"
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "Minimize: Default - Unminimize: Sine"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->options
+msgid "Minimize: Sine - Unminimize: Default"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-effect->description
+#, fuzzy
+msgid "The type of effect"
+msgstr "Efeito de abertura da janela"
+
+#. 6.2->settings-schema.json->magiclamp-effect->tooltip
+msgid ""
+"Using 'default' will result in a curved effect where using 'sine' will "
+"result in a more wavy effect"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-x-tiles->description
+msgid "X Tiles"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-x-tiles->tooltip
+msgid "This effects the quality and the cost of the animation"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-y-tiles->description
+msgid "Y Tiles"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-y-tiles->tooltip
+msgid "This effects the quality and the costs of the animation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-presets->description
+msgid "Mushroom preset"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-scale-style->description
+#, fuzzy
+msgid "Scale Style"
+msgstr "Escala"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-count->description
+#, fuzzy
+msgid "Spark Count"
+msgstr "Contagem de Raios"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-color->description
+#, fuzzy
+msgid "Spark Color"
+msgstr "Cor"
+
+#. 6.2->settings-schema.json->mushroom-custom-spark-rotation->description
+msgid "Spark Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-rays-color->description
+#, fuzzy
+msgid "Rays Color"
+msgstr "Cor"
+
+#. 6.2->settings-schema.json->mushroom-custom-ring-count->description
+#, fuzzy
+msgid "Star Rings Count"
+msgstr "O Pai Natal está Vindo"
+
+#. 6.2->settings-schema.json->mushroom-custom-ring-rotation->description
+msgid "Star Ring Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-custom-star-count->description
+msgid "Stars Count Per Ring"
+msgstr ""
+
+#. 6.2->settings-schema.json->mushroom-star-colors->description
+#, fuzzy
+msgid "Colors 1-6"
+msgstr "Cor #1"
+
 #. 6.2->settings-schema.json->pixelate-noise->description
 msgid "Noise"
 msgstr "Ruído"
@@ -584,3 +905,62 @@ msgstr "Girando"
 #. 6.2->settings-schema.json->portal-details->description
 msgid "Details"
 msgstr "Detalhes"
+
+#. 6.2->settings-schema.json->rgbwarp-brightness->description
+msgid "Brightness"
+msgstr ""
+
+#. 6.2->settings-schema.json->rgbwarp-speed-r->description
+#, fuzzy
+msgid "Red Speed"
+msgstr "Velocidade"
+
+#. 6.2->settings-schema.json->rgbwarp-speed-g->description
+#, fuzzy
+msgid "Green Speed"
+msgstr "Velocidade"
+
+#. 6.2->settings-schema.json->rgbwarp-speed-b->description
+#, fuzzy
+msgid "Blue Speed"
+msgstr "Velocidade"
+
+#. 6.2->settings-schema.json->team-rocket-animation-split->description
+msgid "Animation Split"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-horizontal-sparkle-
+#. position->description
+#, fuzzy
+msgid "Horizontal Sparkle Position"
+msgstr "Escala Horizontal"
+
+#. 6.2->settings-schema.json->team-rocket-vertical-sparkle-
+#. position->description
+#, fuzzy
+msgid "Vertical Sparkle Position"
+msgstr "Escala  Vertical"
+
+#. 6.2->settings-schema.json->team-rocket-window-rotation->description
+msgid "Rotate Window"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-sparkle-rot->description
+msgid "Sparkle Rotation"
+msgstr ""
+
+#. 6.2->settings-schema.json->team-rocket-sparkle-size->description
+msgid "Sparkle Size"
+msgstr ""
+
+#. 6.2->settings-schema.json->wisps-color-1->description
+msgid "Color #1"
+msgstr "Cor #1"
+
+#. 6.2->settings-schema.json->wisps-color-2->description
+msgid "Color #2"
+msgstr "Cor #2"
+
+#. 6.2->settings-schema.json->wisps-color-3->description
+msgid "Color #3"
+msgstr "Cor #3"

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/resources/shaders/aura-glow.frag
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/resources/shaders/aura-glow.frag
@@ -1,0 +1,117 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//          )                                                   (                       //
+//       ( /(   (  (               )    (       (  (  (         )\ )    (  (            //
+//       )\()) ))\ )(   (         (     )\ )    )\))( )\  (    (()/( (  )\))(  (        //
+//      ((_)\ /((_|()\  )\ )      )\  '(()/(   ((_)()((_) )\ )  ((_)))\((_)()\ )\       //
+//      | |(_|_))( ((_)_(_/(    _((_))  )(_))  _(()((_|_)_(_/(  _| |((_)(()((_|(_)      //
+//      | '_ \ || | '_| ' \))  | '  \()| || |  \ V  V / | ' \)) _` / _ \ V  V (_-<      //
+//      |_.__/\_,_|_| |_||_|   |_|_|_|  \_, |   \_/\_/|_|_||_|\__,_\___/\_/\_//__/      //
+//                                 |__/                                                 //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Justin Garza <JGarza9788@gmail.com>
+// SPDX-FileCopyrightText: Simon Schneegans <code@simonschneegans.de>
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// The content from common.glsl is automatically prepended to each shader effect. This
+// provides the standard input:
+
+// vec2  iTexCoord:     Texture coordinates for retrieving the window input color.
+// bool  uIsFullscreen: True if the window is maximized or in fullscreen mode.
+// bool  uForOpening:   True if a window-open animation is ongoing, false otherwise.
+// float uProgress:     A value which transitions from 0 to 1 during the animation.
+// float uDuration:     The duration of the current animation in seconds.
+// vec2  uSize:         The size of uTexture in pixels.
+// float uPadding:      The empty area around the actual window (e.g. where the shadow
+//                      is drawn). For now, this will only be set on GNOME.
+
+// Furthermore, there are two global methods for reading the window input color and
+// setting the shader output color. Both methods assume straight alpha:
+
+// vec4 getInputColor(vec2 coords)
+// void setOutputColor(vec4 outColor)
+
+uniform float uSpeed;
+uniform bool uRandomColor;
+uniform float uStartHue;
+uniform float uSaturation;
+uniform float uBlur;
+uniform vec2 uSeed;
+uniform float uEdgeSize;
+uniform float uEdgeHardness;
+
+void main() {
+
+  // We simply inverse the progress for opening windows.
+  float progress = uForOpening ? uProgress : 1.0 - uProgress;
+
+  // Map UV to window content (without the shadow padding).
+  vec2 uv = (iTexCoord.st - 0.5) * uSize / (vec2(1.0) - vec2(uPadding * 2.0) / uSize);
+  uv      = uv / uSize + 0.5;
+
+  // We want the shapes of the masks at the end of the animation to have a 1:1 aspect
+  // ratio. For this, we scale the UV coordinates based on the aspect ratio of the window
+  // and later blend between the original UV and the 1:1 UV based on the progress.
+  vec2 oneToOneUV = uv;
+  oneToOneUV -= 0.5;
+
+  if (uSize.x > uSize.y) {
+    oneToOneUV.y *= uSize.y / uSize.x;
+  } else {
+    oneToOneUV.x *= uSize.x / uSize.y;
+  }
+
+  oneToOneUV += 0.5;
+
+  uv = mix(oneToOneUV, uv, progress);
+
+  // This blends between a square-shaped gradient towards the window edges and a circular
+  // gradient.
+  float shape    = mix(2.0, 100.0, pow(progress, 5.0));
+  float gradient = pow(abs(uv.x - 0.5) * 2.0, shape) + pow(abs(uv.y - 0.5) * 2.0, shape);
+  gradient += simplex2D((iTexCoord + uSeed)) * 0.5;
+
+  // This mask is used for the color overlay.
+  float glowMask = (progress - gradient) / (uEdgeSize + 0.1);
+  glowMask       = 1.0 - clamp(glowMask, 0.0, 1.0);
+
+  // Quickly fade out the glow mask at the end of the animation.
+  glowMask *= easeOutSine(min(1.0, (1.0 - progress) * 4.0));
+
+  // Get the color from the window texture. We gradually blur the input color based on
+  // the progress of the animation. We also slightly scale the UV coordinates to make
+  // the window scale up during the animation.
+  vec2 windowUV = (iTexCoord.st - 0.5) * mix(1.1, 1.0, easeOutCubic(progress)) + 0.5;
+  vec4 windowColor;
+  if (uBlur > 0.0) {
+    windowColor = getBlurredInputColor(windowUV, (1.0 - progress) * uBlur, 3.0);
+  } else {
+    windowColor = getInputColor(windowUV);
+  }
+  glowMask *= windowColor.a;
+
+  vec3 glowColor    = cos(progress * uSpeed + uv.xyx + vec3(0, 2, 4)).xyz;
+  float colorOffset = (uRandomColor) ? hash12(uSeed) : uStartHue;
+  glowColor         = offsetHue(glowColor, colorOffset + 0.1);
+  glowColor         = clamp(glowColor * uSaturation, vec3(0.0), vec3(1.0));
+
+  windowColor.rgb += glowColor * glowMask;
+
+  // To make this look better on light themes, we also add some color non-additively.
+  windowColor = alphaOver(windowColor, vec4(glowColor, glowMask * 0.2));
+
+  // A mask which will crop the window gradually into a circle.
+  float softCrop = 1.0 - smoothstep(progress - 0.5, progress + 0.5, gradient);
+  float hardCrop = 1.0 - smoothstep(progress - 0.05, progress + 0.05, gradient);
+  float cropMask = mix(softCrop, hardCrop, uEdgeHardness);
+
+  // Quickly fade in the alpha mask at the beginning of the animation.
+  cropMask *= easeInSine(min(1.0, progress * 2.0));
+
+  // Quickly fade out the alpha mask at the end of the animation.
+  cropMask = max(cropMask, 1.0 - easeOutSine(min(1.0, (1.0 - progress) * 4.0)));
+
+  windowColor.a *= cropMask;
+
+  setOutputColor(windowColor);
+}

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/resources/shaders/common.glsl
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/resources/shaders/common.glsl
@@ -42,6 +42,10 @@ uniform float uDuration;
 
 #if defined(KWIN)  // --------------------------------------------------------------------
 
+#if defined(PLASMA6)
+#include "colormanagement.glsl"
+#endif
+
 uniform sampler2D sampler;
 uniform int textureWidth;
 uniform int textureHeight;
@@ -74,9 +78,18 @@ void setOutputColor(vec4 outColor) {
   }
 
   fragColor = vec4(outColor.rgb * outColor.a, outColor.a);
+
+#if defined(PLASMA6)
+  fragColor = sourceEncodingToNitsInDestinationColorspace(fragColor);
+  fragColor = nitsToDestinationEncoding(fragColor);
+#endif
 }
 
 #elif defined(KWIN_LEGACY)  // -----------------------------------------------------------
+
+#if defined(PLASMA6)
+#include "colormanagement.glsl"
+#endif
 
 uniform sampler2D sampler;
 uniform int textureWidth;
@@ -108,6 +121,11 @@ void setOutputColor(vec4 outColor) {
   }
 
   gl_FragColor = vec4(outColor.rgb * outColor.a, outColor.a);
+
+#if defined(PLASMA6)
+  fragColor = sourceEncodingToNitsInDestinationColorspace(fragColor);
+  fragColor = nitsToDestinationEncoding(fragColor);
+#endif
 }
 
 #else  // GNOME --------------------------------------------------------------------------
@@ -134,6 +152,35 @@ vec4 getInputColor(vec2 coords) {
 void setOutputColor(vec4 outColor) { cogl_color_out = outColor; }
 
 #endif  // -------------------------------------------------------------------------------
+
+// A simple blur function
+vec4 getBlurredInputColor(vec2 uv, float radius, float samples) {
+  // Initialize the color accumulator to zero.
+  vec4 color = vec4(0.0);
+
+  // Define a constant for 2 * PI (tau), which represents a full circle in radians.
+  const float tau = 6.28318530718;
+
+  // Number of directions for sampling around the circle.
+  const float directions = 15.0;
+
+  // Outer loop iterates over multiple directions evenly spaced around a circle.
+  for (float d = 0.0; d < tau; d += tau / directions) {
+    // Inner loop samples along each direction, with decreasing intensity.
+    for (float s = 0.0; s < 1.0; s += 1.0 / samples) {
+      // Calculate the offset for this sample based on direction, radius, and step.
+      // The (1.0 - s) term ensures more sampling occurs closer to the center.
+      vec2 offset = vec2(cos(d), sin(d)) * radius * (1.0 - s) / uSize;
+
+      // Add the sampled color at the offset position to the accumulator.
+      color += getInputColor(uv + offset);
+    }
+  }
+
+  // Normalize the accumulated color by dividing by the total number of samples
+  // and directions to ensure the result is averaged.
+  return color / samples / directions;
+}
 
 // ----------------------------------------------------------------- compositing operators
 
@@ -167,6 +214,54 @@ vec3 darken(vec3 color, float fac) { return color * (1.0 - fac); }
 // color will be white.
 vec3 lighten(vec3 color, float fac) { return color + (vec3(1.0) - color) * fac; }
 
+// change the color based on an offset amount
+vec3 offsetHue(vec3 color, float hueOffset) {
+  // Convert RGB to HSV
+  float maxC  = max(max(color.r, color.g), color.b);
+  float minC  = min(min(color.r, color.g), color.b);
+  float delta = maxC - minC;
+
+  float hue = 0.0;
+  if (delta > 0.0) {
+    if (maxC == color.r) {
+      hue = mod((color.g - color.b) / delta, 6.0);
+    } else if (maxC == color.g) {
+      hue = (color.b - color.r) / delta + 2.0;
+    } else {
+      hue = (color.r - color.g) / delta + 4.0;
+    }
+  }
+  hue /= 6.0;
+
+  float saturation = (maxC > 0.0) ? (delta / maxC) : 0.0;
+  float value      = maxC;
+
+  // Offset the hue
+  hue = mod(hue + hueOffset, 1.0);
+
+  // Convert HSV back to RGB
+  float c = value * saturation;
+  float x = c * (1.0 - abs(mod(hue * 6.0, 2.0) - 1.0));
+  float m = value - c;
+
+  vec3 rgb;
+  if (hue < 1.0 / 6.0) {
+    rgb = vec3(c, x, 0.0);
+  } else if (hue < 2.0 / 6.0) {
+    rgb = vec3(x, c, 0.0);
+  } else if (hue < 3.0 / 6.0) {
+    rgb = vec3(0.0, c, x);
+  } else if (hue < 4.0 / 6.0) {
+    rgb = vec3(0.0, x, c);
+  } else if (hue < 5.0 / 6.0) {
+    rgb = vec3(x, 0.0, c);
+  } else {
+    rgb = vec3(c, 0.0, x);
+  }
+
+  return rgb + m;
+}
+
 // ---------------------------------------------------------------------- easing functions
 
 // Here are some basic easing function. More can be added if required!
@@ -182,6 +277,121 @@ float easeInBack(float x, float e) { return x * x * ((e + 1.0) * x - e); }
 float easeOutBack(float x, float e) {
   float p = x - 1.0;
   return p * p * ((e + 1.0) * p + e) + 1.0;
+}
+
+// https://easings.net/
+/*
+Easing functions define the rate of change of a parameter over time, commonly used in
+animations, UI transitions, and game development. They provide a way to make movements
+more natural or visually appealing rather than linear and mechanical. Popular categories
+of easing functions include:
+
+Linear: Constant speed from start to finish.
+Quadratic (Ease In, Ease Out, Ease In Out): Changes at varying rates, with smoother starts
+or stops. Cubic: Similar to quadratic but allows for even more nuanced transitions.
+Exponential: Drastic changes at the start or end, often used for dramatic effects.
+Bounce: Mimics a bouncing object with oscillations.
+Elastic: Simulates the behavior of a spring, with overshooting and oscillations.
+Below are text-based "graphs" of some easing functions, where the horizontal axis
+represents time and the vertical axis represents progress.
+*/
+
+// Quadratic Easing
+// Smooth acceleration and deceleration using quadratic (t^2) curves.
+
+float easeInOutQuad(float t) {
+  // Accelerates for the first half, decelerates for the second half.
+  return t < 0.5 ? 2.0 * t * t : -1.0 + (4.0 - 2.0 * t) * t;
+}
+
+// Cubic Easing
+// Smoother transitions compared to quadratic easing using cubic (t^3) curves.
+
+float easeInCubic(float t) {
+  // Starts slow and accelerates as t increases.
+  return t * t * t;
+}
+
+float easeOutCubic(float t) {
+  // Starts fast and decelerates as t approaches 1.0.
+  float f = t - 1.0;
+  return f * f * f + 1.0;
+}
+
+float easeInOutCubic(float t) {
+  // Combines easeIn and easeOut cubic behavior for smooth transitions.
+  return t < 0.5 ? 4.0 * t * t * t : (t - 1.0) * (2.0 * t - 2.0) * (2.0 * t - 2.0) + 1.0;
+}
+
+// Quartic Easing
+// Even smoother transitions than cubic, using quartic (t^4) curves.
+
+float easeInQuart(float t) {
+  // Starts very slow and accelerates steeply.
+  return t * t * t * t;
+}
+
+float easeOutQuart(float t) {
+  // Starts steeply and slows down dramatically.
+  float f = t - 1.0;
+  return 1.0 - f * f * f * f;
+}
+
+float easeInOutQuart(float t) {
+  // Combines easeIn and easeOut quartic behavior for very smooth transitions.
+  return t < 0.5 ? 8.0 * t * t * t * t
+                 : 1.0 - 8.0 * (t - 1.0) * (t - 1.0) * (t - 1.0) * (t - 1.0);
+}
+
+// Sine Easing
+// Smooth, wave-like acceleration and deceleration using sine curves.
+
+float easeInSine(float t) {
+  // Starts very slow, following a sine wave curve.
+  return 1.0 - cos((t * 3.141592653589793) / 2.0);
+}
+
+float easeOutSine(float t) {
+  // Starts fast and slows down following a sine wave curve.
+  return sin((t * 3.141592653589793) / 2.0);
+}
+
+float easeInOutSine(float t) {
+  // Smooth start and end, mimicking half a sine wave.
+  return -0.5 * (cos(3.141592653589793 * t) - 1.0);
+}
+
+// Exponential Easing
+// Sharp transitions with rapid acceleration and deceleration.
+
+float easeInExpo(float t) {
+  // Very slow start, accelerates exponentially.
+  return t == 0.0 ? 0.0 : pow(2.0, 10.0 * (t - 1.0));
+}
+
+float easeOutExpo(float t) {
+  // Starts fast and slows down exponentially.
+  return t == 1.0 ? 1.0 : 1.0 - pow(2.0, -10.0 * t);
+}
+
+float easeInOutExpo(float t) {
+  // Combines easeIn and easeOut exponential for sharp transitions.
+  if (t == 0.0) return 0.0;
+  if (t == 1.0) return 1.0;
+  return t < 0.5 ? 0.5 * pow(2.0, 20.0 * t - 10.0)
+                 : 1.0 - 0.5 * pow(2.0, -20.0 * t + 10.0);
+}
+
+// Back Easing
+// Creates an overshooting effect for more dynamic animations.
+
+float easeInOutBack(float t) {
+  // Uses constants to define the overshooting magnitude.
+  const float c1 = 1.70158;
+  const float c2 = c1 * 1.525;
+  return t < 0.5
+           ? (pow(2.0 * t, 2.0) * ((c2 + 1.0) * 2.0 * t - c2)) / 2.0
+           : (pow(2.0 * t - 2.0, 2.0) * ((c2 + 1.0) * (t * 2.0 - 2.0) + c2) + 2.0) / 2.0;
 }
 
 // --------------------------------------------------------------------- edge mask helpers
@@ -207,7 +417,7 @@ float getEdgeMask(vec2 uv, vec2 maxUV, float fadeWidth) {
 // the fade zone is given in pixels. This uses the standard uniforms uSize and uPadding.
 // This means that the fading zone is not actually at the actors boundaries but at the
 // position of the window border in the texture.
-// The offset paramter controls whether the fading is placed inside the window borders
+// The offset parameter controls whether the fading is placed inside the window borders
 // (offset = 0), ontop the window borders (offset = 0.5) or outside the window borders
 // (offset = 1).
 float getAbsoluteEdgeMask(float fadePixels, float offset) {
@@ -249,6 +459,12 @@ float getWinding(vec2 a, vec2 b) { return cross(vec3(a, 0.0), vec3(b, 0.0)).z; }
 // Rotates the given 2D vector a clockwise by the angle alpha (given in radians).
 vec2 rotate(vec2 a, float angle) {
   return vec2(a.x * cos(angle) - a.y * sin(angle), a.x * sin(angle) + a.y * cos(angle));
+}
+
+// rotates a given 2d vector, around a given center (angle is in radians)
+vec2 rotate(vec2 a, float angle, vec2 center) {
+  return vec2(cos(angle) * (a.x - center.x) + sin(angle) * (a.y - center.y) + center.x,
+              cos(angle) * (a.y - center.y) - sin(angle) * (a.x - center.x) + center.y);
 }
 
 // --------------------------------------------------------------------------------- noise
@@ -451,4 +667,56 @@ float simplex3DFractal(vec3 m) {
 
   return 0.5333333 * simplex3D(m * rot1) + 0.2666667 * simplex3D(2.0 * m * rot2) +
          0.1333333 * simplex3D(4.0 * m * rot3) + 0.0666667 * simplex3D(8.0 * m);
+}
+
+// --------------------------------------------------------------------------------- remap
+
+/*
+These functions remap a given value from one range to another.
+The remap operation is particularly useful in shader programming
+to scale or normalize data, ensuring compatibility across various
+input ranges. Each version of the remap function supports a
+different data type:
+
+1. float: Remap a single scalar value.
+2. vec2: Remap a 2D vector.
+3. vec3: Remap a 3D vector.
+4. vec4: Remap a 4D vector.
+
+The general formula used is:
+    newMin + (value - oldMin) * (newMax - newMin) / (oldMax - oldMin)
+
+This ensures a linear transformation from the old range to the new range.
+*/
+
+// Remap for float
+// Maps a float value from one range [oldMin, oldMax] to another range [newMin, newMax].
+// This is useful for normalizing or scaling scalar values to fit within a desired range.
+float remap(float value, float oldMin, float oldMax, float newMin, float newMax) {
+  return clamp(newMin + (value - oldMin) * (newMax - newMin) / (oldMax - oldMin), newMin,
+               newMax);
+}
+
+// Remap for vec2
+// Maps a 2D vector (vec2) from one range [oldMin, oldMax] to another range [newMin,
+// newMax]. Each component of the vec2 is individually scaled and transformed.
+vec2 remap(vec2 value, vec2 oldMin, vec2 oldMax, vec2 newMin, vec2 newMax) {
+  return clamp(newMin + (value - oldMin) * (newMax - newMin) / (oldMax - oldMin), newMin,
+               newMax);
+}
+
+// Remap for vec3
+// Maps a 3D vector (vec3) from one range [oldMin, oldMax] to another range [newMin,
+// newMax]. Each component of the vec3 is individually scaled and transformed.
+vec3 remap(vec3 value, vec3 oldMin, vec3 oldMax, vec3 newMin, vec3 newMax) {
+  return clamp(newMin + (value - oldMin) * (newMax - newMin) / (oldMax - oldMin), newMin,
+               newMax);
+}
+
+// Remap for vec4
+// Maps a 4D vector (vec4) from one range [oldMin, oldMax] to another range [newMin,
+// newMax]. Each component of the vec4 is individually scaled and transformed.
+vec4 remap(vec4 value, vec4 oldMin, vec4 oldMax, vec4 newMin, vec4 newMax) {
+  return clamp(newMin + (value - oldMin) * (newMax - newMin) / (oldMax - oldMin), newMin,
+               newMax);
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/resources/shaders/mushroom.frag
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/resources/shaders/mushroom.frag
@@ -1,0 +1,403 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//          )                                                   (                       //
+//       ( /(   (  (               )    (       (  (  (         )\ )    (  (            //
+//       )\()) ))\ )(   (         (     )\ )    )\))( )\  (    (()/( (  )\))(  (        //
+//      ((_)\ /((_|()\  )\ )      )\  '(()/(   ((_)()((_) )\ )  ((_)))\((_)()\ )\       //
+//      | |(_|_))( ((_)_(_/(    _((_))  )(_))  _(()((_|_)_(_/(  _| |((_)(()((_|(_)      //
+//      | '_ \ || | '_| ' \))  | '  \()| || |  \ V  V / | ' \)) _` / _ \ V  V (_-<      //
+//      |_.__/\_,_|_| |_||_|   |_|_|_|  \_, |   \_/\_/|_|_||_|\__,_\___/\_/\_//__/      //
+//                                 |__/                                                 //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Justin Garza JGarza9788@gmail.com
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// The content from common.glsl is automatically prepended to each shader effect. This
+// provides the standard input:
+
+// vec2  iTexCoord:     Texture coordinates for retrieving the window input color.
+// bool  uIsFullscreen: True if the window is maximized or in fullscreen mode.
+// bool  uForOpening:   True if a window-open animation is ongoing, false otherwise.
+// float uProgress:     A value which transitions from 0 to 1 during the animation.
+// float uDuration:     The duration of the current animation in seconds.
+// vec2  uSize:         The size of uTexture in pixels.
+// float uPadding:      The empty area around the actual window (e.g. where the shadow
+//                      is drawn). For now, this will only be set on GNOME.
+
+// Furthermore, there are two global methods for reading the window input color and
+// setting the shader output color. Both methods assume straight alpha:
+
+// vec4 getInputColor(vec2 coords)
+// void setOutputColor(vec4 outColor)
+
+// The width of the fading effect is loaded from the settings.
+
+// use 8BitStyle or not (sliding scale)
+uniform float uScaleStyle;
+
+// these are for the sparks
+uniform float uSparkCount;
+uniform vec4 uSparkColor;
+uniform float uSparkRotation;
+
+// these are for the Rays
+uniform vec4 uRaysColor;
+
+// these are for the stars
+uniform float uRingCount;
+uniform float uRingRotation;
+uniform float uStarCount;
+
+// and the colors they change over time
+uniform vec4 uStarColor0;
+uniform vec4 uStarColor1;
+uniform vec4 uStarColor2;
+uniform vec4 uStarColor3;
+uniform vec4 uStarColor4;
+uniform vec4 uStarColor5;
+
+// seed
+uniform vec2 uSeed;
+
+// helps to find the angle
+vec3 getPosByAngle(float angle) { return vec3(cos(angle), sin(angle), 0); }
+
+// gets the mask of a Star
+float getStar(vec2 uv, vec2 center, float npoints, float radiusRatio, float size,
+              float rotation) {
+
+  float radiusMax = 1.0;
+  float radiusMin = radiusMax * radiusRatio;
+
+  float PI        = 3.1415926;
+  float starangle = 2.0 * PI / npoints;  // Angle between points on the star
+
+  // Offset rotation to ensure one point is always up when rotation = 0
+  rotation += PI / 2.0 - starangle / 1.0;
+
+  // Define the positions for the outer and inner points of the star's initial angle,
+  // rotated by `rotation`
+  vec3 p0 =
+    (radiusMax * size) * getPosByAngle(rotation);  // Outer point, rotated by `rotation`
+  vec3 p1 = (radiusMin * size) *
+            getPosByAngle(starangle + rotation);  // Inner point, also rotated
+
+  // Calculate the position of the current fragment relative to the star's center
+  vec2 curPosuv =
+    (uv - center);  // Center UV coordinates, then scale to fit the star size
+  float curRadius = length(curPosuv);  // Radius from center, no need to scale further
+  float curPosAngle =
+    atan(curPosuv.y, curPosuv.x) - rotation;  // Calculate angle and adjust by `rotation`
+
+  // Determine the fractional position within the current star segment
+  float a =
+    fract(curPosAngle / starangle);  // Fractional angle position within one segment
+  if (a >= 0.5)
+    a = 1.0 - a;  // Ensure we are within the first half of the segment (symmetry)
+
+  // Calculate the current point on the star segment, applying rotation
+  a           = a * starangle;  // Actual angle for this position on the segment
+  vec3 curPos = curRadius * getPosByAngle(a + rotation);  // Final position, rotated
+
+  // Calculate directions for edge detection using cross product
+  vec3 dir0 = p1 - p0;      // Vector from outer to inner point
+  vec3 dir1 = curPos - p0;  // Vector from outer point to current position
+
+  // Use cross product to determine if `curPos` is inside the star's edge
+  return step(0.0,
+              cross(dir0, dir1).z);  // Returns 1.0 if inside, 0.0 if outside (solid edge)
+}
+
+// use to scale the window
+vec2 scaleUV(vec2 uv, vec2 scale) {
+  // Put texture coordinate origin to center of window.
+  uv = uv * 2.0 - 1.0;
+
+  // scale
+  uv /= mix(vec2(1.0, 1.0), vec2(0.0, 0.0), scale);
+
+  // scale from center
+  uv = uv * 0.5 + 0.5;
+
+  return uv;
+}
+
+// this returns the Spark
+float getSpark(vec2 uv, vec2 center, float brightness, float size, float rotation) {
+  brightness = clamp(brightness, 0.001, 1.0);
+  size       = clamp(size, 0.001, 1.0);
+  float bn   = mix(0.0, 0.07, brightness);  // recalculate size
+
+  uv = (uv + vec2(0.5));
+  uv = (uv - center);  // Center UV coordinates, then scale to fit the star size
+  uv = scaleUV(uv, vec2(1.0 - size));
+  uv = rotate(uv, rotation, vec2(0.5));  // rotate the UV
+
+  // this is basically the brightness
+  float p = mix(-1.0, 1000.0, easeInExpo(bn));
+
+  float m =
+    mix(0.0, 1.0,
+        clamp(pow(abs(uv.x - 0.5) * 2.0, p) + pow(abs(uv.y - 0.5) * 2.0, p), 0.0, 1.0));
+
+  float mask = easeInSine(1.0 - (m - bn)) - 0.004;
+  mask       = clamp(mask, 0.0, 1.0);
+
+  return mask;
+}
+
+// returns the star's color
+vec4 getStarColor(float v, float alpha) {
+  // Clamp v to ensure it's in [0.0, 1.0]
+  v = clamp(v, 0.0, 1.0);
+
+  // Define steps for color interpolation
+  float steps[6];
+  steps[0] = 0.0;
+  steps[1] = 0.1666;
+  steps[2] = 0.3332;
+  steps[3] = 0.4998;
+  steps[4] = 0.6664;
+  steps[5] = 0.8330;
+
+  // Define color values
+  vec4 colors[6];
+  colors[0] = uStarColor0;
+  colors[1] = uStarColor1;
+  colors[2] = uStarColor2;
+  colors[3] = uStarColor3;
+  colors[4] = uStarColor4;
+  colors[5] = uStarColor5;
+
+  // Assign alpha values
+  for (int i = 0; i < 6; ++i) {
+    colors[i].a = alpha * colors[i].a;
+  }
+
+  // Handle edge cases
+  if (v <= steps[0]) {
+    return colors[0];
+  }
+  if (v >= steps[5]) {
+    return colors[5];
+  }
+
+  // Find the correct interpolation segment
+  for (int i = 0; i < 5; ++i) {
+    if (v <= steps[i + 1]) {
+      float t = (v - steps[i]) / (steps[i + 1] - steps[i]);
+      return mix(colors[i], colors[i + 1], t);
+    }
+  }
+
+  // Fallback (should never be reached)
+  return vec4(0.0, 0.0, 0.0, 1.0);
+}
+
+// 1|    __________
+//  |   /          \
+//  |  /            \
+//  | /              \ 
+//  |/                \
+// 0|0.................1
+/*
+graph above ... where t is close to 0, or 1 the result will fade to zero
+i.e. this is just the function of power(x,p) shifted
+where x is time, and p is 2.0,4.0,8.0,10.0 ... or any positive even number
+*/
+float zeroStartEnd(float t, float max_size, float power) {
+  float s = -1.0 * pow((t - 0.5) / (0.5), power) + 1.0;
+  s       = clamp(s, 0.0, 1.0) * max_size;
+  return s;
+}
+
+// this gives us the jerky 8bit growth effect.
+float eightBitScale(float progress) {
+  float scale = 1.0;
+  if (progress <= 0.1) {
+    scale = 0.25;
+  } else if (progress <= 0.2) {
+    scale = 0.5;
+  } else if (progress <= 0.3) {
+    scale = 0.25;
+  } else if (progress <= 0.4) {
+    scale = 0.5;
+  } else if (progress <= 0.5) {
+    scale = 0.25;
+  } else if (progress <= 0.6) {
+    scale = 0.5;
+  } else if (progress <= 0.7) {
+    scale = 1.0;
+  } else if (progress <= 0.8) {
+    scale = 0.25;
+  } else if (progress <= 0.9) {
+    scale = 0.5;
+  }
+  return scale;
+}
+
+// gets all the sparks
+vec4 getSparks(float progress) {
+  // the UV for this function
+  float aspect = uSize.x / uSize.y;
+  vec2 uv      = iTexCoord.st * vec2(aspect, 1.0);
+
+  // this will be the result to return
+  vec4 result = vec4(0.0);
+
+  // 0 at the edges
+  float xEdge = -1.0 * pow((uv.x - (aspect * 0.5)) / (aspect * 0.5), 8.0) + 1.0;
+  xEdge       = clamp(xEdge, 0.0, 1.0);
+
+  // declare some variables before the loop
+  vec2 h  = vec2(0.0);
+  float y = 0.0;
+  float x = 0.0;
+
+  // loop for each spart
+  for (float xusp = 0.0; xusp < uSparkCount; ++xusp) {
+    // calculate some variables
+    h = hash21(xusp + uSeed.x);
+    y = mix(0.0 - h.y, 1.0 + (1.0 - h.y), progress);
+    y = clamp(y, 0.0, 1.0);
+
+    x = 0.66 * sin(h.x * 6.28);
+    x += 0.5 * aspect;
+
+    // here we get the mask for the spark
+    float a4ps = getSpark(uv, vec2(x, y),                          // position (x, y)
+                          zeroStartEnd(y, 1.0, 4.0) * xEdge,       // Brightness
+                          zeroStartEnd(y, 0.5, 4.0) * xEdge,       // Size
+                          progress * 6.28 * float(uSparkRotation)  // rotation
+    );
+
+    // set it to the results
+    result = alphaOver(
+      result, vec4(uSparkColor.r, uSparkColor.g, uSparkColor.b, uSparkColor.a * a4ps));
+  }
+
+  // and we are returning the result
+  return result;
+}
+
+// gets the Rays
+vec4 getRays(float progress) {
+  // create the UV for it
+  vec2 rayUV = iTexCoord.st;
+  rayUV *= vec2(10.0, 0.5);
+  rayUV.y += progress * -1.0;
+  rayUV.x += uSeed.y;
+
+  // gets the ray
+  float ray = simplex2D(rayUV);
+  // 0 around the edges
+  ray *= zeroStartEnd(iTexCoord.t, 1.0, 8.0);
+  ray *= zeroStartEnd(iTexCoord.s, 1.0, 8.0);
+  // 0 at the begining and end of the animation
+  ray *= zeroStartEnd(progress, 1.0, 8.0);
+
+  // adjust the numbers and clamp
+  ray = remap(ray * 1.10, 0.0, 1.0, -5.0, 1.0);
+
+  float alpha = clamp(uRaysColor.a * ray, 0.0, 1.0);
+
+  // return
+  return vec4(uRaysColor.r, uRaysColor.g, uRaysColor.b, alpha);
+}
+
+// returns the stars
+vec4 getStars(vec2 starUV, float aspect, float progress, float oColorAlpha) {
+  // this will be the result to return
+  vec4 result = vec4(0.0);
+
+  vec2 h  = vec2(0.0);
+  float y = 0.0;
+
+  // for each ring
+  for (float r = 0.0; r < uRingCount; ++r) {
+
+    float spread = r * (1.0 / uRingCount);
+    y            = mix(0.0 - spread, 1.0 + (1.0 - spread), 1.0 - progress);
+    y            = clamp(y, 0.00001, 0.99999);
+
+    // each star in each ring
+    for (float s = 0.0; s < uStarCount; ++s) {
+
+      // this returns a Star
+
+      float a5ps =
+        getStar(starUV,
+                vec2(sin(progress * uRingRotation * 6.28 + (s * (6.28 / uStarCount))) *
+                       aspect * 0.33,
+                     y),                    // position (x, y)
+                5.0,                        // nPoints
+                0.5,                        // radiusRatio
+                zeroStartEnd(y, 0.1, 2.0),  // Size
+                0.0                         // rotation
+        );
+      a5ps = clamp(a5ps, 0.0, 1.0);
+
+      // //put the star in back or the front of the window
+      float depth = cos(progress * uRingRotation * 6.28 + (s * (6.28 / uStarCount)));
+
+      // if we want the star behind or infront of the window
+
+      if (depth < 0.0) {
+        result = alphaOver(result, getStarColor(y, a5ps));
+      } else {
+        result = alphaOver(getStarColor(y, a5ps) * (1.0 - oColorAlpha), result);
+      }
+    }
+  }
+
+  // and we are returning the result
+  return result;
+}
+
+void main() {
+
+  // Calculate the animation progress, flipping direction if opening
+  // 'uProgress' varies from 0 to 1, depending on the animation phase
+  float progress = uForOpening ? 1.0 - uProgress : uProgress;
+
+  // Initialize the output color to fully transparent black
+  vec4 oColor = vec4(0.0, 0.0, 0.0, 0.0);
+
+  // get scales
+  float scale8bit = eightBitScale(progress);
+  vec2 scaleV2    = vec2(easeInOutSine(progress), easeInQuad(progress));
+
+  vec2 fscale = mix(vec2(scale8bit), scaleV2, uScaleStyle);
+
+  // Fetch the color based on the scaled texture coordinates
+  oColor = getInputColor(scaleUV(iTexCoord.st, fscale));
+
+  // Store the alpha value of the fetched color for later use
+  float oColorAlpha = oColor.a;
+
+  // Calculate the aspect ratio of the render area
+  float aspect = uSize.x / uSize.y;
+
+  // Transform UV coordinates for star effects
+  // starUV.x [-0.5 , 0.5]
+  // starUV.y [1.0 , 0.0]
+  vec2 starUV = vec2(iTexCoord.s - 0.5, 1.0 - iTexCoord.t) * vec2(aspect, 1.0);
+
+  // If four-point stars are enabled, overlay them on the current color
+  if (uSparkCount > 0.0) {
+    oColor = alphaOver(oColor, getSparks(progress));
+  }
+
+  // If rays are enabled, overlay them on the current color
+  if (uRaysColor.a > 0.0) {
+    oColor = alphaOver(oColor, getRays(progress));
+  }
+
+  // If five-point stars are enabled, overlay them using stored alpha
+  if (uRingCount > 0.0 && uStarCount > 0.0) {
+    oColor = alphaOver(oColor, getStars(starUV, aspect, progress, oColorAlpha));
+  }
+
+  // Set the final output color to the computed value
+  setOutputColor(oColor);
+}

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/resources/shaders/team-rocket.frag
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/resources/shaders/team-rocket.frag
@@ -1,0 +1,163 @@
+//////////////////////////////////////////////////////////////////////////////////////////
+//          )                                                   (                       //
+//       ( /(   (  (               )    (       (  (  (         )\ )    (  (            //
+//       )\()) ))\ )(   (         (     )\ )    )\))( )\  (    (()/( (  )\))(  (        //
+//      ((_)\ /((_|()\  )\ )      )\  '(()/(   ((_)()((_) )\ )  ((_)))\((_)()\ )\       //
+//      | |(_|_))( ((_)_(_/(    _((_))  )(_))  _(()((_|_)_(_/(  _| |((_)(()((_|(_)      //
+//      | '_ \ || | '_| ' \))  | '  \()| || |  \ V  V / | ' \)) _` / _ \ V  V (_-<      //
+//      |_.__/\_,_|_| |_||_|   |_|_|_|  \_, |   \_/\_/|_|_||_|\__,_\___/\_/\_//__/      //
+//                                 |__/                                                 //
+//////////////////////////////////////////////////////////////////////////////////////////
+
+// SPDX-FileCopyrightText: Justin Garza JGarza9788@gmail.com
+// SPDX-License-Identifier: GPL-3.0-or-later
+
+// The content from common.glsl is automatically prepended to each shader effect. This
+// provides the standard input:
+
+// vec2  iTexCoord:     Texture coordinates for retrieving the window input color.
+// bool  uIsFullscreen: True if the window is maximized or in fullscreen mode.
+// bool  uForOpening:   True if a window-open animation is ongoing, false otherwise.
+// float uProgress:     A value which transitions from 0 to 1 during the animation.
+// float uDuration:     The duration of the current animation in seconds.
+// vec2  uSize:         The size of uTexture in pixels.
+// float uPadding:      The empty area around the actual window (e.g. where the shadow
+//                      is drawn). For now, this will only be set on GNOME.
+
+// Furthermore, there are two global methods for reading the window input color and
+// setting the shader output color. Both methods assume straight alpha:
+
+// vec4 getInputColor(vec2 coords)
+// void setOutputColor(vec4 outColor)
+
+// window time ... how we split the time between the window and the sparkle/star
+uniform float uAnimationSplit;
+uniform float uHorizontalSparklePosition;  // the Xposition of the star
+uniform float uVerticalSparklePosition;    // the Yposition of the star
+uniform float uSparkleRot;                 // the rotation of the star
+uniform float uSparkleSize;                // the size of the star
+uniform bool uWindowRotation;              // window rotation... but it's more of a warp
+uniform vec2 uSeed;                        // and random numbers
+
+// Used to scale the window.
+vec2 scaleUV(vec2 uv, vec2 scale, vec2 centerOffset) {
+  // Put texture coordinate origin to center of window.
+  uv -= centerOffset;
+  uv = uv * 2.0 - 1.0;
+
+  // scale
+  uv /= mix(vec2(1.0, 1.0), vec2(0.0, 0.0), scale);
+
+  // scale from center
+  uv = uv * 0.5 + 0.5;
+
+  return uv;
+}
+
+// This returns the Spark.
+float getSpark(vec2 uv, vec2 center, float brightness, float size, float rotation) {
+  brightness = clamp(brightness, 0.001, 1.0);
+  size       = clamp(size, 0.001, 1.0);
+
+  float bn = mix(0.0, 0.07, brightness);  // recalculate size
+
+  uv = (uv + vec2(0.5));  // set center
+  uv = (uv - center);     // Center UV coordinates, then scale to fit the star size
+  uv = scaleUV(uv, vec2(1.0 - size), vec2(0.0));
+  uv = rotate(uv, rotation, vec2(0.5));  // rotate the UV
+
+  // this is basically the brightness
+  float p = mix(-1.0, 1000.0, easeInExpo(bn));
+
+  float m =
+    mix(0.0, 1.0,
+        clamp(pow(abs(uv.x - 0.5) * 2.0, p) + pow(abs(uv.y - 0.5) * 2.0, p), 0.0, 1.0));
+
+  // calcuate and return this mask
+  float mask = easeInSine(1.0 - (m - bn)) - 0.004;
+  mask       = clamp(mask, 0.0, 1.0);
+  return mask;
+}
+
+// fades out at 0 and 1 ...based on the power
+//  1|     __________
+//   |    /          \
+//   |   /            \
+//   |  /              \ 
+//   | /                \
+//  0| 0.................1
+/*
+graph above ... where t is close to 0, or 1 the result will fade to zero
+i.e. this is just the function of power(x,p) shifted
+where x is time, and p is 2.0,4.0,8.0,10.0 ... or any positive even number
+*/
+float fadeInOut(float t, float power) {
+  float s = -1.0 * pow((t - 0.5) / (0.5), power) + 1.0;
+  s       = clamp(s, 0.0, 1.0);
+  return s;
+}
+
+// 2x pi ... don't think too much about it
+float TAU = 6.28;
+
+void main() {
+  // Calculate the progression value based on the animation direction.
+  // If opening, use uProgress as-is; if closing, invert the progression.
+  float progress = uForOpening ? 1.0 - uProgress : uProgress;
+
+  // Scale progress ... the first half of the animation.
+  float scalep = remap(progress, 0.0, uAnimationSplit + 0.1, 0.0, 1.0);
+  scalep       = easeOutQuad(scalep);
+
+  // Sparkle progress ... the second half of the animation.
+  float sparkp = remap(progress, uAnimationSplit - 0.1, 1.0, 0.0, 1.0);
+  sparkp       = easeInOutSine(sparkp);
+
+  // This is the offset of the window... don't let them go too far each way.
+  vec2 offset = vec2(uHorizontalSparklePosition, uVerticalSparklePosition * -1.0) * 0.20;
+  vec2 scaleOffset =
+    mix(vec2(0.0),
+        vec2(uHorizontalSparklePosition, uVerticalSparklePosition * -1.0) * 0.50, scalep);
+
+  // the UV for this function
+  float aspect = uSize.x / uSize.y;
+  vec2 uv      = iTexCoord.st * vec2(aspect, 1.0);
+
+  // get and adjust
+  vec2 uv2 = iTexCoord.st;
+  uv2      = uv2 * 2.0 - 1.0;
+  uv2 -= (scaleOffset / vec2(aspect, 1.0)) * scalep;
+  uv2 /= 1.0 - scalep;
+
+  // Rotation and if we are gonna rotate or not.
+  vec3 rot = vec3(0.0);
+  if (uWindowRotation) {
+    rot = hash32(uSeed);
+    rot *= 2.0;
+    rot -= 1.0;
+    rot *= 0.1;
+  }
+
+  // Rotate around x, y , and z.
+  uv2.x /= mix(1.0, rot.x * TAU * uv2.y, scalep);
+  uv2.y /= mix(1.0, rot.y * TAU * uv2.x, scalep);
+  uv2 = rotate(uv2, rot.z * TAU * scalep);
+
+  // re-center
+  uv2 = uv2 * 0.5 + 0.5;
+
+  // Get the sparkle.
+  float size = mix(25.0, 50.0, uSparkleSize);
+  float sparkle =
+    getSpark(uv, offset + vec2(0.5 * aspect, 0.5), fadeInOut(sparkp, 2) * uSparkleSize,
+             fadeInOut(sparkp, 2) * size, sparkp * TAU * float(uSparkleRot));
+  // Fade out at the edges.
+  sparkle *= fadeInOut(iTexCoord.t, 8);
+  sparkle *= fadeInOut(iTexCoord.s, 8);
+
+  // Combine the final color.
+  vec4 oColor = getInputColor(uv2);
+  oColor      = alphaOver(oColor, vec4(1.0, 1.0, 1.0, sparkle));
+
+  setOutputColor(oColor);
+}


### PR DESCRIPTION
- Added new effects from the Gnome version (Aura Glow, Mushroom, RGB Warp, Team Rocket)
- Added Magic Lap effect based on hermes83/compiz-alike-magic-lamp-effect (same as CinnamonMagicLamp)
- Added the ability to apply effects to the minimize & unminimize events
- Fixed an issue where the window was jumping a pixel to the right post open animation (finally!)
- Added Fire effect presets (5 pre-configured fire setups)
- Changed the Random Effects tab to use a standard List widget
- Moved the Application Specific settings options to it's own tab
- Added a custom color selection widget to save configurator GUI space
- Use WM_CLASS when adding a app specific setting if no app can be found
- Improvements to the Focus effect (from Gnome version)
- Added an "About" tab with credits to the various authors