### PR TITLE
[CinnamonBurnMyWindows@klangman] Version 0.9.9

### DIFF
--- a/CinnamonBurnMyWindows@klangman/CHANGELOG.md
+++ b/CinnamonBurnMyWindows@klangman/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.9.9
+
+* Added a "Reset to default" button for each effect under the "Effect Settings" tab. 
+* Added an "Open effect preview window" button to "Effect Settings" tab. It opens a preview window to test out the currently selected effect in the "Show setting for effect" drop down list.
+* Added a custom "scale" widget that puts the label, scale, and number in a line to save GUI space. It also "marks" the default value for the setting.
+* Fixed the issue where some setting under the "Effect Settings" were not appearing properly after changing the "Show settings for effect" drop-down. It turns out that adding a common element at the end of the effect settings somehow makes the issue disappear. So I didn't really "fix" anything but adding the "Open effect preview window" button at the bottom of the effect settings section has the added benefit of avoiding the issue.
+* Added a custom "About page" widget to improve the look of the about tab and changed the URLs to clickable links. Also added a "Report an issue" link and the version number to the about tab.
+* Added buttons to set or clear all the random set check boxes.
+* Added BMW Gnome version changes to add a random color option to the Fire effect, also added a "Nuclear" preset.
+* Added an Doom setting option to manually adjust the target location for the Doom open effect so that people can work-around the Doom effect issue while I work on finding a proper fix.
+
 ## 0.9.8
 
 * Added new effects from the Gnome version (Aura Glow, Mushroom, RGB Warp, Team Rocket)

--- a/CinnamonBurnMyWindows@klangman/README.md
+++ b/CinnamonBurnMyWindows@klangman/README.md
@@ -17,13 +17,12 @@ This extension needs the Cinnamon.GLSLEffect class which is only available in Ci
 
 ## Known issues
 
-1. In the setting configure window under the "Effect Settings" tab, when changing the "Show setting for effect" drop-down to select a different effect, sometimes the contents under the "Effect Specific Settings" title will not properly update. Because of this, only a subset of the available options are visible. I believe this is a Cinnamon bug. You can force Cinnamon to properly redraw the options by selecting the "General" tab then returning to the "Effect Settings" tab again. After that, the complete set of "Effect Specific Settings" should be visible.
-2. When closing the Steam Client "setting" window the 'close window effect' does not show the windows contents, resulting in the closing effect to show where the window had existed but otherwise has no negative effect.
-3. When running VirtualBox, some actions (like restarting Cinnamon or changing panel hide settings) will show a full screen animation of both the Open and Close effect. I assume this is caused by some weirdness with how VirtualBox was written. The problem can be avoided by using two "Application specific settings" list entries to disable open/close animations for the "VirtualBox" and "VirtualBoxVM" WM_CLASS names (entered under the "Application" entry box). New installs of this extension will have these entries by default, but installs that are upgraded to the latest version will need to manually enter these app rules to avoid the issues.
-4. The Doom open effect seems to finish animating at a noticeably lower position than where the window is actually located. This results in the sudden jump up after the animation is completed. When used as a close effect it works correctly.
-5. The window shadows are not part of the animation and therefore they suddenly appear or disappear right after or before the animation.
-6. After upgrading to 0.9.8 the Fire effect setting and the effects included in the randomized sets will be reset to default.
-7. The Magic Lap effect when used as a minimize effect the window "flashes" the window at the start of the effect and so far I have not been able to determine why. The issue does not appear when used as a close event which is very odd. For this reason you might want to continue using the standalone Magic Lamp Effect extension until I find a way to fix this.
+1. When closing the Steam Client "setting" window the 'close window effect' does not show the windows contents, resulting in the closing effect to show where the window had existed but otherwise has no negative effect.
+2. When running VirtualBox, some actions (like restarting Cinnamon or changing panel hide settings) will show a full screen animation of both the Open and Close effect. I assume this is caused by some weirdness with how VirtualBox was written. The problem can be avoided by using two "Application specific settings" list entries to disable open/close animations for the "VirtualBox" and "VirtualBoxVM" WM_CLASS names (entered under the "Application" entry box). New installs of this extension will have these entries by default, but installs that are upgraded to the latest version will need to manually enter these app rules to avoid the issues.
+3. The Doom open effect seems to finish animating at a noticeably lower position than where the window is actually located. This results in the sudden jump up after the animation is completed. When used as a close effect it works correctly. There is a Doom effect option called "Y offset fix for open/unminimize events" which allows you to manually fix this issue while I look for a proper fix that works for everyone.
+4. The window shadows are not part of the animation and therefore they suddenly appear or disappear right after or before the animation.
+5. After upgrading to 0.9.8 the Fire effect setting and the effects included in the randomized sets will be reset to default.
+6. The Magic Lap effect when used as a minimize effect the window "flashes" the window at the start of the effect and so far I have not been able to determine why. The issue does not appear when used as a close event which is very odd. For this reason you might want to continue using the standalone Magic Lamp Effect extension until I find a way to fix this.
 
 ### Currently these effects are working in Cinnamon:
 
@@ -52,7 +51,7 @@ This extension needs the Cinnamon.GLSLEffect class which is only available in Ci
 
 ### Effects currently disabled:
 
-Because Cinnamon is missing a required API, the following effects are disabled. I am hoping to find a way around this issue:
+Because Cinnamon is missing a required API, the following effects are disabled. I am hoping I can enable these effect when Cinnamon 6.6 is available later this year:
 
 - Broken Glass
 - Matrix

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/CustomWidgets.py
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/CustomWidgets.py
@@ -1,144 +1,237 @@
 #!/usr/bin/python3
 
 import random
+import math
+import gi
+
 from JsonSettingsWidgets import *
-from gi.repository import Gio, Gtk
+from gi.repository import Gio, Gtk, Gdk, GLib
 
 class FireColorChooser(SettingsWidget):
    def __init__(self, info, key, settings):
-        SettingsWidget.__init__(self)
-        self.key = key
-        self.settings = settings
-        self.info = info
-        rgba = Gdk.RGBA()
+      SettingsWidget.__init__(self)
+      self.key = key
+      self.settings = settings
+      self.info = info
+      rgba = Gdk.RGBA()
 
-        self.pack_start(Gtk.Label(_(info['description']), halign=Gtk.Align.START), True, True, 0)
-        self.cBtn1 = Gtk.ColorButton()
-        self.cBtn1.set_use_alpha(True)
-        self.cBtn1.set_margin_start(2)
+      self.pack_start(Gtk.Label(_(info['description']), halign=Gtk.Align.START), True, True, 0)
+      self.cBtn1 = Gtk.ColorButton()
+      self.cBtn1.set_use_alpha(True)
+      self.cBtn1.set_margin_start(2)
 
-        self.cBtn2 = Gtk.ColorButton()
-        self.cBtn2.set_use_alpha(True)
-        self.cBtn2.set_margin_start(2)
+      self.cBtn2 = Gtk.ColorButton()
+      self.cBtn2.set_use_alpha(True)
+      self.cBtn2.set_margin_start(2)
 
-        self.cBtn3 = Gtk.ColorButton()
-        self.cBtn3.set_use_alpha(True)
-        self.cBtn3.set_margin_start(2)
+      self.cBtn3 = Gtk.ColorButton()
+      self.cBtn3.set_use_alpha(True)
+      self.cBtn3.set_margin_start(2)
 
-        self.cBtn4 = Gtk.ColorButton()
-        self.cBtn4.set_use_alpha(True)
-        self.cBtn4.set_margin_start(2)
+      self.cBtn4 = Gtk.ColorButton()
+      self.cBtn4.set_use_alpha(True)
+      self.cBtn4.set_margin_start(2)
 
-        self.cBtn5 = Gtk.ColorButton()
-        self.cBtn5.set_use_alpha(True)
-        self.cBtn5.set_margin_start(2)
+      self.cBtn5 = Gtk.ColorButton()
+      self.cBtn5.set_use_alpha(True)
+      self.cBtn5.set_margin_start(2)
 
-        self.pack_end(self.cBtn5, False, False, 2)
-        self.pack_end(self.cBtn4, False, False, 2)
-        self.pack_end(self.cBtn3, False, False, 2)
-        self.pack_end(self.cBtn2, False, False, 2)
-        self.pack_end(self.cBtn1, False, False, 2)
+      self.pack_end(self.cBtn5, False, False, 2)
+      self.pack_end(self.cBtn4, False, False, 2)
+      self.pack_end(self.cBtn3, False, False, 2)
+      self.pack_end(self.cBtn2, False, False, 2)
+      self.pack_end(self.cBtn1, False, False, 2)
 
-        rgba.parse(settings.get_value(info["color1"]))
-        self.cBtn1.set_rgba(rgba);
-        rgba.parse(settings.get_value(info["color2"]))
-        self.cBtn2.set_rgba(rgba);
-        rgba.parse(settings.get_value(info["color3"]))
-        self.cBtn3.set_rgba(rgba);
-        rgba.parse(settings.get_value(info["color4"]))
-        self.cBtn4.set_rgba(rgba);
-        rgba.parse(settings.get_value(info["color5"]))
-        self.cBtn5.set_rgba(rgba);
+      rgba.parse(settings.get_value(info["color1"]))
+      self.cBtn1.set_rgba(rgba);
+      rgba.parse(settings.get_value(info["color2"]))
+      self.cBtn2.set_rgba(rgba);
+      rgba.parse(settings.get_value(info["color3"]))
+      self.cBtn3.set_rgba(rgba);
+      rgba.parse(settings.get_value(info["color4"]))
+      self.cBtn4.set_rgba(rgba);
+      rgba.parse(settings.get_value(info["color5"]))
+      self.cBtn5.set_rgba(rgba);
 
-        self.cBtn1.connect('color-set', self.on_my_value_changed)
-        self.cBtn2.connect('color-set', self.on_my_value_changed)
-        self.cBtn3.connect('color-set', self.on_my_value_changed)
-        self.cBtn4.connect('color-set', self.on_my_value_changed)
-        self.cBtn5.connect('color-set', self.on_my_value_changed)
+      settings.listen(info["color1"], self.on_key_value_changed1);
+      settings.listen(info["color2"], self.on_key_value_changed2);
+      settings.listen(info["color3"], self.on_key_value_changed3);
+      settings.listen(info["color4"], self.on_key_value_changed4);
+      settings.listen(info["color5"], self.on_key_value_changed5);
+
+      self.cBtn1.connect('color-set', self.on_my_value_changed)
+      self.cBtn2.connect('color-set', self.on_my_value_changed)
+      self.cBtn3.connect('color-set', self.on_my_value_changed)
+      self.cBtn4.connect('color-set', self.on_my_value_changed)
+      self.cBtn5.connect('color-set', self.on_my_value_changed)
+
+   def on_key_value_changed1(self, key, value):
+      color_string = self.cBtn1.get_rgba().to_string()
+      if color_string != value:
+         rgba = Gdk.RGBA()
+         rgba.parse(value)
+         self.cBtn1.set_rgba(rgba);
+
+   def on_key_value_changed2(self, key, value):
+      color_string = self.cBtn2.get_rgba().to_string()
+      if color_string != value:
+         rgba = Gdk.RGBA()
+         rgba.parse(value)
+         self.cBtn2.set_rgba(rgba);
+
+   def on_key_value_changed3(self, key, value):
+      color_string = self.cBtn3.get_rgba().to_string()
+      if color_string != value:
+         rgba = Gdk.RGBA()
+         rgba.parse(value)
+         self.cBtn3.set_rgba(rgba);
+
+   def on_key_value_changed4(self, key, value):
+      color_string = self.cBtn4.get_rgba().to_string()
+      if color_string != value:
+         rgba = Gdk.RGBA()
+         rgba.parse(value)
+         self.cBtn4.set_rgba(rgba);
+
+   def on_key_value_changed5(self, key, value):
+      color_string = self.cBtn5.get_rgba().to_string()
+      if color_string != value:
+         rgba = Gdk.RGBA()
+         rgba.parse(value)
+         self.cBtn5.set_rgba(rgba);
 
    def on_my_value_changed(self, widget):
-       color_string = self.cBtn1.get_rgba().to_string()
-       self.settings.set_value(self.info["color1"], color_string)
-       color_string = self.cBtn2.get_rgba().to_string()
-       self.settings.set_value(self.info["color2"], color_string)
-       color_string = self.cBtn3.get_rgba().to_string()
-       self.settings.set_value(self.info["color3"], color_string)
-       color_string = self.cBtn4.get_rgba().to_string()
-       self.settings.set_value(self.info["color4"], color_string)
-       color_string = self.cBtn5.get_rgba().to_string()
-       self.settings.set_value(self.info["color5"], color_string)
+      color_string = self.cBtn1.get_rgba().to_string()
+      self.settings.set_value(self.info["color1"], color_string)
+      color_string = self.cBtn2.get_rgba().to_string()
+      self.settings.set_value(self.info["color2"], color_string)
+      color_string = self.cBtn3.get_rgba().to_string()
+      self.settings.set_value(self.info["color3"], color_string)
+      color_string = self.cBtn4.get_rgba().to_string()
+      self.settings.set_value(self.info["color4"], color_string)
+      color_string = self.cBtn5.get_rgba().to_string()
+      self.settings.set_value(self.info["color5"], color_string)
 
 
 class MushroomColorChooser(SettingsWidget):
    def __init__(self, info, key, settings):
-        SettingsWidget.__init__(self)
-        self.key = key
-        self.settings = settings
-        self.info = info
-        rgba = Gdk.RGBA()
+      SettingsWidget.__init__(self)
+      self.key = key
+      self.settings = settings
+      self.info = info
+      rgba = Gdk.RGBA()
 
-        self.pack_start(Gtk.Label(_(info['description']), halign=Gtk.Align.START), True, True, 0)
-        self.cBtn1 = Gtk.ColorButton()
-        self.cBtn1.set_use_alpha(True)
-        self.cBtn1.set_margin_start(2)
+      self.pack_start(Gtk.Label(_(info['description']), halign=Gtk.Align.START), True, True, 0)
+      self.cBtn1 = Gtk.ColorButton()
+      self.cBtn1.set_use_alpha(True)
+      self.cBtn1.set_margin_start(2)
 
-        self.cBtn2 = Gtk.ColorButton()
-        self.cBtn2.set_use_alpha(True)
-        self.cBtn2.set_margin_start(2)
+      self.cBtn2 = Gtk.ColorButton()
+      self.cBtn2.set_use_alpha(True)
+      self.cBtn2.set_margin_start(2)
 
-        self.cBtn3 = Gtk.ColorButton()
-        self.cBtn3.set_use_alpha(True)
-        self.cBtn3.set_margin_start(2)
+      self.cBtn3 = Gtk.ColorButton()
+      self.cBtn3.set_use_alpha(True)
+      self.cBtn3.set_margin_start(2)
 
-        self.cBtn4 = Gtk.ColorButton()
-        self.cBtn4.set_use_alpha(True)
-        self.cBtn4.set_margin_start(2)
+      self.cBtn4 = Gtk.ColorButton()
+      self.cBtn4.set_use_alpha(True)
+      self.cBtn4.set_margin_start(2)
 
-        self.cBtn5 = Gtk.ColorButton()
-        self.cBtn5.set_use_alpha(True)
-        self.cBtn5.set_margin_start(2)
+      self.cBtn5 = Gtk.ColorButton()
+      self.cBtn5.set_use_alpha(True)
+      self.cBtn5.set_margin_start(2)
 
-        self.cBtn6 = Gtk.ColorButton()
-        self.cBtn6.set_use_alpha(True)
-        self.cBtn6.set_margin_start(2)
+      self.cBtn6 = Gtk.ColorButton()
+      self.cBtn6.set_use_alpha(True)
+      self.cBtn6.set_margin_start(2)
 
-        self.pack_end(self.cBtn6, False, False, 2)
-        self.pack_end(self.cBtn5, False, False, 2)
-        self.pack_end(self.cBtn4, False, False, 2)
-        self.pack_end(self.cBtn3, False, False, 2)
-        self.pack_end(self.cBtn2, False, False, 2)
-        self.pack_end(self.cBtn1, False, False, 2)
+      self.pack_end(self.cBtn6, False, False, 2)
+      self.pack_end(self.cBtn5, False, False, 2)
+      self.pack_end(self.cBtn4, False, False, 2)
+      self.pack_end(self.cBtn3, False, False, 2)
+      self.pack_end(self.cBtn2, False, False, 2)
+      self.pack_end(self.cBtn1, False, False, 2)
 
-        rgba.parse(settings.get_value(info["color1"]))
-        self.cBtn1.set_rgba(rgba);
-        rgba.parse(settings.get_value(info["color2"]))
-        self.cBtn2.set_rgba(rgba);
-        rgba.parse(settings.get_value(info["color3"]))
-        self.cBtn3.set_rgba(rgba);
-        rgba.parse(settings.get_value(info["color4"]))
-        self.cBtn4.set_rgba(rgba);
-        rgba.parse(settings.get_value(info["color5"]))
-        self.cBtn5.set_rgba(rgba);
-        rgba.parse(settings.get_value(info["color6"]))
-        self.cBtn6.set_rgba(rgba);
+      rgba.parse(settings.get_value(info["color1"]))
+      self.cBtn1.set_rgba(rgba);
+      rgba.parse(settings.get_value(info["color2"]))
+      self.cBtn2.set_rgba(rgba);
+      rgba.parse(settings.get_value(info["color3"]))
+      self.cBtn3.set_rgba(rgba);
+      rgba.parse(settings.get_value(info["color4"]))
+      self.cBtn4.set_rgba(rgba);
+      rgba.parse(settings.get_value(info["color5"]))
+      self.cBtn5.set_rgba(rgba);
+      rgba.parse(settings.get_value(info["color6"]))
+      self.cBtn6.set_rgba(rgba);
 
-        self.cBtn1.connect('color-set', self.on_my_value_changed)
-        self.cBtn2.connect('color-set', self.on_my_value_changed)
-        self.cBtn3.connect('color-set', self.on_my_value_changed)
-        self.cBtn4.connect('color-set', self.on_my_value_changed)
-        self.cBtn5.connect('color-set', self.on_my_value_changed)
-        self.cBtn6.connect('color-set', self.on_my_value_changed)
+      settings.listen(info["color1"], self.on_key_value_changed1);
+      settings.listen(info["color2"], self.on_key_value_changed2);
+      settings.listen(info["color3"], self.on_key_value_changed3);
+      settings.listen(info["color4"], self.on_key_value_changed4);
+      settings.listen(info["color5"], self.on_key_value_changed5);
+      settings.listen(info["color6"], self.on_key_value_changed6);
+
+      self.cBtn1.connect('color-set', self.on_my_value_changed)
+      self.cBtn2.connect('color-set', self.on_my_value_changed)
+      self.cBtn3.connect('color-set', self.on_my_value_changed)
+      self.cBtn4.connect('color-set', self.on_my_value_changed)
+      self.cBtn5.connect('color-set', self.on_my_value_changed)
+      self.cBtn6.connect('color-set', self.on_my_value_changed)
+
+   def on_key_value_changed1(self, key, value):
+      color_string = self.cBtn1.get_rgba().to_string()
+      if color_string != value:
+         rgba = Gdk.RGBA()
+         rgba.parse(value)
+         self.cBtn1.set_rgba(rgba);
+
+   def on_key_value_changed2(self, key, value):
+      color_string = self.cBtn2.get_rgba().to_string()
+      if color_string != value:
+         rgba = Gdk.RGBA()
+         rgba.parse(value)
+         self.cBtn2.set_rgba(rgba);
+
+   def on_key_value_changed3(self, key, value):
+      color_string = self.cBtn3.get_rgba().to_string()
+      if color_string != value:
+         rgba = Gdk.RGBA()
+         rgba.parse(value)
+         self.cBtn3.set_rgba(rgba);
+
+   def on_key_value_changed4(self, key, value):
+      color_string = self.cBtn4.get_rgba().to_string()
+      if color_string != value:
+         rgba = Gdk.RGBA()
+         rgba.parse(value)
+         self.cBtn4.set_rgba(rgba);
+
+   def on_key_value_changed5(self, key, value):
+      color_string = self.cBtn5.get_rgba().to_string()
+      if color_string != value:
+         rgba = Gdk.RGBA()
+         rgba.parse(value)
+         self.cBtn5.set_rgba(rgba);
+
+   def on_key_value_changed6(self, key, value):
+      color_string = self.cBtn6.get_rgba().to_string()
+      if color_string != value:
+         rgba = Gdk.RGBA()
+         rgba.parse(value)
+         self.cBtn6.set_rgba(rgba);
 
    def on_my_value_changed(self, widget):
-       color_string = self.cBtn1.get_rgba().to_string()
-       self.settings.set_value(self.info["color1"], color_string)
-       color_string = self.cBtn2.get_rgba().to_string()
-       self.settings.set_value(self.info["color2"], color_string)
-       color_string = self.cBtn3.get_rgba().to_string()
-       self.settings.set_value(self.info["color3"], color_string)
-       color_string = self.cBtn4.get_rgba().to_string()
-       self.settings.set_value(self.info["color4"], color_string)
-       color_string = self.cBtn5.get_rgba().to_string()
-       self.settings.set_value(self.info["color5"], color_string)
-       color_string = self.cBtn6.get_rgba().to_string()
-       self.settings.set_value(self.info["color6"], color_string)
+      color_string = self.cBtn1.get_rgba().to_string()
+      self.settings.set_value(self.info["color1"], color_string)
+      color_string = self.cBtn2.get_rgba().to_string()
+      self.settings.set_value(self.info["color2"], color_string)
+      color_string = self.cBtn3.get_rgba().to_string()
+      self.settings.set_value(self.info["color3"], color_string)
+      color_string = self.cBtn4.get_rgba().to_string()
+      self.settings.set_value(self.info["color4"], color_string)
+      color_string = self.cBtn5.get_rgba().to_string()
+      self.settings.set_value(self.info["color5"], color_string)
+      color_string = self.cBtn6.get_rgba().to_string()
+      self.settings.set_value(self.info["color6"], color_string)

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/settings-schema.json
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/settings-schema.json
@@ -49,28 +49,29 @@
     "effect-settings" : {
       "type" : "section",
       "title" : "Effect Specific Settings",
-      "keys" : ["apparition-shake-intensity", "apparition-twirl-intensity", "apparition-suction-intensity", "apparition-randomness", "apparition-animation-time",
-                "aura-glow-random-color", "aura-glow-start-hue", "aura-glow-speed", "aura-glow-saturation", "aura-glow-edge-size", "aura-glow-edge-hardness", "aura-glow-blur", "aura-glow-animation-time",
-                "doom-horizontal-scale", "doom-vertical-scale", "doom-pixel-size", "doom-animation-time",
-                "energize-a-scale", "energize-a-color", "energize-a-animation-time",
-                "energize-b-scale", "energize-b-color", "energize-b-animation-time",
-                "fire-presets", "fire-3d-noise", "fire-animation-time",
-                "focus-blur-amount", "focus-blur-quality", "focus-animation-time",
-                "glide-scale", "glide-squish", "glide-tilt", "glide-shift", "glide-animation-time",
-                "glitch-scale", "glitch-strength", "glitch-speed", "glitch-color", "glitch-animation-time",
-                "hexagon-scale", "hexagon-line-width", "hexagon-line-color", "hexagon-glow-color", "hexagon-additive-blending", "hexagon-animation-time",
-                "incinerate-scale", "incinerate-turbulence", "incinerate-color", "incinerate-use-pointer", "incinerate-animation-time",
-                "magiclamp-effect", "magiclamp-x-tiles", "magiclamp-y-tiles", "magiclamp-animation-time",
-                "mushroom-presets", "mushroom-animation-time",
-                "pixelate-noise", "pixelate-pixel-size", "pixelate-animation-time",
-                "pixel-wheel-spoke-count", "pixel-wheel-pixel-size", "pixel-wheel-animation-time",
-                "pixel-wipe-pixel-size", "pixel-wipe-animation-time",
-                "portal-color", "portal-rotation-speed", "portal-whirling", "portal-details", "portal-animation-time",
-                "rgbwarp-brightness", "rgbwarp-speed-r", "rgbwarp-speed-g", "rgbwarp-speed-b", "rgbwarp-animation-time",
-                "team-rocket-animation-split", "team-rocket-horizontal-sparkle-position", "team-rocket-vertical-sparkle-position", "team-rocket-window-rotation", "team-rocket-sparkle-rot", "team-rocket-sparkle-size", "team-rocket-animation-time",
-                "tv-effect-color", "tv-animation-time",
-                "tv-glitch-scale", "tv-glitch-strength", "tv-glitch-speed", "tv-glitch-color", "tv-glitch-animation-time",
-                "wisps-scale", "wisps-color-1", "wisps-color-2", "wisps-color-3", "wisps-animation-time"]
+      "keys" : ["apparition-shake-intensity", "apparition-twirl-intensity", "apparition-suction-intensity", "apparition-randomness", "apparition-animation-time", "apparition-reset",
+                "aura-glow-random-color", "aura-glow-start-hue", "aura-glow-speed", "aura-glow-saturation", "aura-glow-edge-size", "aura-glow-edge-hardness", "aura-glow-blur", "aura-glow-animation-time", "aura-glow-reset",
+                "doom-horizontal-scale", "doom-vertical-scale", "doom-pixel-size", "doom-y-hack", "doom-animation-time", "doom-reset",
+                "energize-a-scale", "energize-a-color", "energize-a-animation-time", "energize-a-reset",
+                "energize-b-scale", "energize-b-color", "energize-b-animation-time", "energize-b-reset",
+                "fire-presets", "fire-3d-noise", "fire-random-color", "fire-animation-time", "fire-reset",
+                "focus-blur-amount", "focus-blur-quality", "focus-animation-time", "focus-reset",
+                "glide-scale", "glide-squish", "glide-tilt", "glide-shift", "glide-animation-time", "glide-reset",
+                "glitch-scale", "glitch-strength", "glitch-speed", "glitch-color", "glitch-animation-time", "glitch-reset",
+                "hexagon-scale", "hexagon-line-width", "hexagon-line-color", "hexagon-glow-color", "hexagon-additive-blending", "hexagon-animation-time", "hexagon-reset",
+                "incinerate-scale", "incinerate-turbulence", "incinerate-color", "incinerate-use-pointer", "incinerate-animation-time", "incinerate-reset",
+                "magiclamp-effect", "magiclamp-x-tiles", "magiclamp-y-tiles", "magiclamp-animation-time", "magiclamp-reset",
+                "mushroom-presets", "mushroom-animation-time", "mushroom-reset",
+                "pixelate-noise", "pixelate-pixel-size", "pixelate-animation-time", "pixelate-reset",
+                "pixel-wheel-spoke-count", "pixel-wheel-pixel-size", "pixel-wheel-animation-time", "pixel-wheel-reset",
+                "pixel-wipe-pixel-size", "pixel-wipe-animation-time", "pixel-wipe-reset",
+                "portal-color", "portal-rotation-speed", "portal-whirling", "portal-details", "portal-animation-time", "portal-reset",
+                "rgbwarp-brightness", "rgbwarp-speed-r", "rgbwarp-speed-g", "rgbwarp-speed-b", "rgbwarp-animation-time", "rgbwarp-reset",
+                "team-rocket-animation-split", "team-rocket-horizontal-sparkle-position", "team-rocket-vertical-sparkle-position", "team-rocket-window-rotation", "team-rocket-sparkle-rot", "team-rocket-sparkle-size", "team-rocket-animation-time", "team-rocket-reset",
+                "tv-effect-color", "tv-animation-time", "tv-reset",
+                "tv-glitch-scale", "tv-glitch-strength", "tv-glitch-speed", "tv-glitch-color", "tv-glitch-animation-time", "tv-glitch-reset",
+                "wisps-scale", "wisps-color-1", "wisps-color-2", "wisps-color-3", "wisps-animation-time", "wisps-reset",
+                "test-effect"]
     },
     "fire-custom-section" : {
      "type" : "section",
@@ -87,7 +88,7 @@
     "random-section" : {
       "type" : "section",
       "title" : "Effects included in the randomized sets:",
-      "keys" : ["random-include"]
+      "keys" : ["random-include", "random-buttons"]
     },
     "about-section" : {
       "type" : "section",
@@ -97,8 +98,11 @@
   },
 
   "about-text": {
-     "type" : "label",
-     "description" : "Ported to Cinnamon by Kevin Langman\nGithub: https://github.com/klangman/CinnamonBurnMyWindows\n\nBased on the Burn-My-Windows code by Schneegans and contributors\nGithub: https://github.com/Schneegans/Burn-My-Windows\n\nThe Magic Lamp Effect is ported from code by hermes83\nGitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
+    "type" : "custom",
+    "file" : "CustomWidgets.py",
+    "widget" : "About",
+    "description" : "\n<b>Disintegrate your windows with style.</b>\nVersion: ext-version\n\nPorted to Cinnamon by Kevin Langman\n<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / <a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/new\">Report an issue</a>\n\nBased on the Burn-My-Windows code by Schneegans and contributors\n<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n\nThe Magic Lamp Effect is ported from code by hermes83\n<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-effect\">Github</a>",
+    "icon" : "/icons/cinnamon-burn-my-window.png"
   },
 
   "app-rules": {
@@ -274,6 +278,14 @@
         { "name": "TV Glitch",   "open": true, "close": true, "minimize": true, "unminimize": true },
         { "name": "Wisps",       "open": true, "close": true, "minimize": true, "unminimize": true }
         ]
+  },
+
+  "random-buttons" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "SetClearButtons",
+     "set-button" : "Set all check boxes",
+     "clear-button" : "Clear all check boxes"
   },
 
   "effect-selector": {
@@ -508,7 +520,9 @@
   },
 
   "apparition-shake-intensity": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Shake Intensity",
      "min" : 0.0,
      "max" : 10.0,
@@ -518,7 +532,9 @@
   },
 
   "apparition-twirl-intensity": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Twirl Intensity",
      "min" : -10.0,
      "max" : 10.0,
@@ -528,7 +544,9 @@
   },
 
   "apparition-suction-intensity": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Suction Intensity",
      "min" : 0.0,
      "max" : 1.0,
@@ -538,7 +556,9 @@
   },
 
   "apparition-randomness": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Randomness",
      "min" : 0.0,
      "max" : 1.0,
@@ -548,14 +568,26 @@
   },
 
   "apparition-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 2000,
      "step" : 10,
      "dependency" : "effect-selector=0",
      "default": 300
   },
+
+  "apparition-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=0",
+     "keys" : ["apparition-shake-intensity", "apparition-twirl-intensity", "apparition-suction-intensity", "apparition-randomness", "apparition-animation-time"]
+  },
+
 
   "aura-glow-random-color": {
     "type" : "switch",
@@ -565,7 +597,9 @@
   },
 
   "aura-glow-start-hue": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Start Hue",
      "min" : 0.0,
      "max" : 1.0,
@@ -575,7 +609,9 @@
   },
 
   "aura-glow-speed": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Speed",
      "min" : -5,
      "max" : 5,
@@ -585,7 +621,9 @@
   },
 
   "aura-glow-saturation": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Saturation",
      "min" : 0.0,
      "max" : 1.0,
@@ -595,7 +633,9 @@
   },
 
   "aura-glow-edge-size": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Edge Size",
      "min" : 0.0,
      "max" : 1.0,
@@ -605,7 +645,9 @@
   },
 
   "aura-glow-edge-hardness": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Edge Hardness",
      "min" : 0.0,
      "max" : 1.0,
@@ -615,7 +657,9 @@
   },
 
   "aura-glow-blur": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Blur Amount",
      "min" : 0,
      "max" : 30,
@@ -625,8 +669,10 @@
   },
 
   "aura-glow-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 3000,
      "step" : 10,
@@ -634,8 +680,20 @@
      "default": 750
   },
 
+  "aura-glow-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=22",
+     "keys" : ["aura-glow-random-color", "aura-glow-start-hue", "aura-glow-speed", "aura-glow-saturation", "aura-glow-edge-size", "aura-glow-edge-hardness", "aura-glow-blur", "aura-glow-animation-time"]
+  },
+
+
   "doom-horizontal-scale": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Horizontal Scale",
      "min" : 1,
      "max" : 50,
@@ -645,7 +703,9 @@
   },
 
   "doom-vertical-scale": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Vertical Scale",
      "min" : 1,
      "max" : 50,
@@ -655,7 +715,9 @@
   },
 
   "doom-pixel-size": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Pixel Size",
      "min" : 1,
      "max" : 50,
@@ -664,9 +726,24 @@
      "default": 10
   },
 
+  "doom-y-hack": {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Y offset fix for open/unminimize events",
+     "min" : -100,
+     "max" : 100,
+     "step" : 1,
+     "dependency" : "effect-selector=2",
+     "tooltip" : "Apply an offset to the Y axis window target position so that the open/unminimize animation completes at the right location. This is a hack fix for the Doom effect until I can find a proper fix",
+     "default": 0
+  },
+
   "doom-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 10000,
      "step" : 10,
@@ -674,8 +751,20 @@
      "default": 1000
   },
 
+  "doom-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=2",
+     "keys" : ["doom-horizontal-scale", "doom-vertical-scale", "doom-pixel-size", "doom-y-hack", "doom-animation-time"]
+  },
+
+
   "energize-a-scale": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Scale",
      "min" : 0.1,
      "max" : 10.0,
@@ -692,8 +781,10 @@
   },
 
   "energize-a-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 10000,
      "step" : 10,
@@ -701,8 +792,20 @@
      "default": 2000
   },
 
+  "energize-a-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=3",
+     "keys" : ["energize-a-scale", "energize-a-color", "energize-a-animation-time"]
+  },
+
+
   "energize-b-scale": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Scale",
      "min" : 0.1,
      "max" : 10.0,
@@ -719,13 +822,24 @@
   },
 
   "energize-b-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 10000,
      "step" : 10,
      "dependency" : "effect-selector=4",
      "default": 1000
+  },
+
+  "energize-b-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=4",
+     "keys" : ["energize-b-scale", "energize-b-color", "energize-b-animation-time"]
   },
 
 
@@ -738,14 +852,17 @@
       "Dark and Smutty" : "Dark and Smutty",
       "Cold Breeze" : "Cold Breeze",
       "Santa is Coming" : "Santa is Coming",
+      "Nuclear" : "Nuclear",
       "Custom" : "Custom"
     },
-    "description": "Fire preset",
+    "description": "Fire Preset",
     "dependency" : "effect-selector=5"
   },
 
   "fire-custom-scale": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Scale",
      "min" : 0.1,
      "max" : 3,
@@ -755,7 +872,9 @@
   },
 
   "fire-custom-movement-speed": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Fire Movement Speed",
      "min" : -2,
      "max" : 2,
@@ -768,6 +887,14 @@
     "type" : "switch",
     "description": "Fire 3D Noise",
     "tooltip": "Creates a more dynamic fire but requires more GPU power.",
+    "dependency" : "effect-selector=5",
+    "default": false
+  },
+
+  "fire-random-color": {
+    "type" : "switch",
+    "description": "Use a Random Color (overrides other color settings)",
+    "tooltip": "Use a random fire color. This setting will override any preset or custom colors settings you select.",
     "dependency" : "effect-selector=5",
     "default": false
   },
@@ -810,8 +937,10 @@
   },
 
   "fire-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 10000,
      "step" : 10,
@@ -819,9 +948,20 @@
      "default": 1500
   },
 
+  "fire-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=5",
+     "keys" : ["fire-presets", "fire-3d-noise", "fire-animation-time", "fire-custom-scale", "fire-custom-movement-speed", "fire-custom-color-1", "fire-custom-color-2", "fire-custom-color-3", "fire-custom-color-4", "fire-custom-color-5"]
+  },
+
 
   "focus-blur-amount": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Blur Amount",
      "min" : 0,
      "max" : 100,
@@ -831,7 +971,9 @@
   },
 
   "focus-blur-quality": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Blur Quality",
      "min" : 1,
      "max" : 10,
@@ -842,8 +984,10 @@
   },
 
   "focus-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 5000,
      "step" : 10,
@@ -851,8 +995,20 @@
      "default": 500
   },
 
+  "focus-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=21",
+     "keys" : ["focus-blur-amount", "focus-blur-quality", "focus-animation-time"]
+  },
+
+
   "glide-scale": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Scale",
      "min" : 0.1,
      "max" : 1,
@@ -862,7 +1018,9 @@
   },
 
   "glide-squish": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Squish",
      "min" : 0,
      "max" : 1,
@@ -872,7 +1030,9 @@
   },
 
   "glide-tilt": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Tilt",
      "min" : -1,
      "max" : 1,
@@ -882,7 +1042,9 @@
   },
 
   "glide-shift": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Shift",
      "min" : -1,
      "max" : 1,
@@ -892,8 +1054,10 @@
   },
 
   "glide-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 2000,
      "step" : 10,
@@ -901,8 +1065,20 @@
      "default": 250
   },
 
+  "glide-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=6",
+     "keys" : ["glide-scale", "glide-squish", "glide-tilt", "glide-shift", "glide-animation-time"]
+  },
+
+
   "glitch-scale": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Scale",
      "min" : 0.1,
      "max" : 10,
@@ -912,7 +1088,9 @@
   },
 
   "glitch-strength": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Strength",
      "min" : 0.1,
      "max" : 10,
@@ -922,7 +1100,9 @@
   },
 
   "glitch-speed": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Speed",
      "min" : 0.1,
      "max" : 10,
@@ -939,8 +1119,10 @@
   },
 
   "glitch-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 2000,
      "step" : 10,
@@ -948,8 +1130,20 @@
      "default": 750
   },
 
+  "glitch-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=7",
+     "keys" : ["glitch-scale", "glitch-strength", "glitch-speed", "glitch-color", "glitch-animation-time"]
+  },
+
+
   "hexagon-scale": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Scale",
      "min" : 0.1,
      "max" : 10,
@@ -959,7 +1153,9 @@
   },
 
   "hexagon-line-width": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Mesh Line Width",
      "min" : 0,
      "max" : 10,
@@ -991,8 +1187,10 @@
   },
 
   "hexagon-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 10000,
      "step" : 10,
@@ -1000,8 +1198,20 @@
      "default": 1500
   },
 
+  "hexagon-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=8",
+     "keys" : ["hexagon-scale", "hexagon-line-width", "hexagon-line-color", "hexagon-glow-color", "hexagon-additive-blending", "hexagon-animation-time"]
+  },
+
+
   "incinerate-scale": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Scale",
      "min" : 0.1,
      "max" : 10,
@@ -1011,7 +1221,9 @@
   },
 
   "incinerate-turbulence": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Turbulence",
      "min" : 0,
      "max" : 1,
@@ -1036,13 +1248,24 @@
   },
 
   "incinerate-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 10000,
      "step" : 10,
      "dependency" : "effect-selector=9",
      "default": 2000
+  },
+
+  "incinerate-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=9",
+     "keys" : ["incinerate-scale", "incinerate-turbulence", "incinerate-color", "incinerate-use-pointer", "incinerate-animation-time"]
   },
 
 
@@ -1062,35 +1285,50 @@
   },
 
   "magiclamp-x-tiles": {
-    "type": "scale",
-    "default": 20,
-    "min": 3,
-    "max": 50,
-    "step": 1,
-    "description": "X Tiles",
-    "dependency" : "effect-selector=26",
-    "tooltip": "This effects the quality and the cost of the animation"
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "default": 20,
+     "min": 3,
+     "max": 50,
+     "step": 1,
+     "description": "X Tiles",
+     "dependency" : "effect-selector=26",
+     "tooltip": "This effects the quality and the cost of the animation"
   },
 
   "magiclamp-y-tiles": {
-    "type": "scale",
-    "default": 20,
-    "min": 3,
-    "max": 50,
-    "step": 1,
-    "description": "Y Tiles",
-    "dependency" : "effect-selector=26",
-    "tooltip": "This effects the quality and the costs of the animation"
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "default": 20,
+     "min": 3,
+     "max": 50,
+     "step": 1,
+     "description": "Y Tiles",
+     "dependency" : "effect-selector=26",
+     "tooltip": "This effects the quality and the costs of the animation"
   },
 
   "magiclamp-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 3000,
      "step" : 10,
      "dependency" : "effect-selector=26",
      "default": 1200
+  },
+
+  "magiclamp-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=26",
+     "keys" : ["magiclamp-effect", "magiclamp-x-tiles", "magiclamp-y-tiles", "magiclamp-animation-time"]
   },
 
 
@@ -1139,12 +1377,14 @@
       "Sparkle" : "Sparkle",
       "Custom" : "Custom"
     },
-    "description": "Mushroom preset",
+    "description": "Mushroom Preset",
     "dependency" : "effect-selector=25"
   },
 
   "mushroom-custom-scale-style": {
-     "type": "spinbutton",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Scale Style",
      "min" : 0,
      "max" : 1,
@@ -1154,7 +1394,9 @@
   },
 
   "mushroom-custom-spark-count": {
-     "type": "spinbutton",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Spark Count",
      "min" : 0,
      "max" : 25,
@@ -1171,7 +1413,9 @@
   },
 
   "mushroom-custom-spark-rotation": {
-     "type": "spinbutton",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Spark Rotation",
      "min" : -3,
      "max" : 3,
@@ -1188,7 +1432,9 @@
   },
 
   "mushroom-custom-ring-count": {
-     "type": "spinbutton",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Star Rings Count",
      "min" : 0,
      "max" : 5,
@@ -1198,7 +1444,9 @@
   },
 
   "mushroom-custom-ring-rotation": {
-     "type": "spinbutton",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Star Ring Rotation",
      "min" : -3,
      "max" : 3,
@@ -1208,7 +1456,9 @@
   },
 
   "mushroom-custom-star-count": {
-     "type": "spinbutton",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Stars Count Per Ring",
      "min" : 0,
      "max" : 7,
@@ -1261,8 +1511,10 @@
   },
 
   "mushroom-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 5000,
      "step" : 10,
@@ -1270,9 +1522,20 @@
      "default": 1500
   },
 
+  "mushroom-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=25",
+     "keys" : ["mushroom-presets", "mushroom-animation-time", "mushroom-custom-scale-style", "mushroom-custom-spark-count", "mushroom-custom-spark-color", "mushroom-custom-spark-rotation", "mushroom-custom-rays-color", "mushroom-custom-ring-count", "mushroom-custom-ring-rotation", "mushroom-custom-star-count", "mushroom-custom-star-color-0", "mushroom-custom-star-color-1", "mushroom-custom-star-color-2", "mushroom-custom-star-color-3", "mushroom-custom-star-color-4", "mushroom-custom-star-color-5"]
+  },
+
 
   "pixelate-noise": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Noise",
      "min" : 1,
      "max" : 100,
@@ -1282,7 +1545,9 @@
   },
 
   "pixelate-pixel-size": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Pixel Size",
      "min" : 1,
      "max" : 50,
@@ -1292,8 +1557,10 @@
   },
 
   "pixelate-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 10000,
      "step" : 10,
@@ -1301,8 +1568,19 @@
      "default": 500
   },
 
+  "pixelate-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=12",
+     "keys" : ["pixelate-noise", "pixelate-pixel-size", "pixelate-animation-time"]
+  },
+
   "pixel-wheel-spoke-count": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Spoke Count",
      "min" : 1,
      "max" : 50,
@@ -1312,7 +1590,9 @@
   },
 
   "pixel-wheel-pixel-size": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Pixel Size",
      "min" : 1,
      "max" : 50,
@@ -1322,8 +1602,10 @@
   },
 
   "pixel-wheel-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 2000,
      "step" : 10,
@@ -1331,8 +1613,20 @@
      "default": 300
   },
 
+  "pixel-wheel-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=13",
+     "keys" : ["pixel-wheel-spoke-count", "pixel-wheel-pixel-size", "pixel-wheel-animation-time"]
+  },
+
+
   "pixel-wipe-pixel-size": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Pixel Size",
      "min" : 1,
      "max" : 50,
@@ -1342,14 +1636,26 @@
   },
 
   "pixel-wipe-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 5000,
      "step" : 10,
      "dependency" : "effect-selector=14",
      "default": 1000
   },
+
+  "pixel-wipe-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=14",
+     "keys" : ["pixel-wipe-pixel-size", "pixel-wipe-animation-time"]
+  },
+
 
   "portal-color": {
      "type": "colorchooser",
@@ -1359,7 +1665,9 @@
   },
 
   "portal-rotation-speed": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Rotation Speed",
      "min" : -2,
      "max" : 2,
@@ -1369,7 +1677,9 @@
   },
 
   "portal-whirling": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Whirling",
      "min" : -2,
      "max" : 2,
@@ -1379,7 +1689,9 @@
   },
 
   "portal-details": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Details",
      "min" : 1,
      "max" : 100,
@@ -1389,8 +1701,10 @@
   },
 
   "portal-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 500,
      "max" : 5000,
      "step" : 10,
@@ -1398,8 +1712,20 @@
      "default": 1250
   },
 
+  "portal-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=15",
+     "keys" : ["portal-color", "portal-rotation-speed", "portal-whirling", "portal-details", "portal-animation-time"]
+  },
+
+
   "rgbwarp-brightness": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Brightness",
      "min" : 0,
      "max" : 1,
@@ -1409,7 +1735,9 @@
   },
 
   "rgbwarp-speed-r": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Red Speed",
      "min" : 0,
      "max" : 1,
@@ -1419,7 +1747,9 @@
   },
 
   "rgbwarp-speed-g": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Green Speed",
      "min" : 0,
      "max" : 1,
@@ -1429,7 +1759,9 @@
   },
 
   "rgbwarp-speed-b": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Blue Speed",
      "min" : 0,
      "max" : 1,
@@ -1439,8 +1771,10 @@
   },
 
   "rgbwarp-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 5000,
      "step" : 10,
@@ -1448,8 +1782,20 @@
      "default": 750
   },
 
+  "rgbwarp-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=24",
+     "keys" : ["rgbwarp-brightness", "rgbwarp-speed-r", "rgbwarp-speed-g", "rgbwarp-speed-b", "rgbwarp-animation-time"]
+  },
+
+
   "team-rocket-animation-split": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Animation Split",
      "min" : 0.2,
      "max" : 0.8,
@@ -1459,7 +1805,9 @@
   },
 
   "team-rocket-horizontal-sparkle-position": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Horizontal Sparkle Position",
      "min" : -1.0,
      "max" : 1.0,
@@ -1469,7 +1817,9 @@
   },
 
   "team-rocket-vertical-sparkle-position": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Vertical Sparkle Position",
      "min" : -1.0,
      "max" : 1.0,
@@ -1486,7 +1836,9 @@
   },
 
   "team-rocket-sparkle-rot": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Sparkle Rotation",
      "min" : -1.0,
      "max" : 1.0,
@@ -1496,7 +1848,9 @@
   },
 
   "team-rocket-sparkle-size": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Sparkle Size",
      "min" : 0.5,
      "max" : 1.0,
@@ -1506,14 +1860,26 @@
   },
 
   "team-rocket-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 5000,
      "step" : 10,
      "dependency" : "effect-selector=23",
      "default": 1500
   },
+
+  "team-rocket-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=23",
+     "keys" : ["team-rocket-animation-split", "team-rocket-horizontal-sparkle-position", "team-rocket-vertical-sparkle-position", "team-rocket-window-rotation", "team-rocket-sparkle-rot", "team-rocket-sparkle-size", "team-rocket-animation-time"]
+  },
+
 
   "tv-effect-color": {
      "type": "colorchooser",
@@ -1523,8 +1889,10 @@
   },
 
   "tv-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 10000,
      "step" : 10,
@@ -1532,8 +1900,20 @@
      "default": 400
   },
 
+  "tv-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=18",
+     "keys" : ["tv-effect-color", "tv-animation-time"]
+  },
+
+
   "tv-glitch-scale": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Scale",
      "min" : 0.1,
      "max" : 10,
@@ -1543,7 +1923,9 @@
   },
 
   "tv-glitch-strength": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Strength",
      "min" : 0.1,
      "max" : 10,
@@ -1553,7 +1935,9 @@
   },
 
   "tv-glitch-speed": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Speed",
      "min" : 0.1,
      "max" : 10,
@@ -1570,8 +1954,10 @@
   },
 
   "tv-glitch-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 2000,
      "step" : 10,
@@ -1579,8 +1965,20 @@
      "default": 750
   },
 
+  "tv-glitch-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=19",
+     "keys" : ["tv-glitch-scale", "tv-glitch-strength", "tv-glitch-speed", "tv-glitch-color", "tv-glitch-animation-time"]
+  },
+
+
   "wisps-scale": {
-     "type": "scale",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
      "description" : "Scale",
      "min" : 0.1,
      "max" : 10,
@@ -1611,13 +2009,36 @@
   },
 
   "wisps-animation-time": {
-     "type": "scale",
-     "description" : "Effect Duration (milliseconds)",
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "description" : "Effect Duration (ms)",
      "min" : 100,
      "max" : 10000,
      "step" : 10,
      "dependency" : "effect-selector=20",
      "default": 1500
+  },
+
+  "wisps-reset" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ResetToDefault",
+     "description" : "Reset to default",
+     "dependency" : "effect-selector=20",
+     "keys" : ["wisps-scale", "wisps-color-1", "wisps-color-2", "wisps-color-3", "wisps-animation-time"]
+  },
+
+  "test-effect" : {
+     "type" : "button",
+     "description" : "Open effect preview window",
+     "callback" : "on_test_button_pressed",
+     "tooltip" : "Opens a window using the currently selected effect."
+  },
+
+  "ext-version" : {
+     "type": "generic",
+     "default": ""
   },
 
   "test-mode": {

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/CinnamonBurnMyWindowsTest
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/CinnamonBurnMyWindowsTest
@@ -1,0 +1,9 @@
+#!/usr/bin/python3
+
+import os
+import sys
+import gi
+gi.require_version('Gtk', '3.0')
+from gi.repository import GLib 
+
+os.execvp(GLib.get_home_dir() + "/.local/share/cinnamon/extensions/CinnamonBurnMyWindows@klangman/CinnamonBurnMyWindowsTest.py", (" ",) + tuple(sys.argv[1:]))

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/CinnamonBurnMyWindowsTest.py
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/CinnamonBurnMyWindowsTest.py
@@ -1,0 +1,33 @@
+#!/usr/bin/python3
+
+import gi
+
+gi.require_version("Gtk", "3.0")
+from gi.repository import Gtk, GLib
+
+UUID = "CinnamonBurnMyWindows@klangman"
+extensions_path  = GLib.get_home_dir() + "/.local/share/cinnamon/extensions/"
+
+class TestWindow(Gtk.Window):
+    def __init__(self):
+        super().__init__(title="Burn-My-Windows Preview Window")
+
+        self.box = Gtk.Box(spacing=10,orientation=Gtk.Orientation.VERTICAL,margin_start=50, margin_end=70, margin_top=70, margin_left=50, margin_right=50)
+        self.button = Gtk.Button(label="Close")
+        self.label = Gtk.Label.new("Close this Window to Preview the Effect!");
+        self.image = Gtk.Image.new_from_file(extensions_path + UUID + "/icons/cinnamon-burn-my-window.png")
+        self.button.connect("clicked", self.on_button_clicked)
+        self.box.add(self.image)
+        self.box.add(self.label)
+        self.box.add(self.button)
+        self.add(self.box)
+
+    def on_button_clicked(self, widget):
+        Gtk.main_quit();
+
+
+win = TestWindow()
+win.connect("destroy", Gtk.main_quit)
+win.set_default_size(650, 550)
+win.show_all()
+Gtk.main()

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Fire.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Fire.js
@@ -83,6 +83,9 @@ var Effect = class Effect {
       shader._uScale         = shader.get_uniform_location('uScale');
       shader._uMovementSpeed = shader.get_uniform_location('uMovementSpeed');
 
+      shader._uRandomColor = shader.get_uniform_location('uRandomColor');
+      shader._uSeed        = shader.get_uniform_location('uSeed');
+
       // And update all uniforms at the start of each animation.
       shader.connect('begin-animation', (shader, settings) => {
         for (let i = 0; i < 5; i++) {
@@ -94,6 +97,8 @@ var Effect = class Effect {
 
         // clang-format off
         shader.set_uniform_float(shader._u3DNoise,       1, [settings.getValue('fire-3d-noise')]);
+        shader.set_uniform_float(shader._uRandomColor,   1, [settings.getValue('fire-random-color')]);
+        shader.set_uniform_float(shader._uSeed,          1, [Math.random()]);
         shader.set_uniform_float(shader._uScale,         1, [settings.fireScale]);
         shader.set_uniform_float(shader._uMovementSpeed, 1, [settings.fireMovementSpeed]);
         // clang-format on
@@ -220,6 +225,16 @@ var Effect = class Effect {
         color3: 'rgba(207,235,255,0.84)',
         color4: 'rgb(208,243,255)',
         color5: 'rgb(255,255,255)'
+      },
+      {
+        name: _('Nuclear'),
+        scale: 1.5,
+        speed: 0.5,
+        color1: 'rgba(0,0,0,0)',
+        color2: 'rgba(2, 40, 0, 0.3)',
+        color3: 'rgba(0, 200, 50, 0.9)',
+        color4: 'rgba(255, 255, 0, 1.0)',
+        color5: 'rgba(255, 255, 255, 1.0)'
       }
     ];
 

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/metadata.json
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "CinnamonBurnMyWindows@klangman",
   "name": "Burn My Windows",
-  "version": "0.9.8",
+  "version": "0.9.9",
   "description": "Window open/close/minimize/unminimize effects based on the Burn-My-Windows Gnome extension by Schneegans",
   "url": "https://github.com/klangman/CinnamonBurnMyWindows",
   "website": "https://github.com/klangman/CinnamonBurnMyWindows",

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/CinnamonBurnMyWindows@klangman.pot
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/CinnamonBurnMyWindows@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.8\n"
+"Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.9\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-03-06 10:34-0500\n"
+"POT-Creation-Date: 2025-03-23 14:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,31 +17,31 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.2/extension.js:190 6.2/extension.js:266 6.2/extension.js:572
+#. 6.2/extension.js:193 6.2/extension.js:268 6.2/extension.js:579
 msgid "Error"
 msgstr ""
 
-#. 6.2/extension.js:190
+#. 6.2/extension.js:193
 msgid "was NOT enabled"
 msgstr ""
 
-#. 6.2/extension.js:191 6.2/extension.js:267
+#. 6.2/extension.js:194 6.2/extension.js:269
 msgid "The existing extension"
 msgstr ""
 
-#. 6.2/extension.js:191
+#. 6.2/extension.js:194
 msgid "conflicts with this extension."
 msgstr ""
 
-#. 6.2/extension.js:266
+#. 6.2/extension.js:268
 msgid "minimize/unminimize effects can not be enabled"
 msgstr ""
 
-#. 6.2/extension.js:267
+#. 6.2/extension.js:269
 msgid "already handles minimize/unminimize animation events."
 msgstr ""
 
-#. 6.2/extension.js:573
+#. 6.2/extension.js:580
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore application specific effects can not be applied to "
@@ -114,33 +114,38 @@ msgstr ""
 #. 6.2->settings-schema.json->dialog-close-effect->options
 #. 6.2->settings-schema.json->minimize-effect->options
 #. 6.2->settings-schema.json->unminimize-effect->options
-#. effects/Fire.js:122
+#. effects/Fire.js:127
 msgid "Fire"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:175
+#. effects/Fire.js:180
 msgid "Default Fire"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:185
+#. effects/Fire.js:190
 msgid "Hell Fire"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:195
+#. effects/Fire.js:200
 msgid "Dark and Smutty"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:205
+#. effects/Fire.js:210
 msgid "Cold Breeze"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:215
+#. effects/Fire.js:220
 msgid "Santa is Coming"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:230
+msgid "Nuclear"
 msgstr ""
 
 #. 6.2->settings-schema.json->effect-selector->options
@@ -425,14 +430,21 @@ msgstr ""
 
 #. 6.2->settings-schema.json->about-text->description
 msgid ""
+"\n"
+"<b>Disintegrate your windows with style.</b>\n"
+"Version: ext-version\n"
+"\n"
 "Ported to Cinnamon by Kevin Langman\n"
-"Github: https://github.com/klangman/CinnamonBurnMyWindows\n"
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
+"new\">Report an issue</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
-"Github: https://github.com/Schneegans/Burn-My-Windows\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
-"GitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
+"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
+"effect\">Github</a>"
 msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->description
@@ -615,7 +627,32 @@ msgstr ""
 #. 6.2->settings-schema.json->tv-animation-time->description
 #. 6.2->settings-schema.json->tv-glitch-animation-time->description
 #. 6.2->settings-schema.json->wisps-animation-time->description
-msgid "Effect Duration (milliseconds)"
+msgid "Effect Duration (ms)"
+msgstr ""
+
+#. 6.2->settings-schema.json->apparition-reset->description
+#. 6.2->settings-schema.json->aura-glow-reset->description
+#. 6.2->settings-schema.json->doom-reset->description
+#. 6.2->settings-schema.json->energize-a-reset->description
+#. 6.2->settings-schema.json->energize-b-reset->description
+#. 6.2->settings-schema.json->fire-reset->description
+#. 6.2->settings-schema.json->focus-reset->description
+#. 6.2->settings-schema.json->glide-reset->description
+#. 6.2->settings-schema.json->glitch-reset->description
+#. 6.2->settings-schema.json->hexagon-reset->description
+#. 6.2->settings-schema.json->incinerate-reset->description
+#. 6.2->settings-schema.json->magiclamp-reset->description
+#. 6.2->settings-schema.json->mushroom-reset->description
+#. 6.2->settings-schema.json->pixelate-reset->description
+#. 6.2->settings-schema.json->pixel-wheel-reset->description
+#. 6.2->settings-schema.json->pixel-wipe-reset->description
+#. 6.2->settings-schema.json->portal-reset->description
+#. 6.2->settings-schema.json->rgbwarp-reset->description
+#. 6.2->settings-schema.json->team-rocket-reset->description
+#. 6.2->settings-schema.json->tv-reset->description
+#. 6.2->settings-schema.json->tv-glitch-reset->description
+#. 6.2->settings-schema.json->wisps-reset->description
+msgid "Reset to default"
 msgstr ""
 
 #. 6.2->settings-schema.json->aura-glow-random-color->description
@@ -664,6 +701,17 @@ msgstr ""
 msgid "Pixel Size"
 msgstr ""
 
+#. 6.2->settings-schema.json->doom-y-hack->description
+msgid "Y offset fix for open/unminimize events"
+msgstr ""
+
+#. 6.2->settings-schema.json->doom-y-hack->tooltip
+msgid ""
+"Apply an offset to the Y axis window target position so that the open/"
+"unminimize animation completes at the right location. This is a hack fix for "
+"the Doom effect until I can find a proper fix"
+msgstr ""
+
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
 #. 6.2->settings-schema.json->fire-custom-scale->description
@@ -692,7 +740,7 @@ msgid "Custom"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire preset"
+msgid "Fire Preset"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
@@ -705,6 +753,16 @@ msgstr ""
 
 #. 6.2->settings-schema.json->fire-3d-noise->tooltip
 msgid "Creates a more dynamic fire but requires more GPU power."
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-random-color->description
+msgid "Use a Random Color (overrides other color settings)"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-random-color->tooltip
+msgid ""
+"Use a random fire color. This setting will override any preset or custom "
+"colors settings you select."
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-colors->description
@@ -817,7 +875,7 @@ msgid "This effects the quality and the costs of the animation"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom preset"
+msgid "Mushroom Preset"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description
@@ -928,4 +986,12 @@ msgstr ""
 
 #. 6.2->settings-schema.json->wisps-color-3->description
 msgid "Color #3"
+msgstr ""
+
+#. 6.2->settings-schema.json->test-effect->description
+msgid "Open effect preview window"
+msgstr ""
+
+#. 6.2->settings-schema.json->test-effect->tooltip
+msgid "Opens a window using the currently selected effect."
 msgstr ""

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/ca.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-03-06 10:34-0500\n"
+"POT-Creation-Date: 2025-03-23 14:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,31 +18,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.2/extension.js:190 6.2/extension.js:266 6.2/extension.js:572
+#. 6.2/extension.js:193 6.2/extension.js:268 6.2/extension.js:579
 msgid "Error"
 msgstr "Error"
 
-#. 6.2/extension.js:190
+#. 6.2/extension.js:193
 msgid "was NOT enabled"
 msgstr "no s'ha activat"
 
-#. 6.2/extension.js:191 6.2/extension.js:267
+#. 6.2/extension.js:194 6.2/extension.js:269
 msgid "The existing extension"
 msgstr "L'extensió existent"
 
-#. 6.2/extension.js:191
+#. 6.2/extension.js:194
 msgid "conflicts with this extension."
 msgstr "conflictivitza amb aquesta extensió."
 
-#. 6.2/extension.js:266
+#. 6.2/extension.js:268
 msgid "minimize/unminimize effects can not be enabled"
 msgstr ""
 
-#. 6.2/extension.js:267
+#. 6.2/extension.js:269
 msgid "already handles minimize/unminimize animation events."
 msgstr ""
 
-#. 6.2/extension.js:573
+#. 6.2/extension.js:580
 #, fuzzy
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
@@ -118,34 +118,39 @@ msgstr "Energitzar B"
 #. 6.2->settings-schema.json->dialog-close-effect->options
 #. 6.2->settings-schema.json->minimize-effect->options
 #. 6.2->settings-schema.json->unminimize-effect->options
-#. effects/Fire.js:122
+#. effects/Fire.js:127
 msgid "Fire"
 msgstr "Foc"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:175
+#. effects/Fire.js:180
 msgid "Default Fire"
 msgstr "Foc per defecte"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:185
+#. effects/Fire.js:190
 msgid "Hell Fire"
 msgstr "Foc infernal"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:195
+#. effects/Fire.js:200
 msgid "Dark and Smutty"
 msgstr "Fosc i brut"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:205
+#. effects/Fire.js:210
 msgid "Cold Breeze"
 msgstr "Brisa freda"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:215
+#. effects/Fire.js:220
 msgid "Santa is Coming"
 msgstr "Ja arriba el Pare Noel"
+
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:230
+msgid "Nuclear"
+msgstr ""
 
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
@@ -433,14 +438,21 @@ msgstr ""
 
 #. 6.2->settings-schema.json->about-text->description
 msgid ""
+"\n"
+"<b>Disintegrate your windows with style.</b>\n"
+"Version: ext-version\n"
+"\n"
 "Ported to Cinnamon by Kevin Langman\n"
-"Github: https://github.com/klangman/CinnamonBurnMyWindows\n"
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
+"new\">Report an issue</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
-"Github: https://github.com/Schneegans/Burn-My-Windows\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
-"GitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
+"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
+"effect\">Github</a>"
 msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->description
@@ -633,8 +645,35 @@ msgstr "Aleatorietat"
 #. 6.2->settings-schema.json->tv-animation-time->description
 #. 6.2->settings-schema.json->tv-glitch-animation-time->description
 #. 6.2->settings-schema.json->wisps-animation-time->description
-msgid "Effect Duration (milliseconds)"
+#, fuzzy
+msgid "Effect Duration (ms)"
 msgstr "Duració de l'efecte (mil·lisegons)"
+
+#. 6.2->settings-schema.json->apparition-reset->description
+#. 6.2->settings-schema.json->aura-glow-reset->description
+#. 6.2->settings-schema.json->doom-reset->description
+#. 6.2->settings-schema.json->energize-a-reset->description
+#. 6.2->settings-schema.json->energize-b-reset->description
+#. 6.2->settings-schema.json->fire-reset->description
+#. 6.2->settings-schema.json->focus-reset->description
+#. 6.2->settings-schema.json->glide-reset->description
+#. 6.2->settings-schema.json->glitch-reset->description
+#. 6.2->settings-schema.json->hexagon-reset->description
+#. 6.2->settings-schema.json->incinerate-reset->description
+#. 6.2->settings-schema.json->magiclamp-reset->description
+#. 6.2->settings-schema.json->mushroom-reset->description
+#. 6.2->settings-schema.json->pixelate-reset->description
+#. 6.2->settings-schema.json->pixel-wheel-reset->description
+#. 6.2->settings-schema.json->pixel-wipe-reset->description
+#. 6.2->settings-schema.json->portal-reset->description
+#. 6.2->settings-schema.json->rgbwarp-reset->description
+#. 6.2->settings-schema.json->team-rocket-reset->description
+#. 6.2->settings-schema.json->tv-reset->description
+#. 6.2->settings-schema.json->tv-glitch-reset->description
+#. 6.2->settings-schema.json->wisps-reset->description
+#, fuzzy
+msgid "Reset to default"
+msgstr "Foc per defecte"
 
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 #, fuzzy
@@ -685,6 +724,17 @@ msgstr "Escala vertical"
 msgid "Pixel Size"
 msgstr "Mida del píxel"
 
+#. 6.2->settings-schema.json->doom-y-hack->description
+msgid "Y offset fix for open/unminimize events"
+msgstr ""
+
+#. 6.2->settings-schema.json->doom-y-hack->tooltip
+msgid ""
+"Apply an offset to the Y axis window target position so that the open/"
+"unminimize animation completes at the right location. This is a hack fix for "
+"the Doom effect until I can find a proper fix"
+msgstr ""
+
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
 #. 6.2->settings-schema.json->fire-custom-scale->description
@@ -713,7 +763,7 @@ msgid "Custom"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire preset"
+msgid "Fire Preset"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
@@ -727,6 +777,16 @@ msgstr "Soroll 3D del foc"
 #. 6.2->settings-schema.json->fire-3d-noise->tooltip
 msgid "Creates a more dynamic fire but requires more GPU power."
 msgstr "Crea un foc més dinàmic a costa de consumir més potència gràfica"
+
+#. 6.2->settings-schema.json->fire-random-color->description
+msgid "Use a Random Color (overrides other color settings)"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-random-color->tooltip
+msgid ""
+"Use a random fire color. This setting will override any preset or custom "
+"colors settings you select."
+msgstr ""
 
 #. 6.2->settings-schema.json->fire-colors->description
 #, fuzzy
@@ -844,7 +904,7 @@ msgid "This effects the quality and the costs of the animation"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom preset"
+msgid "Mushroom Preset"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description
@@ -967,3 +1027,11 @@ msgstr "Color #2"
 #. 6.2->settings-schema.json->wisps-color-3->description
 msgid "Color #3"
 msgstr "Color #3"
+
+#. 6.2->settings-schema.json->test-effect->description
+msgid "Open effect preview window"
+msgstr ""
+
+#. 6.2->settings-schema.json->test-effect->tooltip
+msgid "Opens a window using the currently selected effect."
+msgstr ""

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/es.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-03-06 10:34-0500\n"
+"POT-Creation-Date: 2025-03-23 14:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,31 +17,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. 6.2/extension.js:190 6.2/extension.js:266 6.2/extension.js:572
+#. 6.2/extension.js:193 6.2/extension.js:268 6.2/extension.js:579
 msgid "Error"
 msgstr "Error"
 
-#. 6.2/extension.js:190
+#. 6.2/extension.js:193
 msgid "was NOT enabled"
 msgstr "no estaba habilitado"
 
-#. 6.2/extension.js:191 6.2/extension.js:267
+#. 6.2/extension.js:194 6.2/extension.js:269
 msgid "The existing extension"
 msgstr "La extensión existente"
 
-#. 6.2/extension.js:191
+#. 6.2/extension.js:194
 msgid "conflicts with this extension."
 msgstr "entra en conflicto con esta extensión."
 
-#. 6.2/extension.js:266
+#. 6.2/extension.js:268
 msgid "minimize/unminimize effects can not be enabled"
 msgstr "no se pueden activar los efectos de minimizar/maximizar"
 
-#. 6.2/extension.js:267
+#. 6.2/extension.js:269
 msgid "already handles minimize/unminimize animation events."
 msgstr "ya maneja eventos de animación de minimizar/maximizar."
 
-#. 6.2/extension.js:573
+#. 6.2/extension.js:580
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore application specific effects can not be applied to "
@@ -117,34 +117,39 @@ msgstr "Energizar B"
 #. 6.2->settings-schema.json->dialog-close-effect->options
 #. 6.2->settings-schema.json->minimize-effect->options
 #. 6.2->settings-schema.json->unminimize-effect->options
-#. effects/Fire.js:122
+#. effects/Fire.js:127
 msgid "Fire"
 msgstr "Fuego"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:175
+#. effects/Fire.js:180
 msgid "Default Fire"
 msgstr "Fuego predeterminado"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:185
+#. effects/Fire.js:190
 msgid "Hell Fire"
 msgstr "Fuego infernal"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:195
+#. effects/Fire.js:200
 msgid "Dark and Smutty"
 msgstr "Oscuro y sucio"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:205
+#. effects/Fire.js:210
 msgid "Cold Breeze"
 msgstr "Brisa fría"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:215
+#. effects/Fire.js:220
 msgid "Santa is Coming"
 msgstr "Papá Noel ya viene"
+
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:230
+msgid "Nuclear"
+msgstr ""
 
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
@@ -429,15 +434,23 @@ msgid "About Cinnamon Burn-My-Windows"
 msgstr "Acerca de Cinnamon Burn-My-Windows"
 
 #. 6.2->settings-schema.json->about-text->description
+#, fuzzy
 msgid ""
+"\n"
+"<b>Disintegrate your windows with style.</b>\n"
+"Version: ext-version\n"
+"\n"
 "Ported to Cinnamon by Kevin Langman\n"
-"Github: https://github.com/klangman/CinnamonBurnMyWindows\n"
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
+"new\">Report an issue</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
-"Github: https://github.com/Schneegans/Burn-My-Windows\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
-"GitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
+"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
+"effect\">Github</a>"
 msgstr ""
 "Adaptado a Cinnamon por Kevin Langman\n"
 "Github: https://github.com/klangman/CinnamonBurnMyWindows\n"
@@ -640,8 +653,35 @@ msgstr "Aleatoriedad"
 #. 6.2->settings-schema.json->tv-animation-time->description
 #. 6.2->settings-schema.json->tv-glitch-animation-time->description
 #. 6.2->settings-schema.json->wisps-animation-time->description
-msgid "Effect Duration (milliseconds)"
+#, fuzzy
+msgid "Effect Duration (ms)"
 msgstr "Duración del efecto (milisegundos)"
+
+#. 6.2->settings-schema.json->apparition-reset->description
+#. 6.2->settings-schema.json->aura-glow-reset->description
+#. 6.2->settings-schema.json->doom-reset->description
+#. 6.2->settings-schema.json->energize-a-reset->description
+#. 6.2->settings-schema.json->energize-b-reset->description
+#. 6.2->settings-schema.json->fire-reset->description
+#. 6.2->settings-schema.json->focus-reset->description
+#. 6.2->settings-schema.json->glide-reset->description
+#. 6.2->settings-schema.json->glitch-reset->description
+#. 6.2->settings-schema.json->hexagon-reset->description
+#. 6.2->settings-schema.json->incinerate-reset->description
+#. 6.2->settings-schema.json->magiclamp-reset->description
+#. 6.2->settings-schema.json->mushroom-reset->description
+#. 6.2->settings-schema.json->pixelate-reset->description
+#. 6.2->settings-schema.json->pixel-wheel-reset->description
+#. 6.2->settings-schema.json->pixel-wipe-reset->description
+#. 6.2->settings-schema.json->portal-reset->description
+#. 6.2->settings-schema.json->rgbwarp-reset->description
+#. 6.2->settings-schema.json->team-rocket-reset->description
+#. 6.2->settings-schema.json->tv-reset->description
+#. 6.2->settings-schema.json->tv-glitch-reset->description
+#. 6.2->settings-schema.json->wisps-reset->description
+#, fuzzy
+msgid "Reset to default"
+msgstr "predeterminado"
 
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 msgid "Random Color"
@@ -689,6 +729,17 @@ msgstr "Escala vertical"
 msgid "Pixel Size"
 msgstr "Tamaño de píxel"
 
+#. 6.2->settings-schema.json->doom-y-hack->description
+msgid "Y offset fix for open/unminimize events"
+msgstr ""
+
+#. 6.2->settings-schema.json->doom-y-hack->tooltip
+msgid ""
+"Apply an offset to the Y axis window target position so that the open/"
+"unminimize animation completes at the right location. This is a hack fix for "
+"the Doom effect until I can find a proper fix"
+msgstr ""
+
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
 #. 6.2->settings-schema.json->fire-custom-scale->description
@@ -717,7 +768,8 @@ msgid "Custom"
 msgstr "Personalizar"
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire preset"
+#, fuzzy
+msgid "Fire Preset"
 msgstr "Preajuste de fuego"
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
@@ -731,6 +783,16 @@ msgstr "Ruido 3D del fuego"
 #. 6.2->settings-schema.json->fire-3d-noise->tooltip
 msgid "Creates a more dynamic fire but requires more GPU power."
 msgstr "Crea un fuego más dinámico pero requiere más potencia de GPU."
+
+#. 6.2->settings-schema.json->fire-random-color->description
+msgid "Use a Random Color (overrides other color settings)"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-random-color->tooltip
+msgid ""
+"Use a random fire color. This setting will override any preset or custom "
+"colors settings you select."
+msgstr ""
 
 #. 6.2->settings-schema.json->fire-colors->description
 msgid "Colors 1-5"
@@ -847,7 +909,8 @@ msgid "This effects the quality and the costs of the animation"
 msgstr "Esto repercute en la calidad y el coste de la animación"
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom preset"
+#, fuzzy
+msgid "Mushroom Preset"
 msgstr "Preajuste de setas"
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description
@@ -959,3 +1022,11 @@ msgstr "Color #2"
 #. 6.2->settings-schema.json->wisps-color-3->description
 msgid "Color #3"
 msgstr "Color #3"
+
+#. 6.2->settings-schema.json->test-effect->description
+msgid "Open effect preview window"
+msgstr ""
+
+#. 6.2->settings-schema.json->test-effect->tooltip
+msgid "Opens a window using the currently selected effect."
+msgstr ""

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/fi.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/fi.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-03-06 10:34-0500\n"
+"POT-Creation-Date: 2025-03-23 14:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -18,31 +18,31 @@ msgstr ""
 "X-Generator: Poedit 2.3\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
-#. 6.2/extension.js:190 6.2/extension.js:266 6.2/extension.js:572
+#. 6.2/extension.js:193 6.2/extension.js:268 6.2/extension.js:579
 msgid "Error"
 msgstr "Virhe"
 
-#. 6.2/extension.js:190
+#. 6.2/extension.js:193
 msgid "was NOT enabled"
 msgstr "eI ollut käytössä"
 
-#. 6.2/extension.js:191 6.2/extension.js:267
+#. 6.2/extension.js:194 6.2/extension.js:269
 msgid "The existing extension"
 msgstr "Nykyinen laajennus"
 
-#. 6.2/extension.js:191
+#. 6.2/extension.js:194
 msgid "conflicts with this extension."
 msgstr "on ristiriidassa tämän laajennuksen kanssa."
 
-#. 6.2/extension.js:266
+#. 6.2/extension.js:268
 msgid "minimize/unminimize effects can not be enabled"
 msgstr ""
 
-#. 6.2/extension.js:267
+#. 6.2/extension.js:269
 msgid "already handles minimize/unminimize animation events."
 msgstr ""
 
-#. 6.2/extension.js:573
+#. 6.2/extension.js:580
 #, fuzzy
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
@@ -118,34 +118,39 @@ msgstr "Energia B"
 #. 6.2->settings-schema.json->dialog-close-effect->options
 #. 6.2->settings-schema.json->minimize-effect->options
 #. 6.2->settings-schema.json->unminimize-effect->options
-#. effects/Fire.js:122
+#. effects/Fire.js:127
 msgid "Fire"
 msgstr "Tuli"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:175
+#. effects/Fire.js:180
 msgid "Default Fire"
 msgstr "Oletus tuli"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:185
+#. effects/Fire.js:190
 msgid "Hell Fire"
 msgstr "Helvetin tuli"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:195
+#. effects/Fire.js:200
 msgid "Dark and Smutty"
 msgstr "Tumma tahra"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:205
+#. effects/Fire.js:210
 msgid "Cold Breeze"
 msgstr "Kylmää tuulta"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:215
+#. effects/Fire.js:220
 msgid "Santa is Coming"
 msgstr "Joulupukki tulee"
+
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:230
+msgid "Nuclear"
+msgstr ""
 
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
@@ -433,14 +438,21 @@ msgstr ""
 
 #. 6.2->settings-schema.json->about-text->description
 msgid ""
+"\n"
+"<b>Disintegrate your windows with style.</b>\n"
+"Version: ext-version\n"
+"\n"
 "Ported to Cinnamon by Kevin Langman\n"
-"Github: https://github.com/klangman/CinnamonBurnMyWindows\n"
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
+"new\">Report an issue</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
-"Github: https://github.com/Schneegans/Burn-My-Windows\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
-"GitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
+"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
+"effect\">Github</a>"
 msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->description
@@ -631,8 +643,35 @@ msgstr "Satunnaisuus"
 #. 6.2->settings-schema.json->tv-animation-time->description
 #. 6.2->settings-schema.json->tv-glitch-animation-time->description
 #. 6.2->settings-schema.json->wisps-animation-time->description
-msgid "Effect Duration (milliseconds)"
+#, fuzzy
+msgid "Effect Duration (ms)"
 msgstr "Tehosteen kesto (ms)"
+
+#. 6.2->settings-schema.json->apparition-reset->description
+#. 6.2->settings-schema.json->aura-glow-reset->description
+#. 6.2->settings-schema.json->doom-reset->description
+#. 6.2->settings-schema.json->energize-a-reset->description
+#. 6.2->settings-schema.json->energize-b-reset->description
+#. 6.2->settings-schema.json->fire-reset->description
+#. 6.2->settings-schema.json->focus-reset->description
+#. 6.2->settings-schema.json->glide-reset->description
+#. 6.2->settings-schema.json->glitch-reset->description
+#. 6.2->settings-schema.json->hexagon-reset->description
+#. 6.2->settings-schema.json->incinerate-reset->description
+#. 6.2->settings-schema.json->magiclamp-reset->description
+#. 6.2->settings-schema.json->mushroom-reset->description
+#. 6.2->settings-schema.json->pixelate-reset->description
+#. 6.2->settings-schema.json->pixel-wheel-reset->description
+#. 6.2->settings-schema.json->pixel-wipe-reset->description
+#. 6.2->settings-schema.json->portal-reset->description
+#. 6.2->settings-schema.json->rgbwarp-reset->description
+#. 6.2->settings-schema.json->team-rocket-reset->description
+#. 6.2->settings-schema.json->tv-reset->description
+#. 6.2->settings-schema.json->tv-glitch-reset->description
+#. 6.2->settings-schema.json->wisps-reset->description
+#, fuzzy
+msgid "Reset to default"
+msgstr "Oletus tuli"
 
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 #, fuzzy
@@ -683,6 +722,17 @@ msgstr "Pystysuora skaalaus"
 msgid "Pixel Size"
 msgstr "Pikselikoko"
 
+#. 6.2->settings-schema.json->doom-y-hack->description
+msgid "Y offset fix for open/unminimize events"
+msgstr ""
+
+#. 6.2->settings-schema.json->doom-y-hack->tooltip
+msgid ""
+"Apply an offset to the Y axis window target position so that the open/"
+"unminimize animation completes at the right location. This is a hack fix for "
+"the Doom effect until I can find a proper fix"
+msgstr ""
+
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
 #. 6.2->settings-schema.json->fire-custom-scale->description
@@ -711,7 +761,7 @@ msgid "Custom"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire preset"
+msgid "Fire Preset"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
@@ -724,6 +774,16 @@ msgstr ""
 
 #. 6.2->settings-schema.json->fire-3d-noise->tooltip
 msgid "Creates a more dynamic fire but requires more GPU power."
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-random-color->description
+msgid "Use a Random Color (overrides other color settings)"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-random-color->tooltip
+msgid ""
+"Use a random fire color. This setting will override any preset or custom "
+"colors settings you select."
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-colors->description
@@ -840,7 +900,7 @@ msgid "This effects the quality and the costs of the animation"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom preset"
+msgid "Mushroom Preset"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description
@@ -963,3 +1023,11 @@ msgstr "Väri #2"
 #. 6.2->settings-schema.json->wisps-color-3->description
 msgid "Color #3"
 msgstr "Väri #3"
+
+#. 6.2->settings-schema.json->test-effect->description
+msgid "Open effect preview window"
+msgstr ""
+
+#. 6.2->settings-schema.json->test-effect->tooltip
+msgid "Opens a window using the currently selected effect."
+msgstr ""

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/fr.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-03-06 10:34-0500\n"
+"POT-Creation-Date: 2025-03-23 14:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -18,31 +18,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.2/extension.js:190 6.2/extension.js:266 6.2/extension.js:572
+#. 6.2/extension.js:193 6.2/extension.js:268 6.2/extension.js:579
 msgid "Error"
 msgstr "Erreur"
 
-#. 6.2/extension.js:190
+#. 6.2/extension.js:193
 msgid "was NOT enabled"
 msgstr "n'a PAS été activée"
 
-#. 6.2/extension.js:191 6.2/extension.js:267
+#. 6.2/extension.js:194 6.2/extension.js:269
 msgid "The existing extension"
 msgstr "L'extension existante"
 
-#. 6.2/extension.js:191
+#. 6.2/extension.js:194
 msgid "conflicts with this extension."
 msgstr "est en conflit avec cette extension."
 
-#. 6.2/extension.js:266
+#. 6.2/extension.js:268
 msgid "minimize/unminimize effects can not be enabled"
 msgstr ""
 
-#. 6.2/extension.js:267
+#. 6.2/extension.js:269
 msgid "already handles minimize/unminimize animation events."
 msgstr ""
 
-#. 6.2/extension.js:573
+#. 6.2/extension.js:580
 #, fuzzy
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
@@ -119,34 +119,39 @@ msgstr "Energize B (Énergie B)"
 #. 6.2->settings-schema.json->dialog-close-effect->options
 #. 6.2->settings-schema.json->minimize-effect->options
 #. 6.2->settings-schema.json->unminimize-effect->options
-#. effects/Fire.js:122
+#. effects/Fire.js:127
 msgid "Fire"
 msgstr "Fire (Feu)"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:175
+#. effects/Fire.js:180
 msgid "Default Fire"
 msgstr "Default Fire (Feu par défaut)"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:185
+#. effects/Fire.js:190
 msgid "Hell Fire"
 msgstr "Hell Fire (Feu d'Enfer)"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:195
+#. effects/Fire.js:200
 msgid "Dark and Smutty"
 msgstr "Dark and Smutty (Sombre et coquin)"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:205
+#. effects/Fire.js:210
 msgid "Cold Breeze"
 msgstr "Cold Breeze (Brise fraîche)"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:215
+#. effects/Fire.js:220
 msgid "Santa is Coming"
 msgstr "Santa is Coming (Le Père Noël arrive)"
+
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:230
+msgid "Nuclear"
+msgstr ""
 
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
@@ -434,14 +439,21 @@ msgstr ""
 
 #. 6.2->settings-schema.json->about-text->description
 msgid ""
+"\n"
+"<b>Disintegrate your windows with style.</b>\n"
+"Version: ext-version\n"
+"\n"
 "Ported to Cinnamon by Kevin Langman\n"
-"Github: https://github.com/klangman/CinnamonBurnMyWindows\n"
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
+"new\">Report an issue</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
-"Github: https://github.com/Schneegans/Burn-My-Windows\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
-"GitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
+"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
+"effect\">Github</a>"
 msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->description
@@ -637,8 +649,35 @@ msgstr "Aléatoire"
 #. 6.2->settings-schema.json->tv-animation-time->description
 #. 6.2->settings-schema.json->tv-glitch-animation-time->description
 #. 6.2->settings-schema.json->wisps-animation-time->description
-msgid "Effect Duration (milliseconds)"
+#, fuzzy
+msgid "Effect Duration (ms)"
 msgstr "Durée de l'effet (millisecondes)"
+
+#. 6.2->settings-schema.json->apparition-reset->description
+#. 6.2->settings-schema.json->aura-glow-reset->description
+#. 6.2->settings-schema.json->doom-reset->description
+#. 6.2->settings-schema.json->energize-a-reset->description
+#. 6.2->settings-schema.json->energize-b-reset->description
+#. 6.2->settings-schema.json->fire-reset->description
+#. 6.2->settings-schema.json->focus-reset->description
+#. 6.2->settings-schema.json->glide-reset->description
+#. 6.2->settings-schema.json->glitch-reset->description
+#. 6.2->settings-schema.json->hexagon-reset->description
+#. 6.2->settings-schema.json->incinerate-reset->description
+#. 6.2->settings-schema.json->magiclamp-reset->description
+#. 6.2->settings-schema.json->mushroom-reset->description
+#. 6.2->settings-schema.json->pixelate-reset->description
+#. 6.2->settings-schema.json->pixel-wheel-reset->description
+#. 6.2->settings-schema.json->pixel-wipe-reset->description
+#. 6.2->settings-schema.json->portal-reset->description
+#. 6.2->settings-schema.json->rgbwarp-reset->description
+#. 6.2->settings-schema.json->team-rocket-reset->description
+#. 6.2->settings-schema.json->tv-reset->description
+#. 6.2->settings-schema.json->tv-glitch-reset->description
+#. 6.2->settings-schema.json->wisps-reset->description
+#, fuzzy
+msgid "Reset to default"
+msgstr "Default Fire (Feu par défaut)"
 
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 #, fuzzy
@@ -689,6 +728,17 @@ msgstr "Échelle verticale"
 msgid "Pixel Size"
 msgstr "Taille d'un pixel"
 
+#. 6.2->settings-schema.json->doom-y-hack->description
+msgid "Y offset fix for open/unminimize events"
+msgstr ""
+
+#. 6.2->settings-schema.json->doom-y-hack->tooltip
+msgid ""
+"Apply an offset to the Y axis window target position so that the open/"
+"unminimize animation completes at the right location. This is a hack fix for "
+"the Doom effect until I can find a proper fix"
+msgstr ""
+
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
 #. 6.2->settings-schema.json->fire-custom-scale->description
@@ -717,7 +767,7 @@ msgid "Custom"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire preset"
+msgid "Fire Preset"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
@@ -731,6 +781,16 @@ msgstr "Perturbation 3D du feu"
 #. 6.2->settings-schema.json->fire-3d-noise->tooltip
 msgid "Creates a more dynamic fire but requires more GPU power."
 msgstr "Crée un feu plus dynamique mais nécessite plus de puissance GPU."
+
+#. 6.2->settings-schema.json->fire-random-color->description
+msgid "Use a Random Color (overrides other color settings)"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-random-color->tooltip
+msgid ""
+"Use a random fire color. This setting will override any preset or custom "
+"colors settings you select."
+msgstr ""
 
 #. 6.2->settings-schema.json->fire-colors->description
 #, fuzzy
@@ -848,7 +908,7 @@ msgid "This effects the quality and the costs of the animation"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom preset"
+msgid "Mushroom Preset"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description
@@ -971,3 +1031,11 @@ msgstr "Couleur n°2"
 #. 6.2->settings-schema.json->wisps-color-3->description
 msgid "Color #3"
 msgstr "Couleur n°3"
+
+#. 6.2->settings-schema.json->test-effect->description
+msgid "Open effect preview window"
+msgstr ""
+
+#. 6.2->settings-schema.json->test-effect->tooltip
+msgid "Opens a window using the currently selected effect."
+msgstr ""

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/hu.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-03-06 10:34-0500\n"
+"POT-Creation-Date: 2025-03-23 14:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,31 +18,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.2/extension.js:190 6.2/extension.js:266 6.2/extension.js:572
+#. 6.2/extension.js:193 6.2/extension.js:268 6.2/extension.js:579
 msgid "Error"
 msgstr "Hiba"
 
-#. 6.2/extension.js:190
+#. 6.2/extension.js:193
 msgid "was NOT enabled"
 msgstr "NEM volt engedélyezve"
 
-#. 6.2/extension.js:191 6.2/extension.js:267
+#. 6.2/extension.js:194 6.2/extension.js:269
 msgid "The existing extension"
 msgstr "A meglévő bővítmény"
 
-#. 6.2/extension.js:191
+#. 6.2/extension.js:194
 msgid "conflicts with this extension."
 msgstr "ütközik ezzel a bővitménnyel."
 
-#. 6.2/extension.js:266
+#. 6.2/extension.js:268
 msgid "minimize/unminimize effects can not be enabled"
 msgstr ""
 
-#. 6.2/extension.js:267
+#. 6.2/extension.js:269
 msgid "already handles minimize/unminimize animation events."
 msgstr ""
 
-#. 6.2/extension.js:573
+#. 6.2/extension.js:580
 #, fuzzy
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
@@ -118,34 +118,39 @@ msgstr "Energizálja B"
 #. 6.2->settings-schema.json->dialog-close-effect->options
 #. 6.2->settings-schema.json->minimize-effect->options
 #. 6.2->settings-schema.json->unminimize-effect->options
-#. effects/Fire.js:122
+#. effects/Fire.js:127
 msgid "Fire"
 msgstr "Tűz"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:175
+#. effects/Fire.js:180
 msgid "Default Fire"
 msgstr "Alapértelmezett Tűz"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:185
+#. effects/Fire.js:190
 msgid "Hell Fire"
 msgstr "Pokol Tüze"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:195
+#. effects/Fire.js:200
 msgid "Dark and Smutty"
 msgstr "Sötét és piszkos"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:205
+#. effects/Fire.js:210
 msgid "Cold Breeze"
 msgstr "Hideg szellő"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:215
+#. effects/Fire.js:220
 msgid "Santa is Coming"
 msgstr "Jön a Mikulás"
+
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:230
+msgid "Nuclear"
+msgstr ""
 
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
@@ -433,14 +438,21 @@ msgstr ""
 
 #. 6.2->settings-schema.json->about-text->description
 msgid ""
+"\n"
+"<b>Disintegrate your windows with style.</b>\n"
+"Version: ext-version\n"
+"\n"
 "Ported to Cinnamon by Kevin Langman\n"
-"Github: https://github.com/klangman/CinnamonBurnMyWindows\n"
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
+"new\">Report an issue</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
-"Github: https://github.com/Schneegans/Burn-My-Windows\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
-"GitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
+"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
+"effect\">Github</a>"
 msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->description
@@ -632,8 +644,35 @@ msgstr "Véletlenszerűség"
 #. 6.2->settings-schema.json->tv-animation-time->description
 #. 6.2->settings-schema.json->tv-glitch-animation-time->description
 #. 6.2->settings-schema.json->wisps-animation-time->description
-msgid "Effect Duration (milliseconds)"
+#, fuzzy
+msgid "Effect Duration (ms)"
 msgstr "Effektus időtartama (ezredmásodperc)"
+
+#. 6.2->settings-schema.json->apparition-reset->description
+#. 6.2->settings-schema.json->aura-glow-reset->description
+#. 6.2->settings-schema.json->doom-reset->description
+#. 6.2->settings-schema.json->energize-a-reset->description
+#. 6.2->settings-schema.json->energize-b-reset->description
+#. 6.2->settings-schema.json->fire-reset->description
+#. 6.2->settings-schema.json->focus-reset->description
+#. 6.2->settings-schema.json->glide-reset->description
+#. 6.2->settings-schema.json->glitch-reset->description
+#. 6.2->settings-schema.json->hexagon-reset->description
+#. 6.2->settings-schema.json->incinerate-reset->description
+#. 6.2->settings-schema.json->magiclamp-reset->description
+#. 6.2->settings-schema.json->mushroom-reset->description
+#. 6.2->settings-schema.json->pixelate-reset->description
+#. 6.2->settings-schema.json->pixel-wheel-reset->description
+#. 6.2->settings-schema.json->pixel-wipe-reset->description
+#. 6.2->settings-schema.json->portal-reset->description
+#. 6.2->settings-schema.json->rgbwarp-reset->description
+#. 6.2->settings-schema.json->team-rocket-reset->description
+#. 6.2->settings-schema.json->tv-reset->description
+#. 6.2->settings-schema.json->tv-glitch-reset->description
+#. 6.2->settings-schema.json->wisps-reset->description
+#, fuzzy
+msgid "Reset to default"
+msgstr "Alapértelmezett Tűz"
 
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 #, fuzzy
@@ -684,6 +723,17 @@ msgstr "Függőleges skála"
 msgid "Pixel Size"
 msgstr "Képpont méret"
 
+#. 6.2->settings-schema.json->doom-y-hack->description
+msgid "Y offset fix for open/unminimize events"
+msgstr ""
+
+#. 6.2->settings-schema.json->doom-y-hack->tooltip
+msgid ""
+"Apply an offset to the Y axis window target position so that the open/"
+"unminimize animation completes at the right location. This is a hack fix for "
+"the Doom effect until I can find a proper fix"
+msgstr ""
+
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
 #. 6.2->settings-schema.json->fire-custom-scale->description
@@ -712,7 +762,7 @@ msgid "Custom"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire preset"
+msgid "Fire Preset"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
@@ -725,6 +775,16 @@ msgstr ""
 
 #. 6.2->settings-schema.json->fire-3d-noise->tooltip
 msgid "Creates a more dynamic fire but requires more GPU power."
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-random-color->description
+msgid "Use a Random Color (overrides other color settings)"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-random-color->tooltip
+msgid ""
+"Use a random fire color. This setting will override any preset or custom "
+"colors settings you select."
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-colors->description
@@ -843,7 +903,7 @@ msgid "This effects the quality and the costs of the animation"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom preset"
+msgid "Mushroom Preset"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description
@@ -966,3 +1026,11 @@ msgstr "Szín #2"
 #. 6.2->settings-schema.json->wisps-color-3->description
 msgid "Color #3"
 msgstr "Szín #3"
+
+#. 6.2->settings-schema.json->test-effect->description
+msgid "Open effect preview window"
+msgstr ""
+
+#. 6.2->settings-schema.json->test-effect->tooltip
+msgid "Opens a window using the currently selected effect."
+msgstr ""

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/nl.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-03-06 10:34-0500\n"
+"POT-Creation-Date: 2025-03-23 14:04-0400\n"
 "PO-Revision-Date: 2025-02-21 10:10+0100\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,31 +16,31 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.2/extension.js:190 6.2/extension.js:266 6.2/extension.js:572
+#. 6.2/extension.js:193 6.2/extension.js:268 6.2/extension.js:579
 msgid "Error"
 msgstr "Fout"
 
-#. 6.2/extension.js:190
+#. 6.2/extension.js:193
 msgid "was NOT enabled"
 msgstr "was NIET ingeschakeld"
 
-#. 6.2/extension.js:191 6.2/extension.js:267
+#. 6.2/extension.js:194 6.2/extension.js:269
 msgid "The existing extension"
 msgstr "De bestaande extensie"
 
-#. 6.2/extension.js:191
+#. 6.2/extension.js:194
 msgid "conflicts with this extension."
 msgstr "conflicteert met deze extensie."
 
-#. 6.2/extension.js:266
+#. 6.2/extension.js:268
 msgid "minimize/unminimize effects can not be enabled"
 msgstr ""
 
-#. 6.2/extension.js:267
+#. 6.2/extension.js:269
 msgid "already handles minimize/unminimize animation events."
 msgstr ""
 
-#. 6.2/extension.js:573
+#. 6.2/extension.js:580
 #, fuzzy
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
@@ -117,34 +117,39 @@ msgstr "Energize B"
 #. 6.2->settings-schema.json->dialog-close-effect->options
 #. 6.2->settings-schema.json->minimize-effect->options
 #. 6.2->settings-schema.json->unminimize-effect->options
-#. effects/Fire.js:122
+#. effects/Fire.js:127
 msgid "Fire"
 msgstr "Vuur"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:175
+#. effects/Fire.js:180
 msgid "Default Fire"
 msgstr "Standaard Vuur"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:185
+#. effects/Fire.js:190
 msgid "Hell Fire"
 msgstr "Hel Vuur"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:195
+#. effects/Fire.js:200
 msgid "Dark and Smutty"
 msgstr "Donker en Smerig"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:205
+#. effects/Fire.js:210
 msgid "Cold Breeze"
 msgstr "Koude Bries"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:215
+#. effects/Fire.js:220
 msgid "Santa is Coming"
 msgstr "Kerstman komt eraan"
+
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:230
+msgid "Nuclear"
+msgstr ""
 
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
@@ -432,14 +437,21 @@ msgstr ""
 
 #. 6.2->settings-schema.json->about-text->description
 msgid ""
+"\n"
+"<b>Disintegrate your windows with style.</b>\n"
+"Version: ext-version\n"
+"\n"
 "Ported to Cinnamon by Kevin Langman\n"
-"Github: https://github.com/klangman/CinnamonBurnMyWindows\n"
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
+"new\">Report an issue</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
-"Github: https://github.com/Schneegans/Burn-My-Windows\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
-"GitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
+"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
+"effect\">Github</a>"
 msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->description
@@ -634,8 +646,35 @@ msgstr "Willekeurigheid"
 #. 6.2->settings-schema.json->tv-animation-time->description
 #. 6.2->settings-schema.json->tv-glitch-animation-time->description
 #. 6.2->settings-schema.json->wisps-animation-time->description
-msgid "Effect Duration (milliseconds)"
+#, fuzzy
+msgid "Effect Duration (ms)"
 msgstr "Effect Duur (milliseconden)"
+
+#. 6.2->settings-schema.json->apparition-reset->description
+#. 6.2->settings-schema.json->aura-glow-reset->description
+#. 6.2->settings-schema.json->doom-reset->description
+#. 6.2->settings-schema.json->energize-a-reset->description
+#. 6.2->settings-schema.json->energize-b-reset->description
+#. 6.2->settings-schema.json->fire-reset->description
+#. 6.2->settings-schema.json->focus-reset->description
+#. 6.2->settings-schema.json->glide-reset->description
+#. 6.2->settings-schema.json->glitch-reset->description
+#. 6.2->settings-schema.json->hexagon-reset->description
+#. 6.2->settings-schema.json->incinerate-reset->description
+#. 6.2->settings-schema.json->magiclamp-reset->description
+#. 6.2->settings-schema.json->mushroom-reset->description
+#. 6.2->settings-schema.json->pixelate-reset->description
+#. 6.2->settings-schema.json->pixel-wheel-reset->description
+#. 6.2->settings-schema.json->pixel-wipe-reset->description
+#. 6.2->settings-schema.json->portal-reset->description
+#. 6.2->settings-schema.json->rgbwarp-reset->description
+#. 6.2->settings-schema.json->team-rocket-reset->description
+#. 6.2->settings-schema.json->tv-reset->description
+#. 6.2->settings-schema.json->tv-glitch-reset->description
+#. 6.2->settings-schema.json->wisps-reset->description
+#, fuzzy
+msgid "Reset to default"
+msgstr "Standaard Vuur"
 
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 #, fuzzy
@@ -686,6 +725,17 @@ msgstr "Verticale Schaal"
 msgid "Pixel Size"
 msgstr "Pixel Grootte"
 
+#. 6.2->settings-schema.json->doom-y-hack->description
+msgid "Y offset fix for open/unminimize events"
+msgstr ""
+
+#. 6.2->settings-schema.json->doom-y-hack->tooltip
+msgid ""
+"Apply an offset to the Y axis window target position so that the open/"
+"unminimize animation completes at the right location. This is a hack fix for "
+"the Doom effect until I can find a proper fix"
+msgstr ""
+
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
 #. 6.2->settings-schema.json->fire-custom-scale->description
@@ -714,7 +764,7 @@ msgid "Custom"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire preset"
+msgid "Fire Preset"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
@@ -728,6 +778,16 @@ msgstr "Vuur 3D-ruis"
 #. 6.2->settings-schema.json->fire-3d-noise->tooltip
 msgid "Creates a more dynamic fire but requires more GPU power."
 msgstr "Creëert een dynamischer vuur, maar vereist meer GPU-kracht."
+
+#. 6.2->settings-schema.json->fire-random-color->description
+msgid "Use a Random Color (overrides other color settings)"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-random-color->tooltip
+msgid ""
+"Use a random fire color. This setting will override any preset or custom "
+"colors settings you select."
+msgstr ""
 
 #. 6.2->settings-schema.json->fire-colors->description
 #, fuzzy
@@ -845,7 +905,7 @@ msgid "This effects the quality and the costs of the animation"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom preset"
+msgid "Mushroom Preset"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description
@@ -968,3 +1028,11 @@ msgstr "Kleur #2"
 #. 6.2->settings-schema.json->wisps-color-3->description
 msgid "Color #3"
 msgstr "Kleur #3"
+
+#. 6.2->settings-schema.json->test-effect->description
+msgid "Open effect preview window"
+msgstr ""
+
+#. 6.2->settings-schema.json->test-effect->tooltip
+msgid "Opens a window using the currently selected effect."
+msgstr ""

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/pt.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/pt.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-03-06 10:34-0500\n"
+"POT-Creation-Date: 2025-03-23 14:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,31 +18,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. 6.2/extension.js:190 6.2/extension.js:266 6.2/extension.js:572
+#. 6.2/extension.js:193 6.2/extension.js:268 6.2/extension.js:579
 msgid "Error"
 msgstr "Erro"
 
-#. 6.2/extension.js:190
+#. 6.2/extension.js:193
 msgid "was NOT enabled"
 msgstr "não foi ativo"
 
-#. 6.2/extension.js:191 6.2/extension.js:267
+#. 6.2/extension.js:194 6.2/extension.js:269
 msgid "The existing extension"
 msgstr "A extensão existente"
 
-#. 6.2/extension.js:191
+#. 6.2/extension.js:194
 msgid "conflicts with this extension."
 msgstr "conflita com esta extensão."
 
-#. 6.2/extension.js:266
+#. 6.2/extension.js:268
 msgid "minimize/unminimize effects can not be enabled"
 msgstr ""
 
-#. 6.2/extension.js:267
+#. 6.2/extension.js:269
 msgid "already handles minimize/unminimize animation events."
 msgstr ""
 
-#. 6.2/extension.js:573
+#. 6.2/extension.js:580
 #, fuzzy
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
@@ -119,34 +119,39 @@ msgstr "Energizar B"
 #. 6.2->settings-schema.json->dialog-close-effect->options
 #. 6.2->settings-schema.json->minimize-effect->options
 #. 6.2->settings-schema.json->unminimize-effect->options
-#. effects/Fire.js:122
+#. effects/Fire.js:127
 msgid "Fire"
 msgstr "Fogo"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:175
+#. effects/Fire.js:180
 msgid "Default Fire"
 msgstr "Fogo Padrão"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:185
+#. effects/Fire.js:190
 msgid "Hell Fire"
 msgstr "Fogo do Inferno"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:195
+#. effects/Fire.js:200
 msgid "Dark and Smutty"
 msgstr "Escuro e Sujo"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:205
+#. effects/Fire.js:210
 msgid "Cold Breeze"
 msgstr "Briza Fria"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:215
+#. effects/Fire.js:220
 msgid "Santa is Coming"
 msgstr "O Pai Natal está Vindo"
+
+#. 6.2->settings-schema.json->fire-presets->options
+#. effects/Fire.js:230
+msgid "Nuclear"
+msgstr ""
 
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
@@ -434,14 +439,21 @@ msgstr ""
 
 #. 6.2->settings-schema.json->about-text->description
 msgid ""
+"\n"
+"<b>Disintegrate your windows with style.</b>\n"
+"Version: ext-version\n"
+"\n"
 "Ported to Cinnamon by Kevin Langman\n"
-"Github: https://github.com/klangman/CinnamonBurnMyWindows\n"
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
+"new\">Report an issue</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
-"Github: https://github.com/Schneegans/Burn-My-Windows\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
-"GitHub: https://github.com/hermes83/compiz-alike-magic-lamp-effect"
+"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
+"effect\">Github</a>"
 msgstr ""
 
 #. 6.2->settings-schema.json->app-rules->description
@@ -632,8 +644,35 @@ msgstr "Aleatoriedade"
 #. 6.2->settings-schema.json->tv-animation-time->description
 #. 6.2->settings-schema.json->tv-glitch-animation-time->description
 #. 6.2->settings-schema.json->wisps-animation-time->description
-msgid "Effect Duration (milliseconds)"
+#, fuzzy
+msgid "Effect Duration (ms)"
 msgstr "Duração do Efeito (milissegundos)"
+
+#. 6.2->settings-schema.json->apparition-reset->description
+#. 6.2->settings-schema.json->aura-glow-reset->description
+#. 6.2->settings-schema.json->doom-reset->description
+#. 6.2->settings-schema.json->energize-a-reset->description
+#. 6.2->settings-schema.json->energize-b-reset->description
+#. 6.2->settings-schema.json->fire-reset->description
+#. 6.2->settings-schema.json->focus-reset->description
+#. 6.2->settings-schema.json->glide-reset->description
+#. 6.2->settings-schema.json->glitch-reset->description
+#. 6.2->settings-schema.json->hexagon-reset->description
+#. 6.2->settings-schema.json->incinerate-reset->description
+#. 6.2->settings-schema.json->magiclamp-reset->description
+#. 6.2->settings-schema.json->mushroom-reset->description
+#. 6.2->settings-schema.json->pixelate-reset->description
+#. 6.2->settings-schema.json->pixel-wheel-reset->description
+#. 6.2->settings-schema.json->pixel-wipe-reset->description
+#. 6.2->settings-schema.json->portal-reset->description
+#. 6.2->settings-schema.json->rgbwarp-reset->description
+#. 6.2->settings-schema.json->team-rocket-reset->description
+#. 6.2->settings-schema.json->tv-reset->description
+#. 6.2->settings-schema.json->tv-glitch-reset->description
+#. 6.2->settings-schema.json->wisps-reset->description
+#, fuzzy
+msgid "Reset to default"
+msgstr "Fogo Padrão"
 
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 #, fuzzy
@@ -684,6 +723,17 @@ msgstr "Escala  Vertical"
 msgid "Pixel Size"
 msgstr "Tamanho do Pixel"
 
+#. 6.2->settings-schema.json->doom-y-hack->description
+msgid "Y offset fix for open/unminimize events"
+msgstr ""
+
+#. 6.2->settings-schema.json->doom-y-hack->tooltip
+msgid ""
+"Apply an offset to the Y axis window target position so that the open/"
+"unminimize animation completes at the right location. This is a hack fix for "
+"the Doom effect until I can find a proper fix"
+msgstr ""
+
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
 #. 6.2->settings-schema.json->fire-custom-scale->description
@@ -712,7 +762,7 @@ msgid "Custom"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire preset"
+msgid "Fire Preset"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
@@ -725,6 +775,16 @@ msgstr ""
 
 #. 6.2->settings-schema.json->fire-3d-noise->tooltip
 msgid "Creates a more dynamic fire but requires more GPU power."
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-random-color->description
+msgid "Use a Random Color (overrides other color settings)"
+msgstr ""
+
+#. 6.2->settings-schema.json->fire-random-color->tooltip
+msgid ""
+"Use a random fire color. This setting will override any preset or custom "
+"colors settings you select."
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-colors->description
@@ -841,7 +901,7 @@ msgid "This effects the quality and the costs of the animation"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom preset"
+msgid "Mushroom Preset"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description
@@ -964,3 +1024,11 @@ msgstr "Cor #2"
 #. 6.2->settings-schema.json->wisps-color-3->description
 msgid "Color #3"
 msgstr "Cor #3"
+
+#. 6.2->settings-schema.json->test-effect->description
+msgid "Open effect preview window"
+msgstr ""
+
+#. 6.2->settings-schema.json->test-effect->tooltip
+msgid "Opens a window using the currently selected effect."
+msgstr ""

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/resources/shaders/fire.frag
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/resources/shaders/fire.frag
@@ -22,6 +22,8 @@ uniform vec4 uGradient2;
 uniform vec4 uGradient3;
 uniform vec4 uGradient4;
 uniform vec4 uGradient5;
+uniform bool uRandomColor;
+uniform float uSeed;
 
 // These may be configurable in the future.
 const float EDGE_FADE  = 70.0;
@@ -29,7 +31,7 @@ const float FADE_WIDTH = 0.1;
 const float HIDE_TIME  = 0.4;
 
 // This maps the input value from [0..1] to a color from the gradient.
-vec4 getFireColor(float v) {
+vec4 getFireColor(float v, vec4 c0, vec4 c1, vec4 c2, vec4 c3, vec4 c4) {
   float steps[5];
   steps[0] = 0.0;
   steps[1] = 0.2;
@@ -38,11 +40,11 @@ vec4 getFireColor(float v) {
   steps[4] = 0.8;
 
   vec4 colors[5];
-  colors[0] = uGradient1;
-  colors[1] = uGradient2;
-  colors[2] = uGradient3;
-  colors[3] = uGradient4;
-  colors[4] = uGradient5;
+  colors[0] = c0;
+  colors[1] = c1;
+  colors[2] = c2;
+  colors[3] = c3;
+  colors[4] = c4;
 
   if (v < steps[0]) {
     return colors[0];
@@ -114,7 +116,25 @@ void main() {
   noise *= effectMask.y;
 
   // Map noise value to color.
-  vec4 fire = getFireColor(noise);
+  vec4 fire = vec4(0.0);
+
+  if (uRandomColor) {
+    vec3 baseColor0 = offsetHue(vec3(1.0, 0.0, 0.0), hash11(uSeed));
+    vec3 baseColor1 = offsetHue(baseColor0, 0.1);
+    vec3 baseColor2 = offsetHue(baseColor1, 0.1);
+
+    // Hardcoding some alpha values.
+    vec4 c0 = vec4(baseColor0, 0.0);
+    vec4 c1 = vec4(baseColor0, 0.5);
+    vec4 c2 = vec4(baseColor1, 0.8);
+    vec4 c3 = vec4(baseColor1, 0.9);
+    vec4 c4 = vec4(baseColor2, 1.0);
+
+    fire = getFireColor(noise, c0, c1, c2, c3, c4);
+  } else {
+    fire =
+      getFireColor(noise, uGradient1, uGradient2, uGradient3, uGradient4, uGradient5);
+  }
 
   // Get the window texture.
   vec4 oColor = getInputColor(iTexCoord.st);


### PR DESCRIPTION
- Added a "Reset to default" button for each effect under the "Effect Settings" tab.
- Added an "Open effect preview window" button to "Effect Settings" tab. It opens a preview window to test out the currently selected effect in the "Show setting for effect" drop down list.
- Added a custom "scale" widget that puts the label, scale, and number in a line to save GUI space. It also "marks" the default value for the setting.
- Fixed the issue where some setting under the "Effect Settings" were not appearing properly after changing the "Show settings for effect" drop-down. It turns out that adding a common element at the end of the effect settings somehow makes the issue disappear. So I didn't really "fix" anything but adding the "Open effect preview window" button at the bottom of the effect settings section has the added benefit of avoiding the issue.
- Added a custom "About page" widget to improve the look of the about tab and changed the URLs to clickable links. Also added a "Report an issue" link and the version number to the about tab.
- Added buttons to set or clear all the random set check boxes.
- Added BMW Gnome version changes to add a random color option to the Fire effect, also added a "Nuclear" preset.
- Added an Doom setting option to manually adjust the target location for the Doom open effect so that people can work-around the Doom effect issue while I work on finding a proper fix.