### PR TITLE
OSD with numbers: Hide percentage level in Caps Lock and Num Lock OSDs, add if statements under setLabel method

### DIFF
--- a/OsdWithNumber@JosephMcc/files/OsdWithNumber@JosephMcc/osdWithNumber.js
+++ b/OsdWithNumber@JosephMcc/files/OsdWithNumber@JosephMcc/osdWithNumber.js
@@ -91,8 +91,15 @@ class OsdWindow extends Clutter.Actor {
 
     setLabel(label) {
         this._label.visible = label != null;
-        if (this._label.visible)
+        
+        if (this._label.visible){
             this._label.text = label;
+            // hide percentage when pressing Caps Lock or Number Lock keys 
+            this._percentage.hide();
+        }
+        else
+            // Show percentage when pressing Caps Lock or Number Lock keys
+            this._percentage.show();
     }
 
     setLevel(value) {


### PR DESCRIPTION
This Adds a simple feature to OsdWithNumber Extension by @JosephMcc where the On-screen Displays now hide previously changed volume or brightness level whenever the user toggles Caps Lock or Num Lock, which don't require percentage values