### PR TITLE
OsdWithNumber@JosephMcc: Hide percentage when it's not needed

### DIFF
--- a/OsdWithNumber@JosephMcc/files/OsdWithNumber@JosephMcc/osdWithNumber.js
+++ b/OsdWithNumber@JosephMcc/files/OsdWithNumber@JosephMcc/osdWithNumber.js
@@ -91,8 +91,13 @@ class OsdWindow extends Clutter.Actor {
 
     setLabel(label) {
         this._label.visible = label != null;
-        if (this._label.visible)
+
+        if (this._label.visible) {
             this._label.text = label;
+            this._percentage.hide();
+        } else {
+            this._percentage.show();
+        }
     }
 
     setLevel(value) {


### PR DESCRIPTION
Thanks to @GabrielCamara3526 for the fix. Just cleaned up whitespace usage a bit.

https://github.com/linuxmint/cinnamon-spices-extensions/pull/857