### PR TITLE
[CinnamonBurnMyWindows@klangman] V1.0.1 Fix for translated presets

### DIFF
--- a/CinnamonBurnMyWindows@klangman/CHANGELOG.md
+++ b/CinnamonBurnMyWindows@klangman/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.1
+
+* Fix Fire and Mushroom effect presets when using a translation of Burn-My-Windows. Note: This fix will reset the prefix settings to default so you will need to reconfigure the extension to use your desired preset if you had previously setup a preset other then the default one.
+* Added "Open/Close Edge" and "Open/Close Offset" options under the Magic Lamp effect settings. These options allow you to set the monitor edge location where the Magic Lamp effect will animate from/to for open and close events. The default will be the "Closest edge to mouse pointer" but you can set it to a specific edge and offset. For example, you could direct the animations to towards the Main Menu location. These options only apply to Open/Close events as the minimize/unminimize events will continue to use the location of the windows icon on the window-list as it's source/target location.
+* Make the custom scale widget show tooltips when hovering over the widgets label rather than just when hovering the scale bar.
+
 ## 1.0.0
 
 Here we are at version 1.0. I had hoped to have the full suite of effects enabled for version 1.0, but that will have to wait for version 1.1 when Cinnamon 6.6 is out 🤞. I wanted to get this release out there since it has two fixes that makes the current feature set work without any major issues, so in that way maybe it is a suitable 1.0 release after all!

--- a/CinnamonBurnMyWindows@klangman/README.md
+++ b/CinnamonBurnMyWindows@klangman/README.md
@@ -6,14 +6,18 @@ This is a Cinnamon port of the Gnome extension Burn-my-Windows which can be foun
 
 https://github.com/Schneegans/Burn-My-Windows
 
-**Please go to the above link and support their project since this is merely a port of their fine work!**
+Also includes a port of the Gnome Magic Lamp effect which can be found here:
+
+https://github.com/hermes83/compiz-alike-magic-lamp-effect
+
+**Please go to the above links and support their project since this is merely a port of their fine work!**
 **But DO NOT use this Github link to report issues. See Feedback section below**
 
 ## Requirements
 
 Cinnamon 6.2 (Mint 22) or better. 
 
-This extension needs the Cinnamon.GLSLEffect class which is only available in Cinnamon 6.2.
+This extension needs the Cinnamon.GLSLEffect class which is only available in Cinnamon 6.2 or better.
 
 ## Known issues
 
@@ -22,6 +26,7 @@ This extension needs the Cinnamon.GLSLEffect class which is only available in Ci
 3. The Doom open effect seems to finish animating at a noticeably lower position than where the window is actually located. This results in the sudden jump up after the animation is completed. When used as a close effect it works correctly. There is a Doom effect option called "Y offset fix for open/unminimize events" which allows you to manually fix this issue while I look for a proper fix that works for everyone.
 4. The window shadows are not part of the animation and therefore they suddenly appear or disappear right after or before the animation.
 5. After upgrading to 0.9.8 the Fire effect setting and the effects included in the randomized sets will be reset to default.
+6. After upgrading to 1.0.1 the Fire and Mushroom preset selections will be reset to default.
 
 ### Currently these effects are working in Cinnamon:
 

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/CustomWidgets.py
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/CustomWidgets.py
@@ -397,6 +397,7 @@ class CompactScale(SettingsWidget):
         settings.listen(key, self.on_key_value_changed);
 
         if "tooltip" in info:
+           self.label.set_tooltip_text(info["tooltip"])
            self.content_widget.set_tooltip_text(info["tooltip"])
 
     def on_key_value_changed(self, key, value):

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/extension.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/extension.js
@@ -500,7 +500,7 @@ class BurnMyWindows {
     }
 
     // Now add a cool shader to our window actor!
-    const shader = effect.shaderFactory.getShader(event);
+    const shader = effect.shaderFactory.getShader(event, this._settings);
     actor.add_effect_with_name('burn-my-windows-effect', shader);
 
     // At the end of the animation, we restore the scale of the overview clone (if any)

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/settings-schema.json
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/settings-schema.json
@@ -60,7 +60,7 @@
                 "glitch-scale", "glitch-strength", "glitch-speed", "glitch-color", "glitch-animation-time", "glitch-reset",
                 "hexagon-scale", "hexagon-line-width", "hexagon-line-color", "hexagon-glow-color", "hexagon-additive-blending", "hexagon-animation-time", "hexagon-reset",
                 "incinerate-scale", "incinerate-turbulence", "incinerate-color", "incinerate-use-pointer", "incinerate-animation-time", "incinerate-reset",
-                "magiclamp-effect", "magiclamp-x-tiles", "magiclamp-y-tiles", "magiclamp-animation-time", "magiclamp-reset",
+                "magiclamp-effect", "magiclamp-edge", "magiclamp-edge-offset", "magiclamp-x-tiles", "magiclamp-y-tiles", "magiclamp-animation-time", "magiclamp-reset",
                 "mushroom-presets", "mushroom-animation-time", "mushroom-reset",
                 "pixelate-noise", "pixelate-pixel-size", "pixelate-animation-time", "pixelate-reset",
                 "pixel-wheel-spoke-count", "pixel-wheel-pixel-size", "pixel-wheel-animation-time", "pixel-wheel-reset",
@@ -101,7 +101,7 @@
     "type" : "custom",
     "file" : "CustomWidgets.py",
     "widget" : "About",
-    "description" : "\n<b>Disintegrate your windows with style.</b>\nVersion: ext-version\n\nPorted to Cinnamon by Kevin Langman\n<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / <a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/new\">Report an issue</a>\n\nBased on the Burn-My-Windows code by Schneegans and contributors\n<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n\nThe Magic Lamp Effect is ported from code by hermes83\n<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-effect\">Github</a>",
+    "description" : "\n<b>Disintegrate your windows with style.</b>\nVersion: ext-version\n\nPorted to Cinnamon by Kevin Langman\n<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / <a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/new\">Report an issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/103\">Website</a>\n\nBased on the Burn-My-Windows code by Schneegans and contributors\n<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a> / <a href=\"https://ko-fi.com/schneegans\">Ko-fi</a>\n\nThe Magic Lamp Effect is ported from code by hermes83\n<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-effect\">Github</a>",
     "icon" : "/icons/cinnamon-burn-my-window.png"
   },
 
@@ -845,15 +845,15 @@
 
   "fire-presets": {
     "type": "combobox",
-    "default": "Default Fire",
+    "default": 0,
     "options": {
-      "Default Fire": "Default Fire",
-      "Hell Fire" : "Hell Fire",
-      "Dark and Smutty" : "Dark and Smutty",
-      "Cold Breeze" : "Cold Breeze",
-      "Santa is Coming" : "Santa is Coming",
-      "Nuclear" : "Nuclear",
-      "Custom" : "Custom"
+      "Default Fire": 0,
+      "Hell Fire" : 1,
+      "Dark and Smutty" : 2,
+      "Cold Breeze" : 3,
+      "Santa is Coming" : 4,
+      "Nuclear" : 5,
+      "Custom" : 1000
     },
     "description": "Fire Preset",
     "dependency" : "effect-selector=5"
@@ -1284,6 +1284,34 @@
     "tooltip": "The effect can be a smooth curve or a wavy animation. The random option will randomly choose between the two and the Appear/Disappear options use different effects whether a window is appearing or disappearing from the screen"
   },
 
+  "magiclamp-edge": {
+    "type": "combobox",
+    "default": 4,
+    "options": {
+      "Top": 0,
+      "Bottom": 1,
+      "Left": 2,
+      "Right": 3,
+      "Edge closest to mouse pointer": 4
+    },
+    "description": "Open/Close Edge",
+    "dependency" : "effect-selector=26",
+    "tooltip": "The monitor edge where a window should originate from when opening, or disappear towards when closing. This setting is not used for minimize or unminimize events"
+  },
+
+  "magiclamp-edge-offset": {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "CompactScale",
+     "default": 50,
+     "min": 0,
+     "max": 100,
+     "step": 1,
+     "description": "Open/Close Edge Offset",
+     "dependency" : "effect-selector=26",
+     "tooltip": "The offset from the top or left of the \"Open/Close Edge\" that the animation should use as the origin/target of the animation. This is a percentage of the monitors width/height and it does not apply to minimize/unminimize events or when the \"Open/Close Edge\" is set to \"Edge closest to mouse pointer\""
+  },
+
   "magiclamp-x-tiles": {
      "type" : "custom",
      "file" : "CustomWidgets.py",
@@ -1328,7 +1356,7 @@
      "widget" : "ResetToDefault",
      "description" : "Reset to default",
      "dependency" : "effect-selector=26",
-     "keys" : ["magiclamp-effect", "magiclamp-x-tiles", "magiclamp-y-tiles", "magiclamp-animation-time"]
+     "keys" : ["magiclamp-effect", "magiclamp-edge", "magiclamp-edge-offset", "magiclamp-x-tiles", "magiclamp-y-tiles", "magiclamp-animation-time"]
   },
 
 
@@ -1365,17 +1393,17 @@
 
   "mushroom-presets": {
     "type": "combobox",
-    "default": "New Bros 2",
+    "default": 1,
     "options": {
-      "8Bit Plumber" : "8Bit Plumber",
-      "New Bros 2" : "New Bros 2",
-      "The True North" : "The True North",
-      "Red White and Blue" : "Red White and Blue",
-      "Rainbow" : "Rainbow",
-      "Cattuccino" : "Cattuccino",
-      "Dracula" : "Dracula",
-      "Sparkle" : "Sparkle",
-      "Custom" : "Custom"
+      "8Bit Plumber" : 0,
+      "New Bros 2" : 1,
+      "The True North" : 2,
+      "Red White and Blue" : 3,
+      "Rainbow" : 4,
+      "Cattuccino" : 5,
+      "Dracula" : 6,
+      "Sparkle" : 7,
+      "Custom" : 1000
     },
     "description": "Mushroom Preset",
     "dependency" : "effect-selector=25"

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Fire.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Fire.js
@@ -239,11 +239,10 @@ var Effect = class Effect {
     ];
 
     // Find the preset that is selected and setup the fire settings appropriately
-    let name = settings.getValue("fire-presets");
-    if (name == "Custom") {
+    let idx = settings.getValue("fire-presets");
+    if (idx == 1000 /*Custom*/) {
       settings.fireScale =  settings.getValue("fire-custom-scale");
       settings.fireMovementSpeed = settings.getValue("fire-custom-movement-speed");
-
       settings.fireColor = [];
       settings.fireColor.push( settings.getValue("fire-custom-color-1") );
       settings.fireColor.push( settings.getValue("fire-custom-color-2") );
@@ -251,21 +250,16 @@ var Effect = class Effect {
       settings.fireColor.push( settings.getValue("fire-custom-color-4") );
       settings.fireColor.push( settings.getValue("fire-custom-color-5") );
     } else {
-
-      presets.forEach((preset, i) => {
-        if (preset.name == name) {
-          settings.fireScale =  preset.speed;
-          settings.fireMovementSpeed = preset.scale;
-
-          settings.fireColor = [];
-          settings.fireColor.push(preset.color1);
-          settings.fireColor.push(preset.color2);
-          settings.fireColor.push(preset.color3);
-          settings.fireColor.push(preset.color4);
-          settings.fireColor.push(preset.color5);
-
-        }
-      });
+      if (isNaN(idx) || idx < 0 || idx >= presets.length)
+         idx = 0;
+      settings.fireScale =  presets[idx].speed;
+      settings.fireMovementSpeed = presets[idx].scale;
+      settings.fireColor = [];
+      settings.fireColor.push(presets[idx].color1);
+      settings.fireColor.push(presets[idx].color2);
+      settings.fireColor.push(presets[idx].color3);
+      settings.fireColor.push(presets[idx].color4);
+      settings.fireColor.push(presets[idx].color5);
     }
   }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Mushroom.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Mushroom.js
@@ -364,8 +364,8 @@ var Effect = class Effect {
      }
     ];
 
-    let name = settings.getValue("mushroom-presets");
-    if (name == "Custom") {
+    let idx = settings.getValue("mushroom-presets");
+    if (idx == 1000 /*Custom*/) {
       settings.mushroomScaleStyle    = settings.getValue("mushroom-custom-scale-style");
       settings.mushroomSparkCount    = settings.getValue("mushroom-custom-spark-count");
       settings.mushroomSparkColor    = settings.getValue("mushroom-custom-spark-color");
@@ -383,27 +383,25 @@ var Effect = class Effect {
       settings.mushroomStarColors.push(settings.getValue("mushroom-custom-star-color-4"));
       settings.mushroomStarColors.push(settings.getValue("mushroom-custom-star-color-5"));
     } else {
-      presets.find((preset, i) => {
-        if (preset.name == name) {
-          settings.mushroomScaleStyle    = preset.ScaleStyle;
-          settings.mushroomSparkCount    = preset.SparkCount;
-          settings.mushroomSparkColor    = preset.SparkColor;
-          settings.mushroomSparkRotation = preset.SparkRotation;
-          settings.mushroomRaysColor     = preset.RayColor;
-          settings.mushroomRingCount     = preset.RingCount;
-          settings.mushroomRingRotation  = preset.RingRotation;
-          settings.mushroomStarCount     = preset.StarCount;
+      if (isNaN(idx) || idx < 0 || idx >= presets.length)
+         idx = 1;
+      settings.mushroomScaleStyle    = presets[idx].ScaleStyle;
+      settings.mushroomSparkCount    = presets[idx].SparkCount;
+      settings.mushroomSparkColor    = presets[idx].SparkColor;
+      settings.mushroomSparkRotation = presets[idx].SparkRotation;
+      settings.mushroomRaysColor     = presets[idx].RayColor;
+      settings.mushroomRingCount     = presets[idx].RingCount;
+      settings.mushroomRingRotation  = presets[idx].RingRotation;
+      settings.mushroomStarCount     = presets[idx].StarCount;
 
-          settings.mushroomStarColors = [];
-          settings.mushroomStarColors.push(preset.color0);
-          settings.mushroomStarColors.push(preset.color1);
-          settings.mushroomStarColors.push(preset.color2);
-          settings.mushroomStarColors.push(preset.color3);
-          settings.mushroomStarColors.push(preset.color4);
-          settings.mushroomStarColors.push(preset.color5);
-          return(true);
-        }
-      });
+      settings.mushroomStarColors = [];
+      settings.mushroomStarColors.push(presets[idx].color0);
+      settings.mushroomStarColors.push(presets[idx].color1);
+      settings.mushroomStarColors.push(presets[idx].color2);
+      settings.mushroomStarColors.push(presets[idx].color3);
+      settings.mushroomStarColors.push(presets[idx].color4);
+      settings.mushroomStarColors.push(presets[idx].color5);
+       return(true);
     }
   }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/metadata.json
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "CinnamonBurnMyWindows@klangman",
   "name": "Burn My Windows",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Window open/close/minimize/unminimize effects based on the Burn-My-Windows Gnome extension by Schneegans",
   "url": "https://github.com/klangman/CinnamonBurnMyWindows",
   "website": "https://github.com/klangman/CinnamonBurnMyWindows",

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/CinnamonBurnMyWindows@klangman.pot
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/CinnamonBurnMyWindows@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: CinnamonBurnMyWindows@klangman 1.0.0\n"
+"Project-Id-Version: CinnamonBurnMyWindows@klangman 1.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-03-26 21:19-0400\n"
+"POT-Creation-Date: 2025-04-16 23:10-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -437,10 +437,12 @@ msgid ""
 "Ported to Cinnamon by Kevin Langman\n"
 "<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
 "<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
-"new\">Report an issue</a>\n"
+"new\">Report an issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/"
+"extensions/view/103\">Website</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
-"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a> / <a "
+"href=\"https://ko-fi.com/schneegans\">Ko-fi</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
 "<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
@@ -858,6 +860,50 @@ msgid ""
 "randomly choose between the two and the Appear/Disappear options use "
 "different effects whether a window is appearing or disappearing from the "
 "screen"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Top"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Bottom"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Left"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Right"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Edge closest to mouse pointer"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->description
+msgid "Open/Close Edge"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->tooltip
+msgid ""
+"The monitor edge where a window should originate from when opening, or "
+"disappear towards when closing. This setting is not used for minimize or "
+"unminimize events"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge-offset->description
+msgid "Open/Close Edge Offset"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge-offset->tooltip
+msgid ""
+"The offset from the top or left of the \"Open/Close Edge\" that the "
+"animation should use as the origin/target of the animation. This is a "
+"percentage of the monitors width/height and it does not apply to minimize/"
+"unminimize events or when the \"Open/Close Edge\" is set to \"Edge closest "
+"to mouse pointer\""
 msgstr ""
 
 #. 6.2->settings-schema.json->magiclamp-x-tiles->description

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/ca.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-03-26 21:19-0400\n"
+"POT-Creation-Date: 2025-04-16 23:10-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -445,10 +445,12 @@ msgid ""
 "Ported to Cinnamon by Kevin Langman\n"
 "<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
 "<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
-"new\">Report an issue</a>\n"
+"new\">Report an issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/"
+"extensions/view/103\">Website</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
-"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a> / <a "
+"href=\"https://ko-fi.com/schneegans\">Ko-fi</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
 "<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
@@ -886,6 +888,50 @@ msgid ""
 "randomly choose between the two and the Appear/Disappear options use "
 "different effects whether a window is appearing or disappearing from the "
 "screen"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Top"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Bottom"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Left"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Right"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Edge closest to mouse pointer"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->description
+msgid "Open/Close Edge"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->tooltip
+msgid ""
+"The monitor edge where a window should originate from when opening, or "
+"disappear towards when closing. This setting is not used for minimize or "
+"unminimize events"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge-offset->description
+msgid "Open/Close Edge Offset"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge-offset->tooltip
+msgid ""
+"The offset from the top or left of the \"Open/Close Edge\" that the "
+"animation should use as the origin/target of the animation. This is a "
+"percentage of the monitors width/height and it does not apply to minimize/"
+"unminimize events or when the \"Open/Close Edge\" is set to \"Edge closest "
+"to mouse pointer\""
 msgstr ""
 
 #. 6.2->settings-schema.json->magiclamp-x-tiles->description

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/es.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-03-26 21:19-0400\n"
+"POT-Creation-Date: 2025-04-16 23:10-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -434,6 +434,7 @@ msgid "About Cinnamon Burn-My-Windows"
 msgstr "Acerca de Cinnamon Burn-My-Windows"
 
 #. 6.2->settings-schema.json->about-text->description
+#, fuzzy
 msgid ""
 "\n"
 "<b>Disintegrate your windows with style.</b>\n"
@@ -442,10 +443,12 @@ msgid ""
 "Ported to Cinnamon by Kevin Langman\n"
 "<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
 "<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
-"new\">Report an issue</a>\n"
+"new\">Report an issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/"
+"extensions/view/103\">Website</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
-"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a> / <a "
+"href=\"https://ko-fi.com/schneegans\">Ko-fi</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
 "<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
@@ -898,6 +901,50 @@ msgstr ""
 "aleatoria elegirá aleatoriamente entre las dos y las opciones Aparecer/"
 "Desaparecer utilizan efectos diferentes si una ventana aparece o desaparece "
 "de la pantalla"
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Top"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Bottom"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Left"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Right"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Edge closest to mouse pointer"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->description
+msgid "Open/Close Edge"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->tooltip
+msgid ""
+"The monitor edge where a window should originate from when opening, or "
+"disappear towards when closing. This setting is not used for minimize or "
+"unminimize events"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge-offset->description
+msgid "Open/Close Edge Offset"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge-offset->tooltip
+msgid ""
+"The offset from the top or left of the \"Open/Close Edge\" that the "
+"animation should use as the origin/target of the animation. This is a "
+"percentage of the monitors width/height and it does not apply to minimize/"
+"unminimize events or when the \"Open/Close Edge\" is set to \"Edge closest "
+"to mouse pointer\""
+msgstr ""
 
 #. 6.2->settings-schema.json->magiclamp-x-tiles->description
 msgid "X Tiles"

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/fi.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/fi.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-03-26 21:19-0400\n"
+"POT-Creation-Date: 2025-04-16 23:10-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -435,6 +435,7 @@ msgid "About Cinnamon Burn-My-Windows"
 msgstr "Tietoja Cinnamon Burn-My-Windows"
 
 #. 6.2->settings-schema.json->about-text->description
+#, fuzzy
 msgid ""
 "\n"
 "<b>Disintegrate your windows with style.</b>\n"
@@ -443,10 +444,12 @@ msgid ""
 "Ported to Cinnamon by Kevin Langman\n"
 "<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
 "<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
-"new\">Report an issue</a>\n"
+"new\">Report an issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/"
+"extensions/view/103\">Website</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
-"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a> / <a "
+"href=\"https://ko-fi.com/schneegans\">Ko-fi</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
 "<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
@@ -899,6 +902,50 @@ msgstr ""
 "satunnaisesti näiden kahden välillä ja Ilmestyminen/Katoaminen käyttävät "
 "erilaisia ​​tehosteita riippumatta siitä, ilmestyykö tai katoaako ikkuna "
 "näytöltä"
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Top"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Bottom"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Left"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Right"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Edge closest to mouse pointer"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->description
+msgid "Open/Close Edge"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->tooltip
+msgid ""
+"The monitor edge where a window should originate from when opening, or "
+"disappear towards when closing. This setting is not used for minimize or "
+"unminimize events"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge-offset->description
+msgid "Open/Close Edge Offset"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge-offset->tooltip
+msgid ""
+"The offset from the top or left of the \"Open/Close Edge\" that the "
+"animation should use as the origin/target of the animation. This is a "
+"percentage of the monitors width/height and it does not apply to minimize/"
+"unminimize events or when the \"Open/Close Edge\" is set to \"Edge closest "
+"to mouse pointer\""
+msgstr ""
 
 #. 6.2->settings-schema.json->magiclamp-x-tiles->description
 msgid "X Tiles"

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/fr.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-03-26 21:19-0400\n"
+"POT-Creation-Date: 2025-04-16 23:10-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -446,10 +446,12 @@ msgid ""
 "Ported to Cinnamon by Kevin Langman\n"
 "<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
 "<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
-"new\">Report an issue</a>\n"
+"new\">Report an issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/"
+"extensions/view/103\">Website</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
-"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a> / <a "
+"href=\"https://ko-fi.com/schneegans\">Ko-fi</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
 "<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
@@ -890,6 +892,50 @@ msgid ""
 "randomly choose between the two and the Appear/Disappear options use "
 "different effects whether a window is appearing or disappearing from the "
 "screen"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Top"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Bottom"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Left"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Right"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Edge closest to mouse pointer"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->description
+msgid "Open/Close Edge"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->tooltip
+msgid ""
+"The monitor edge where a window should originate from when opening, or "
+"disappear towards when closing. This setting is not used for minimize or "
+"unminimize events"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge-offset->description
+msgid "Open/Close Edge Offset"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge-offset->tooltip
+msgid ""
+"The offset from the top or left of the \"Open/Close Edge\" that the "
+"animation should use as the origin/target of the animation. This is a "
+"percentage of the monitors width/height and it does not apply to minimize/"
+"unminimize events or when the \"Open/Close Edge\" is set to \"Edge closest "
+"to mouse pointer\""
 msgstr ""
 
 #. 6.2->settings-schema.json->magiclamp-x-tiles->description

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/hu.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-03-26 21:19-0400\n"
+"POT-Creation-Date: 2025-04-16 23:10-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -437,6 +437,7 @@ msgid "About Cinnamon Burn-My-Windows"
 msgstr "Cinnamon Égjenek az Ablakaim Névjegye"
 
 #. 6.2->settings-schema.json->about-text->description
+#, fuzzy
 msgid ""
 "\n"
 "<b>Disintegrate your windows with style.</b>\n"
@@ -445,10 +446,12 @@ msgid ""
 "Ported to Cinnamon by Kevin Langman\n"
 "<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
 "<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
-"new\">Report an issue</a>\n"
+"new\">Report an issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/"
+"extensions/view/103\">Website</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
-"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a> / <a "
+"href=\"https://ko-fi.com/schneegans\">Ko-fi</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
 "<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
@@ -906,6 +909,50 @@ msgstr ""
 "véletlenszerűen választ a kettő közül, és a Megjelenés/Eltűnés opciók "
 "különböző effektusokat használnak, függetlenül attól, hogy egy ablak "
 "megjelenik vagy eltűnik a képernyőről"
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Top"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Bottom"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Left"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Right"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Edge closest to mouse pointer"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->description
+msgid "Open/Close Edge"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->tooltip
+msgid ""
+"The monitor edge where a window should originate from when opening, or "
+"disappear towards when closing. This setting is not used for minimize or "
+"unminimize events"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge-offset->description
+msgid "Open/Close Edge Offset"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge-offset->tooltip
+msgid ""
+"The offset from the top or left of the \"Open/Close Edge\" that the "
+"animation should use as the origin/target of the animation. This is a "
+"percentage of the monitors width/height and it does not apply to minimize/"
+"unminimize events or when the \"Open/Close Edge\" is set to \"Edge closest "
+"to mouse pointer\""
+msgstr ""
 
 #. 6.2->settings-schema.json->magiclamp-x-tiles->description
 msgid "X Tiles"

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/nl.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-03-26 21:19-0400\n"
+"POT-Creation-Date: 2025-04-16 23:10-0400\n"
 "PO-Revision-Date: 2025-02-21 10:10+0100\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -444,10 +444,12 @@ msgid ""
 "Ported to Cinnamon by Kevin Langman\n"
 "<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
 "<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
-"new\">Report an issue</a>\n"
+"new\">Report an issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/"
+"extensions/view/103\">Website</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
-"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a> / <a "
+"href=\"https://ko-fi.com/schneegans\">Ko-fi</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
 "<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
@@ -887,6 +889,50 @@ msgid ""
 "randomly choose between the two and the Appear/Disappear options use "
 "different effects whether a window is appearing or disappearing from the "
 "screen"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Top"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Bottom"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Left"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Right"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Edge closest to mouse pointer"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->description
+msgid "Open/Close Edge"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->tooltip
+msgid ""
+"The monitor edge where a window should originate from when opening, or "
+"disappear towards when closing. This setting is not used for minimize or "
+"unminimize events"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge-offset->description
+msgid "Open/Close Edge Offset"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge-offset->tooltip
+msgid ""
+"The offset from the top or left of the \"Open/Close Edge\" that the "
+"animation should use as the origin/target of the animation. This is a "
+"percentage of the monitors width/height and it does not apply to minimize/"
+"unminimize events or when the \"Open/Close Edge\" is set to \"Edge closest "
+"to mouse pointer\""
 msgstr ""
 
 #. 6.2->settings-schema.json->magiclamp-x-tiles->description

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/pt.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/pt.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-03-26 21:19-0400\n"
+"POT-Creation-Date: 2025-04-16 23:10-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -446,10 +446,12 @@ msgid ""
 "Ported to Cinnamon by Kevin Langman\n"
 "<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
 "<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
-"new\">Report an issue</a>\n"
+"new\">Report an issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/"
+"extensions/view/103\">Website</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
-"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a>\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a> / <a "
+"href=\"https://ko-fi.com/schneegans\">Ko-fi</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
 "<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
@@ -883,6 +885,50 @@ msgid ""
 "randomly choose between the two and the Appear/Disappear options use "
 "different effects whether a window is appearing or disappearing from the "
 "screen"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Top"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Bottom"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Left"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Right"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->options
+msgid "Edge closest to mouse pointer"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->description
+msgid "Open/Close Edge"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge->tooltip
+msgid ""
+"The monitor edge where a window should originate from when opening, or "
+"disappear towards when closing. This setting is not used for minimize or "
+"unminimize events"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge-offset->description
+msgid "Open/Close Edge Offset"
+msgstr ""
+
+#. 6.2->settings-schema.json->magiclamp-edge-offset->tooltip
+msgid ""
+"The offset from the top or left of the \"Open/Close Edge\" that the "
+"animation should use as the origin/target of the animation. This is a "
+"percentage of the monitors width/height and it does not apply to minimize/"
+"unminimize events or when the \"Open/Close Edge\" is set to \"Edge closest "
+"to mouse pointer\""
 msgstr ""
 
 #. 6.2->settings-schema.json->magiclamp-x-tiles->description


### PR DESCRIPTION
- Fix Fire and Mushroom effect presets when using a translation of Burn-My-Windows. Note: This fix will reset the prefix settings to default so you will need to reconfigure the extension to use your desired preset if you had previously setup a preset other then the default one.

- Added "Open/Close Edge" and "Open/Close Offset" options under the Magic Lamp effect settings. These options allow you to set the monitor edge location where the Magic Lamp effect will animate from/to for open and close events. The default will be the "Closest edge to mouse pointer" but you can set it to a specific edge and offset. For example, you could direct the animations to towards the Main Menu location. These options only apply to Open/Close events as the minimize/unminimize events will continue to use the location of the windows icon on the window-list as it's source/target location.

- Make the custom scale widget show tooltips when hovering over the widgets label rather than just when hovering the scale bar.