### PR TITLE
[Flipper@connerdev] V2.0.2 Disabled option + Fix

### DIFF
--- a/Flipper@connerdev/CHANGELOG.md
+++ b/Flipper@connerdev/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2.0.2
+
+* Added a Disable effect option which will use no workspace switch effect, not even the default Cinnamon workspace switch effect. Since Cinnamon does not offer a way to independently disable the workspace switch effect, with this option you can disable the effect but still allow of the desktop and window effects.
+* Fixed the disappearing effect settings problem using a "hack" fix. Adding a permanent empty label field below the effect settings avoids the issue.
+
 ## 2.0.1
 
 - Make windows that are 'visible on all workspaces' also visible on the animated workspace clones

--- a/Flipper@connerdev/README.md
+++ b/Flipper@connerdev/README.md
@@ -1,6 +1,12 @@
 # Flipper
 
-Fancy workspace switching extension with 7 different effect animation options
+Fancy workspace switching extension with 7 different effect animation options: Cube, Deck, Flip, Pop, Rolodex, Slide and Stack!
+
+Each effect has 5 user adjustable settings: Animation duration, Zoom amount, Fade transition, Background dim amount, Transition easing.
+
+You can use your favorite effect or use a random effect chosen from your selection of the 7 effects.
+
+Also has a "Disabled" option which will not only disable all the Flipper effects but also prevents the default Cinnamon workspace switch effect. Great for people who want a super fast workspace switch but don't want to disable all the other Cinnamon desktop and window effects.
 
 ## Requirements
 
@@ -35,8 +41,6 @@ If you know of other methods of switching the workspace where the Flipper effect
 1. When using Flipper with two or more Monitors attached, the effects will only appear on the primary display. At some point I plan on adding options to control how Flipper works on multi-monitor setups, but it might be a while before I find the time to work on that.
 
 2. If you enable the "Include Panels" option in the Flipper configuration, the panels will disappear while the effect is in action and then reappear when it is done. This is far from ideal, so I recommend that you leave this option disabled so that the panels remain hidden, only reappearing after returning to the normal desktop.
-
-3. In the setting configure window under the "Effect Settings" tab, when changing the "Show setting for effect" drop-down to select a different effect, sometimes the contents under the "Effect Specific Settings" title will not properly update. Because of this, only a subset of the available options are visible. I believe this is a Cinnamon bug. You can force Cinnamon to properly redraw the options by selecting the "General" tab then returning to the "Effect Settings" tab again. After that, the complete set of "Effect Specific Settings" should be visible.
 
 ## Installation
 

--- a/Flipper@connerdev/files/Flipper@connerdev/5.4/extension.js
+++ b/Flipper@connerdev/files/Flipper@connerdev/5.4/extension.js
@@ -28,7 +28,8 @@ const TransitionEffect = {
    Rolodex:    4,
    Slide:      5,
    Stack:      6,
-   Randomized: 7
+   Randomized: 7,
+   Disabled:   8
 }
 
 let enabled;
@@ -61,9 +62,17 @@ Flipper.prototype = {
 
         this.effectName = this.getEffectName();
         if (this.effectName == null ) {
-            // Nothing enabled, so just do a normal workspace switch!
-            Main.soundManager.play('switch');
-            new_workspace.activate(global.get_current_time());
+            if (settings.transitionEffect === TransitionEffect.Disabled) {
+               // Disable Cinnamon effects while the Workspace switch is happening
+               let save = Main.animations_enabled
+               Main.animations_enabled = false;
+               new_workspace.activate(global.get_current_time());
+               Main.animations_enabled = save;
+            } else {
+               // No random effects enabled, so just do a normal workspace switch!
+               Main.soundManager.play('switch');
+               new_workspace.activate(global.get_current_time());
+            }
             Main.wm.showWorkspaceOSD();
             return;
         }
@@ -489,6 +498,7 @@ Flipper.prototype = {
             return "Stack";
          }
       }
+      // Return null if there are no random effects selected, or if the "Disabled" option was selected
       return null;
     },
 

--- a/Flipper@connerdev/files/Flipper@connerdev/5.4/settings-schema.json
+++ b/Flipper@connerdev/files/Flipper@connerdev/5.4/settings-schema.json
@@ -40,8 +40,14 @@
                 "pop-animationTime", "pop-pullaway", "pop-fade", "pop-dim-factor", "pop-rotateEffect",
                 "rolodex-animationTime", "rolodex-pullaway", "rolodex-fade", "rolodex-dim-factor", "rolodex-rotateEffect",
                 "slide-animationTime", "slide-pullaway", "slide-fade", "slide-dim-factor", "slide-rotateEffect",
-                "stack-animationTime", "stack-pullaway", "stack-fade", "stack-dim-factor", "stack-rotateEffect"]
+                "stack-animationTime", "stack-pullaway", "stack-fade", "stack-dim-factor", "stack-rotateEffect",
+                "hack-fix-blank"]
     }
+  },
+
+  "hack-fix-blank": {
+    "type" : "label",
+    "description" : ""
   },
 
   "cube-random-include": {
@@ -490,6 +496,7 @@
   "transitionEffect": {
     "type": "combobox",
     "description": "Workspace Transition Effect",
+    "tooltip": "Select the type of workspace switch effect that will be used. The \"Randomized\" option allows you to choose which effects can be chosen at random for each workspace switch. The \"Disabled\" option will show no effect, not even the Cinnamon built in effect during a workspace switch.",
     "default": "Stack",
     "options": {
       "Cube": 0,
@@ -499,7 +506,8 @@
       "Rolodex": 4,
       "Slide": 5,
       "Stack" : 6,
-      "Randomized" : 7
+      "Randomized" : 7,
+      "Disabled" : 8
     }
   },
   "patchmoveToWorkspace": {

--- a/Flipper@connerdev/files/Flipper@connerdev/metadata.json
+++ b/Flipper@connerdev/files/Flipper@connerdev/metadata.json
@@ -20,7 +20,7 @@
         "5.0",
         "5.4"
     ],
-    "version": "2.0.1",
+    "version": "2.0.2",
     "url": "https://github.com/ConnerHansen/Flipper",
     "uuid": "Flipper@connerdev",
     "name": "Flipper",

--- a/Flipper@connerdev/files/Flipper@connerdev/po/Flipper@connerdev.pot
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/Flipper@connerdev.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: Flipper@connerdev 2.0.1\n"
+"Project-Id-Version: Flipper@connerdev 2.0.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 00:15-0500\n"
+"POT-Creation-Date: 2025-04-17 21:29-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -313,8 +313,20 @@ msgstr ""
 msgid "Workspace Transition Effect"
 msgstr ""
 
+#. 5.4->settings-schema.json->transitionEffect->tooltip
+msgid ""
+"Select the type of workspace switch effect that will be used. The "
+"\"Randomized\" option allows you to choose which effects can be chosen at "
+"random for each workspace switch. The \"Disabled\" option will show no "
+"effect, not even the Cinnamon built in effect during a workspace switch."
+msgstr ""
+
 #. 5.4->settings-schema.json->transitionEffect->options
 msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/Flipper@connerdev/files/Flipper@connerdev/po/ca.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/ca.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 00:15-0500\n"
+"POT-Creation-Date: 2025-04-17 21:29-0400\n"
 "PO-Revision-Date: 2025-02-13 23:47+0100\n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -315,9 +315,21 @@ msgstr "Ajusts exclusius d'efecte"
 msgid "Workspace Transition Effect"
 msgstr "Efecte de transició de l'espai de treball"
 
+#. 5.4->settings-schema.json->transitionEffect->tooltip
+msgid ""
+"Select the type of workspace switch effect that will be used. The "
+"\"Randomized\" option allows you to choose which effects can be chosen at "
+"random for each workspace switch. The \"Disabled\" option will show no "
+"effect, not even the Cinnamon built in effect during a workspace switch."
+msgstr ""
+
 #. 5.4->settings-schema.json->transitionEffect->options
 msgid "Randomized"
 msgstr "Aleatori"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Disabled"
+msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description
 msgid "Use Flipper effect with the Workspace Switcher applet"

--- a/Flipper@connerdev/files/Flipper@connerdev/po/da.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 00:15-0500\n"
+"POT-Creation-Date: 2025-04-17 21:29-0400\n"
 "PO-Revision-Date: 2017-06-10 17:39+0200\n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -317,8 +317,20 @@ msgstr ""
 msgid "Workspace Transition Effect"
 msgstr "Overgangseffekt"
 
+#. 5.4->settings-schema.json->transitionEffect->tooltip
+msgid ""
+"Select the type of workspace switch effect that will be used. The "
+"\"Randomized\" option allows you to choose which effects can be chosen at "
+"random for each workspace switch. The \"Disabled\" option will show no "
+"effect, not even the Cinnamon built in effect during a workspace switch."
+msgstr ""
+
 #. 5.4->settings-schema.json->transitionEffect->options
 msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/Flipper@connerdev/files/Flipper@connerdev/po/de.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/de.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 00:15-0500\n"
+"POT-Creation-Date: 2025-04-17 21:29-0400\n"
 "PO-Revision-Date: 2021-03-02 21:09+0100\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -317,8 +317,20 @@ msgstr ""
 msgid "Workspace Transition Effect"
 msgstr "Übergangseffekt"
 
+#. 5.4->settings-schema.json->transitionEffect->tooltip
+msgid ""
+"Select the type of workspace switch effect that will be used. The "
+"\"Randomized\" option allows you to choose which effects can be chosen at "
+"random for each workspace switch. The \"Disabled\" option will show no "
+"effect, not even the Cinnamon built in effect during a workspace switch."
+msgstr ""
+
 #. 5.4->settings-schema.json->transitionEffect->options
 msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/Flipper@connerdev/files/Flipper@connerdev/po/es.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/es.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 00:15-0500\n"
+"POT-Creation-Date: 2025-04-17 21:29-0400\n"
 "PO-Revision-Date: 2024-12-21 17:49+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -314,9 +314,21 @@ msgstr "Ajustes específicos de los efectos"
 msgid "Workspace Transition Effect"
 msgstr "Efecto de transición del espacio de trabajo"
 
+#. 5.4->settings-schema.json->transitionEffect->tooltip
+msgid ""
+"Select the type of workspace switch effect that will be used. The "
+"\"Randomized\" option allows you to choose which effects can be chosen at "
+"random for each workspace switch. The \"Disabled\" option will show no "
+"effect, not even the Cinnamon built in effect during a workspace switch."
+msgstr ""
+
 #. 5.4->settings-schema.json->transitionEffect->options
 msgid "Randomized"
 msgstr "Aleatorio"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Disabled"
+msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description
 msgid "Use Flipper effect with the Workspace Switcher applet"

--- a/Flipper@connerdev/files/Flipper@connerdev/po/eu.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/eu.po
@@ -9,7 +9,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 00:15-0500\n"
+"POT-Creation-Date: 2025-04-17 21:29-0400\n"
 "PO-Revision-Date: 2024-05-30 9:50+1\n"
 "Last-Translator: Muxutruk <muxutruk2@users.noreply.github.com>\n"
 "Language-Team: Basque <muxutruk2@users.noreply.github.com>\n"
@@ -316,8 +316,20 @@ msgstr ""
 msgid "Workspace Transition Effect"
 msgstr "Trantsizio-efektua"
 
+#. 5.4->settings-schema.json->transitionEffect->tooltip
+msgid ""
+"Select the type of workspace switch effect that will be used. The "
+"\"Randomized\" option allows you to choose which effects can be chosen at "
+"random for each workspace switch. The \"Disabled\" option will show no "
+"effect, not even the Cinnamon built in effect during a workspace switch."
+msgstr ""
+
 #. 5.4->settings-schema.json->transitionEffect->options
 msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/Flipper@connerdev/files/Flipper@connerdev/po/fi.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/fi.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: Flipper@connerdev 1.0.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 00:15-0500\n"
+"POT-Creation-Date: 2025-04-17 21:29-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -315,9 +315,21 @@ msgstr "Tehostekohtaiset asetukset"
 msgid "Workspace Transition Effect"
 msgstr "Työtilan vaihtotehoste"
 
+#. 5.4->settings-schema.json->transitionEffect->tooltip
+msgid ""
+"Select the type of workspace switch effect that will be used. The "
+"\"Randomized\" option allows you to choose which effects can be chosen at "
+"random for each workspace switch. The \"Disabled\" option will show no "
+"effect, not even the Cinnamon built in effect during a workspace switch."
+msgstr ""
+
 #. 5.4->settings-schema.json->transitionEffect->options
 msgid "Randomized"
 msgstr "Satunnainen"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Disabled"
+msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description
 msgid "Use Flipper effect with the Workspace Switcher applet"

--- a/Flipper@connerdev/files/Flipper@connerdev/po/fr.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: Flipper@connerdev 1.0.6\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 00:15-0500\n"
+"POT-Creation-Date: 2025-04-17 21:29-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -314,9 +314,21 @@ msgstr "Préférences pour chaque effet"
 msgid "Workspace Transition Effect"
 msgstr "Effet de changement d'espace de travail"
 
+#. 5.4->settings-schema.json->transitionEffect->tooltip
+msgid ""
+"Select the type of workspace switch effect that will be used. The "
+"\"Randomized\" option allows you to choose which effects can be chosen at "
+"random for each workspace switch. The \"Disabled\" option will show no "
+"effect, not even the Cinnamon built in effect during a workspace switch."
+msgstr ""
+
 #. 5.4->settings-schema.json->transitionEffect->options
 msgid "Randomized"
 msgstr "Aléatoire"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Disabled"
+msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description
 msgid "Use Flipper effect with the Workspace Switcher applet"

--- a/Flipper@connerdev/files/Flipper@connerdev/po/hu.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 00:15-0500\n"
+"POT-Creation-Date: 2025-04-17 21:29-0400\n"
 "PO-Revision-Date: 2025-04-12 08:18+0200\n"
 "Last-Translator: Kálmán „KAMI” Szalai <kami911@gmail.com>\n"
 "Language-Team: \n"
@@ -314,9 +314,21 @@ msgstr "Effektspecifikus beállítások"
 msgid "Workspace Transition Effect"
 msgstr "Munkaterület átmeneti effektus"
 
+#. 5.4->settings-schema.json->transitionEffect->tooltip
+msgid ""
+"Select the type of workspace switch effect that will be used. The "
+"\"Randomized\" option allows you to choose which effects can be chosen at "
+"random for each workspace switch. The \"Disabled\" option will show no "
+"effect, not even the Cinnamon built in effect during a workspace switch."
+msgstr ""
+
 #. 5.4->settings-schema.json->transitionEffect->options
 msgid "Randomized"
 msgstr "Véletlenszerű"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Disabled"
+msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description
 msgid "Use Flipper effect with the Workspace Switcher applet"

--- a/Flipper@connerdev/files/Flipper@connerdev/po/it.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 00:15-0500\n"
+"POT-Creation-Date: 2025-04-17 21:29-0400\n"
 "PO-Revision-Date: 2022-06-03 11:05+0200\n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -317,8 +317,20 @@ msgstr ""
 msgid "Workspace Transition Effect"
 msgstr "Effetto Transizione"
 
+#. 5.4->settings-schema.json->transitionEffect->tooltip
+msgid ""
+"Select the type of workspace switch effect that will be used. The "
+"\"Randomized\" option allows you to choose which effects can be chosen at "
+"random for each workspace switch. The \"Disabled\" option will show no "
+"effect, not even the Cinnamon built in effect during a workspace switch."
+msgstr ""
+
 #. 5.4->settings-schema.json->transitionEffect->options
 msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/Flipper@connerdev/files/Flipper@connerdev/po/nl.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/nl.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 00:15-0500\n"
+"POT-Creation-Date: 2025-04-17 21:29-0400\n"
 "PO-Revision-Date: 2025-02-21 14:10+0100\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -313,9 +313,21 @@ msgstr "Effectspecifieke instellingen"
 msgid "Workspace Transition Effect"
 msgstr "Werkruimte-overgangseffect"
 
+#. 5.4->settings-schema.json->transitionEffect->tooltip
+msgid ""
+"Select the type of workspace switch effect that will be used. The "
+"\"Randomized\" option allows you to choose which effects can be chosen at "
+"random for each workspace switch. The \"Disabled\" option will show no "
+"effect, not even the Cinnamon built in effect during a workspace switch."
+msgstr ""
+
 #. 5.4->settings-schema.json->transitionEffect->options
 msgid "Randomized"
 msgstr "Willekeurig"
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Disabled"
+msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description
 msgid "Use Flipper effect with the Workspace Switcher applet"

--- a/Flipper@connerdev/files/Flipper@connerdev/po/pt_BR.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/pt_BR.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 00:15-0500\n"
+"POT-Creation-Date: 2025-04-17 21:29-0400\n"
 "PO-Revision-Date: 2021-09-26 21:23-0300\n"
 "Last-Translator: Marcelo Aof\n"
 "Language-Team: \n"
@@ -317,8 +317,20 @@ msgstr ""
 msgid "Workspace Transition Effect"
 msgstr "Efeito de transição"
 
+#. 5.4->settings-schema.json->transitionEffect->tooltip
+msgid ""
+"Select the type of workspace switch effect that will be used. The "
+"\"Randomized\" option allows you to choose which effects can be chosen at "
+"random for each workspace switch. The \"Disabled\" option will show no "
+"effect, not even the Cinnamon built in effect during a workspace switch."
+msgstr ""
+
 #. 5.4->settings-schema.json->transitionEffect->options
 msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/Flipper@connerdev/files/Flipper@connerdev/po/ro.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/ro.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 00:15-0500\n"
+"POT-Creation-Date: 2025-04-17 21:29-0400\n"
 "PO-Revision-Date: 2022-08-06 01:55+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -318,8 +318,20 @@ msgstr ""
 msgid "Workspace Transition Effect"
 msgstr "Efectul de tranziție"
 
+#. 5.4->settings-schema.json->transitionEffect->tooltip
+msgid ""
+"Select the type of workspace switch effect that will be used. The "
+"\"Randomized\" option allows you to choose which effects can be chosen at "
+"random for each workspace switch. The \"Disabled\" option will show no "
+"effect, not even the Cinnamon built in effect during a workspace switch."
+msgstr ""
+
 #. 5.4->settings-schema.json->transitionEffect->options
 msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/Flipper@connerdev/files/Flipper@connerdev/po/ru.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/ru.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 00:15-0500\n"
+"POT-Creation-Date: 2025-04-17 21:29-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: blogdron\n"
 "Language-Team: \n"
@@ -312,8 +312,20 @@ msgstr ""
 msgid "Workspace Transition Effect"
 msgstr "Эффект Перехода"
 
+#. 5.4->settings-schema.json->transitionEffect->tooltip
+msgid ""
+"Select the type of workspace switch effect that will be used. The "
+"\"Randomized\" option allows you to choose which effects can be chosen at "
+"random for each workspace switch. The \"Disabled\" option will show no "
+"effect, not even the Cinnamon built in effect during a workspace switch."
+msgstr ""
+
 #. 5.4->settings-schema.json->transitionEffect->options
 msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/Flipper@connerdev/files/Flipper@connerdev/po/tr.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/tr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 00:15-0500\n"
+"POT-Creation-Date: 2025-04-17 21:29-0400\n"
 "PO-Revision-Date: 2021-03-15 20:55+0300\n"
 "Last-Translator: Gökhan Gökkaya <gokhanlnx@gmail.com>\n"
 "Language-Team: \n"
@@ -317,8 +317,20 @@ msgstr ""
 msgid "Workspace Transition Effect"
 msgstr "Kaybolma Efekti"
 
+#. 5.4->settings-schema.json->transitionEffect->tooltip
+msgid ""
+"Select the type of workspace switch effect that will be used. The "
+"\"Randomized\" option allows you to choose which effects can be chosen at "
+"random for each workspace switch. The \"Disabled\" option will show no "
+"effect, not even the Cinnamon built in effect during a workspace switch."
+msgstr ""
+
 #. 5.4->settings-schema.json->transitionEffect->options
 msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description

--- a/Flipper@connerdev/files/Flipper@connerdev/po/zh_CN.po
+++ b/Flipper@connerdev/files/Flipper@connerdev/po/zh_CN.po
@@ -4,7 +4,7 @@ msgstr ""
 "Project-Id-Version: \n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-01-10 00:15-0500\n"
+"POT-Creation-Date: 2025-04-17 21:29-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -313,8 +313,20 @@ msgstr ""
 msgid "Workspace Transition Effect"
 msgstr "过渡特效"
 
+#. 5.4->settings-schema.json->transitionEffect->tooltip
+msgid ""
+"Select the type of workspace switch effect that will be used. The "
+"\"Randomized\" option allows you to choose which effects can be chosen at "
+"random for each workspace switch. The \"Disabled\" option will show no "
+"effect, not even the Cinnamon built in effect during a workspace switch."
+msgstr ""
+
 #. 5.4->settings-schema.json->transitionEffect->options
 msgid "Randomized"
+msgstr ""
+
+#. 5.4->settings-schema.json->transitionEffect->options
+msgid "Disabled"
 msgstr ""
 
 #. 5.4->settings-schema.json->patchmoveToWorkspace->description


### PR DESCRIPTION
- Added a Disable effect option which will use no workspace switch effect, not even the default Cinnamon workspace switch effect. Since Cinnamon does not offer a way to independently disable the workspace switch effect, with this option you can disable the effect but still allow of the desktop and window effects.
- Fixed the disappearing effect settings problem using a "hack" fix. Adding a permanent empty label field below the effect settings avoids the issue.