### PR TITLE
Update "BlurCinnamon" spice to unblur the panel when a window is maximized

### DIFF
--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/extension.js
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/extension.js
@@ -312,7 +312,7 @@ class BlurPanels {
          } else {
             background = new Clutter.Actor();
          }
-         global.overlay_group.add_actor(background);
+         panel.actor.add_child(background);
          blurredPanel.background = background;
          background.set_clip( panel.actor.x, panel.actor.y, panel.actor.width, panel.actor.height );
          if (blurType === BlurType.Simple) {
@@ -369,7 +369,7 @@ class BlurPanels {
                effect = blurredPanel.background.get_effect(DESAT_EFFECT_NAME);
                if (effect)
                   blurredPanel.background.remove_effect(effect);
-               global.overlay_group.remove_actor(blurredPanel.background);
+               panel.actor.remove_child(blurredPanel.background);
                blurredPanel.background.destroy();
             }
             // Find the index of this panels this._blurredPanels entry then remove the entry


### PR DESCRIPTION
Two separate commits:
```
    When a window is maximized, unblur the panel for consistency. In my
    personal experience, maximized windows are virtually never
    transparent to the desktop wallpaper. Therefore, leaving the panel blur
    background active when a window is maximized looks very awkward and
    makes the panel look out of place. Fix this UX issue by unblurring the
    panel when a window is maximized.
    
    Possible transitions that have been tested:
    Window maximized -> blur panel
    Window unmaximized -> unblur panel
    Switch workspace from one with maximized to one without maximized ->
    unblur
    Switch workspace from one without maximized to one with maximized ->
    blur
    Fullscreen a window -> hide panel
    Unfullscreen a window and another is maximized -> unblur and show panel
    Unfullscreen a window and none are maximized -> blur and show panel
    Maximize a window in front of a fullscreen window -> unblur and show
    panel
    Unmaximize or new window in front of a fullscreen window -> hide panel
    (also tested with two other windows with various combinations with the
    fullscreen one)
    Close a maximized or fullscreen window -> blur if no other maximized or
    fullscreen window

```

```
    Previously the blur background was considered an actor of the global
    overlay actor. This causes 2 problems:
    1. The state of the program with regards to fullscreen windows becomes
    harder to understand and manage, and makes it very easy to
    introduce bugs to the extension from changing any panel related code.
    Primary the issue that is likely to occur is that the background of the
    panel will be drawn over the full screen window in the position of where
    the panel would be, even though no other aspects/buttons/etc of the
    panel are even there.
    2. The "transparent background" is actually blocking all the windows
    below it, making it awkward if you try to drag a window under the
    panel, it will look like it disappears or that the panel is not actually
    transparent but actually a foreground (because that's what the global
    overlay actor actually is).
    
    So the fix to make this more robust is to make the blur background a
    child of the panel actor itself, instead of the global overlay actor.
```

@klangman I have updated an extension which was authored by you. Please check if you are okay with this change, and let me know if you have any feedback. I also was not sure, if this were to merge, in what way to update the changelog/version. I also considered making this a toggleable feature, and I started some code to do that, but my feeling is that mostly this update should be the expected behavior.