### PR TITLE
Fix for it.po preventing the Fire effect option from appearing

### DIFF
--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/it.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/it.po
@@ -161,7 +161,7 @@ msgstr "Nucleare"
 #. 6.2->settings-schema.json->unminimize-effect->options
 #. effects/Focus.js:91
 msgid "Focus"
-msgstr "Fuoco"
+msgstr "Messa a fuoco"
 
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options


### PR DESCRIPTION
The recent it.po translation used "Fuoco" as the translation for both "Fire" and "Focus". This prevented the "Fire" option from appearing the the drop-down lists and making the Fire effect inaccessible when using the Italian translation.