### PR TITLE
gTile@shuairan: hotkey fix, add Gnome Tactile-like feature

### DIFF
--- a/gTile@shuairan/README.md
+++ b/gTile@shuairan/README.md
@@ -1,5 +1,4 @@
-gTile
------
+## gTile
 
 ### Usage
 
@@ -10,7 +9,10 @@ gTile
 - `Space` or `Enter` tile the selected area
 - `Alt`+`ARROWS` to move between monitors
 - `1`,`2`,`3`,`4` to select between the 4 tiling settings
+- If _Show Tile Labels_ is enabled in settings, type two labels to tile active window. The first
+  label will be used for the top left corner, and the second for the bottom right corner. For more info, see Gnome extension [Tactile](https://extensions.gnome.org/extension/4548/tactile/).
 
 More options are available in Cinnamon Settings -> Extensions -> gTile@shuairan -> Settings.
 
 This extension was originally developed by vibou and shuairan. It is now maintained by the community.
+

--- a/gTile@shuairan/files/gTile@shuairan/5.4/settings-schema.json
+++ b/gTile@shuairan/files/gTile@shuairan/5.4/settings-schema.json
@@ -60,7 +60,8 @@
             "autoclose",
             "aspect-ratio",
             "useMonitorCenter",
-            "showGridOnAllMonitors"
+            "showGridOnAllMonitors",
+            "select-using-keyboard"
          ]
       },
       "grid1-section": {
@@ -408,5 +409,10 @@
             "span": 1
          }
       ]
-	}
+	},
+   "select-using-keyboard": {
+      "type": "checkbox",
+      "default": false,
+      "description": "Show tile labels"
+   }
 }

--- a/gTile@shuairan/files/gTile@shuairan/5.4/stylesheet.css
+++ b/gTile@shuairan/files/gTile@shuairan/5.4/stylesheet.css
@@ -90,3 +90,10 @@
 .very-bottom-box {
     padding-bottom:10px;
 }
+
+.tile-label {
+    color: white;
+    font-size: 24px;
+    font-weight: bold;
+    text-align: center;
+}


### PR DESCRIPTION
@sphh - are you still handling PRs?

This pull request has a bug fix and a new feature.

1. Issue #444: the hotkey stops working after monitor wakes up from sleep. Simply switching the monitor off and on reproduced the problem for me. This PR fixes the issue.

2. I've adopted [Gnome Tactile](https://extensions.gnome.org/extension/4548/tactile/) feature. If _Show tile labels_ is enabled in Settings > Behaviour, lowercase letters are shown on each tile. Selecting two letters places the active window into the space. The two letters correspond to the top left and bottom right rectangle to place the active window. If the same letter is pressed twice, the active window goes into that tile, which is what #906 requested. If more than 26 tiles are visible, uppercase letters are shown. So a-z is shown first then A-Z. To select an uppercase letter, the user must press shift-<letter>. If there are more than 52 tiles, the behaviour is undefined.

By default, _Show tile labels_ is disabled so that the extension behaves the same as before.