### PR TITLE
[BlurCinnamon@klangman] V1.5.2 Fixes

### DIFF
--- a/BlurCinnamon@klangman/CHANGELOG.md
+++ b/BlurCinnamon@klangman/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.5.2
+
+* When the theme override option is disabled, restore the theme's menu settings
+* Fix an issue with Alt-Tab support after the extension is reloaded (after an update) or disabled
+* Fix a typo in Notifications settings tab (Sent -> Send)
+
 ## 1.5.1
 
 * Fix 1.5.0 regression, a missing function left out of the 1.5.0 merge into the spices repo
@@ -10,7 +16,7 @@
 * Added the ability to apply effects to the Notification popups (disabled by default)
 * Added the ability to apply effects to the Panel Tooltip popups (disabled by default)
 * Added a welcome Notification popup with a button to open the configuration window
-* Added a panel option to restore the default (solid) look of the panel(s) when a window is maximized
+* Added a panel option to restore the default (solid) look of the panel(s) when a window is maximized (thanks to [decsny](https://github.com/decsny) for some code)
 * Fixed an issue where a blurred element remains visible after a menu is closed (thanks to [SpeeQz1](https://github.com/SpeeQz1) for the bug report)
 * Fixed an issue where some signals are not disconnected when disabling the extension
 * Rewrote some parts of the code to make it easier to maintain and reduce code duplication

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/extension.js
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/extension.js
@@ -1119,6 +1119,19 @@ class BlurPopupMenus extends BlurBase {
 
       // Update the accent dimming color
       this._accentColor = this._getColor( blendColor, accentOpacity );
+
+      // If the options to allow theme overrides is disabled, remove theme overrides
+      if (!settings.allowTransparentColorPopup) {
+         debugMsg( "Removing theme override for popup menus" );
+         let menus = this._menus;
+         if (menus) {
+            for (let i=0 ; i < menus.length ; i++) {
+               if (menus[i].box._blurCinnamonData) {
+                  this._restoreMenuStyle(menus[i]);
+               }
+            }
+         }
+      }
    }
 
    destroy() {
@@ -1485,7 +1498,7 @@ class BlurSettings {
       this.settings.bind('popup-radius',         'popupRadius',        updatePopupEffects);
       this.settings.bind('popup-blendColor',     'popupBlendColor',    updatePopupEffects);
       this.settings.bind('popup-saturation',     'popupSaturation',    updatePopupEffects);
-      this.settings.bind('allow-transparent-color-popup', 'allowTransparentColorPopup');
+      this.settings.bind('allow-transparent-color-popup', 'allowTransparentColorPopup', updatePopupEffects);
 
       this.settings.bind('desktop-opacity',       'desktopOpacity',      updateDesktopEffects);
       this.settings.bind('desktop-blurType',      'desktopBlurType',     updateDesktopEffects);
@@ -1763,6 +1776,8 @@ function disable() {
    if (settings.enableAppswitcherEffects) {
       delete AppSwitcher3D.AppSwitcher3D.prototype._oldInit;
       AppSwitcher3D.AppSwitcher3D.prototype._init = originalInitAppSwitcher3D;
+      delete AppSwitcher3D.AppSwitcher3D.prototype._oldHide;
+      AppSwitcher3D.AppSwitcher3D.prototype._hide = originalHideAppSwitcher3D;
    }
 
    if (blurPanels) {

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/settings-schema.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/settings-schema.json
@@ -734,7 +734,7 @@
 
    "notification-test-button" : {
       "type" : "button",
-      "description" : "Sent a test notification",
+      "description" : "Send a test notification",
       "callback" : "on_notification_test_button_pressed",
       "tooltip" : "This button will cause a notification message to appear so you can see how your notification setting behave."
     },

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
@@ -1,7 +1,7 @@
 {
     "uuid": "BlurCinnamon@klangman",
     "name": "Blur Cinnamon",
-    "version": "1.5.1",
+    "version": "1.5.2",
     "description": "Allows you to blur, colorize, desaturate and adjust the dimming of several Cinnamon Desktop components",
     "url": "https://github.com/klangman/BlurCinnamon",
     "cinnamon-version": [

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: BlurCinnamon@klangman 1.5.1\n"
+"Project-Id-Version: BlurCinnamon@klangman 1.5.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-09-23 09:24-0400\n"
+"POT-Creation-Date: 2025-09-30 09:50-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.0/extension.js:1739
+#. 6.0/extension.js:1752
 msgid "Welcome to Blur Cinnamon"
 msgstr ""
 
-#. 6.0/extension.js:1740
+#. 6.0/extension.js:1753
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -32,15 +32,15 @@ msgid ""
 "effect properties like blur intensity, color saturation and dimming."
 msgstr ""
 
-#. 6.0/extension.js:1744
+#. 6.0/extension.js:1757
 msgid "Open Blur Cinnamon Settings"
 msgstr ""
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1823
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:1809
+#. 6.0/extension.js:1824
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -610,7 +610,7 @@ msgid "Dim background Image (percentage)"
 msgstr ""
 
 #. 6.0->settings-schema.json->notification-test-button->description
-msgid "Sent a test notification"
+msgid "Send a test notification"
 msgstr ""
 
 #. 6.0->settings-schema.json->notification-test-button->tooltip

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-09-23 09:24-0400\n"
+"POT-Creation-Date: 2025-09-30 09:50-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,11 +18,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.6\n"
 
-#. 6.0/extension.js:1739
+#. 6.0/extension.js:1752
 msgid "Welcome to Blur Cinnamon"
 msgstr "Benvingut al Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:1740
+#. 6.0/extension.js:1753
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -41,15 +41,15 @@ msgstr ""
 "per defecte. També podeu realitzar canvis a les propietats dels efectes, com "
 "ara la intensitat del desenfoc, la saturació del color i l'enfoscament."
 
-#. 6.0/extension.js:1744
+#. 6.0/extension.js:1757
 msgid "Open Blur Cinnamon Settings"
 msgstr "Obre la configuració del Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1823
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Provant els efectes del Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:1809
+#. 6.0/extension.js:1824
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -710,7 +710,8 @@ msgid "Dim background Image (percentage)"
 msgstr "Atenuació/Tint de la imatge de fons (percentatge)"
 
 #. 6.0->settings-schema.json->notification-test-button->description
-msgid "Sent a test notification"
+#, fuzzy
+msgid "Send a test notification"
 msgstr "Envia una notificació de prova"
 
 #. 6.0->settings-schema.json->notification-test-button->tooltip

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-09-23 09:24-0400\n"
+"POT-Creation-Date: 2025-09-30 09:50-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.7\n"
 
-#. 6.0/extension.js:1739
+#. 6.0/extension.js:1752
 msgid "Welcome to Blur Cinnamon"
 msgstr "Bienvenido a Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:1740
+#. 6.0/extension.js:1753
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -40,15 +40,15 @@ msgstr ""
 "realizar cambios en las propiedades de los efectos, como la intensidad del "
 "desenfoque, la saturación del color y el oscurecimiento."
 
-#. 6.0/extension.js:1744
+#. 6.0/extension.js:1757
 msgid "Open Blur Cinnamon Settings"
 msgstr "Abrir configuración de desenfoque de Cinnamon"
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1823
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Probando los efectos de notificación de Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:1809
+#. 6.0/extension.js:1824
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -736,7 +736,8 @@ msgid "Dim background Image (percentage)"
 msgstr "Atenuar Imagen de fondo (porcentaje)"
 
 #. 6.0->settings-schema.json->notification-test-button->description
-msgid "Sent a test notification"
+#, fuzzy
+msgid "Send a test notification"
 msgstr "Enviar una notificación de prueba"
 
 #. 6.0->settings-schema.json->notification-test-button->tooltip

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fi.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-09-23 09:24-0400\n"
+"POT-Creation-Date: 2025-09-30 09:50-0400\n"
 "PO-Revision-Date: 2025-03-30 10:53+0300\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -18,12 +18,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1739
+#. 6.0/extension.js:1752
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Blur Cinnamon"
 
-#. 6.0/extension.js:1740
+#. 6.0/extension.js:1753
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -34,16 +34,16 @@ msgid ""
 "effect properties like blur intensity, color saturation and dimming."
 msgstr ""
 
-#. 6.0/extension.js:1744
+#. 6.0/extension.js:1757
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Blur Cinnamon"
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1823
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:1809
+#. 6.0/extension.js:1824
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -695,7 +695,7 @@ msgid "Dim background Image (percentage)"
 msgstr "Himmennä taustakuvaa (prosenttia)"
 
 #. 6.0->settings-schema.json->notification-test-button->description
-msgid "Sent a test notification"
+msgid "Send a test notification"
 msgstr ""
 
 #. 6.0->settings-schema.json->notification-test-button->tooltip

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-09-23 09:24-0400\n"
+"POT-Creation-Date: 2025-09-30 09:50-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -18,12 +18,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1739
+#. 6.0/extension.js:1752
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Flou pour Cinnamon"
 
-#. 6.0/extension.js:1740
+#. 6.0/extension.js:1753
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -34,16 +34,16 @@ msgid ""
 "effect properties like blur intensity, color saturation and dimming."
 msgstr ""
 
-#. 6.0/extension.js:1744
+#. 6.0/extension.js:1757
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Flou pour Cinnamon"
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1823
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:1809
+#. 6.0/extension.js:1824
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -729,7 +729,7 @@ msgid "Dim background Image (percentage)"
 msgstr "Graduer/Colorer l'arrière-plan (pourcentage)"
 
 #. 6.0->settings-schema.json->notification-test-button->description
-msgid "Sent a test notification"
+msgid "Send a test notification"
 msgstr ""
 
 #. 6.0->settings-schema.json->notification-test-button->tooltip

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/hu.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-09-23 09:24-0400\n"
+"POT-Creation-Date: 2025-09-30 09:50-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,12 +18,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.6\n"
 
-#. 6.0/extension.js:1739
+#. 6.0/extension.js:1752
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Cinnamon elhomályosítása"
 
-#. 6.0/extension.js:1740
+#. 6.0/extension.js:1753
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -34,16 +34,16 @@ msgid ""
 "effect properties like blur intensity, color saturation and dimming."
 msgstr ""
 
-#. 6.0/extension.js:1744
+#. 6.0/extension.js:1757
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Cinnamon elhomályosítása"
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1823
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:1809
+#. 6.0/extension.js:1824
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -720,7 +720,7 @@ msgid "Dim background Image (percentage)"
 msgstr "Halvány háttérkép (százalék)"
 
 #. 6.0->settings-schema.json->notification-test-button->description
-msgid "Sent a test notification"
+msgid "Send a test notification"
 msgstr ""
 
 #. 6.0->settings-schema.json->notification-test-button->tooltip

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/it.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-09-23 09:24-0400\n"
+"POT-Creation-Date: 2025-09-30 09:50-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -18,12 +18,12 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1739
+#. 6.0/extension.js:1752
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Sfoca Cinnamom"
 
-#. 6.0/extension.js:1740
+#. 6.0/extension.js:1753
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -34,16 +34,16 @@ msgid ""
 "effect properties like blur intensity, color saturation and dimming."
 msgstr ""
 
-#. 6.0/extension.js:1744
+#. 6.0/extension.js:1757
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Sfoca Cinnamom"
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1823
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:1809
+#. 6.0/extension.js:1824
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -729,7 +729,7 @@ msgid "Dim background Image (percentage)"
 msgstr "Oscuramento immagine di sfondo (percentuale)"
 
 #. 6.0->settings-schema.json->notification-test-button->description
-msgid "Sent a test notification"
+msgid "Send a test notification"
 msgstr ""
 
 #. 6.0->settings-schema.json->notification-test-button->tooltip

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/nl.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-09-23 09:24-0400\n"
+"POT-Creation-Date: 2025-09-30 09:50-0400\n"
 "PO-Revision-Date: 2025-06-13 17:14+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,12 +16,12 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.0/extension.js:1739
+#. 6.0/extension.js:1752
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Vervaag Cinnamon"
 
-#. 6.0/extension.js:1740
+#. 6.0/extension.js:1753
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -32,16 +32,16 @@ msgid ""
 "effect properties like blur intensity, color saturation and dimming."
 msgstr ""
 
-#. 6.0/extension.js:1744
+#. 6.0/extension.js:1757
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Vervaag Cinnamon"
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1823
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:1809
+#. 6.0/extension.js:1824
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -723,7 +723,7 @@ msgid "Dim background Image (percentage)"
 msgstr "Achtergrondafbeelding dimmen (percentage)"
 
 #. 6.0->settings-schema.json->notification-test-button->description
-msgid "Sent a test notification"
+msgid "Send a test notification"
 msgstr ""
 
 #. 6.0->settings-schema.json->notification-test-button->tooltip


### PR DESCRIPTION
1. When the theme override option is disabled, restore the theme's menu settings
2. Fix an issue with Alt-Tab support after the extension is reloaded (after an update) or disabled
3. Fix a typo in Notifications settings tab (Sent -> Send)