### PR TITLE
[BlurCinnamon@klangman] One Fix and rounded corner panel support

### DIFF
--- a/BlurCinnamon@klangman/CHANGELOG.md
+++ b/BlurCinnamon@klangman/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.6.1
+
+* Fixed a 1.6.0 regression where the dimming of desktop effects are not removed after disabiling the desktop effects on the general page in the config window.
+* Added support for rounded cinnamon panels, but currently to enable rounded corners in Cinnamon panels you need to manually edit your cinnamon.css file.
+
 ## 1.6.0
 
 * Added the ability to apply effects to application window backgrounds

--- a/BlurCinnamon@klangman/README.md
+++ b/BlurCinnamon@klangman/README.md
@@ -14,7 +14,7 @@ Cinnamon components you can apply effects to (currently):
 8. The Coverflow and Timeline 3D Alt-Tab switchers (not the Cinnamon default Alt-Tab switcher!)
 9. Application window backgrounds **(#)**
 
-**(#)** Note: The Blur Cinnamon effects for the (#) marked Cinnamon components above are disabled by default. They can be enabled in the Blur Cinnamon configuration window. These effects will override some of your theme settings (i.e. rounded corners etc.).
+**(#)** Note: The Blur Cinnamon effects for the (#) marked Cinnamon components above are disabled by default. They can be enabled in the Blur Cinnamon configuration window. Some effects will override your theme settings to force transparency.
 
 Blurring can also be disabled if you just want a transparent or semi-transparent effect without blurring for Panels, Applet popup menu or the Expo.
 
@@ -25,6 +25,7 @@ Blurring can also be disabled if you just want a transparent or semi-transparent
 - Dimming overlay with user configurable color and intensity (fully-transparent to a solid color)
 - Makes the components transparent (when needed) so that the desktop background image effects are visible
 - Allows you to adjust the color saturation of the Cinnamon components. You can reduced saturation all the way down to gray scale
+- Uses a rounded corner effect to match your themes rounded corner settings, and provides manual rounded corner setting for application window effects so you can match the rounded corner of the application windows you choose to blur
 - Ability to changes the opacity of application windows so application window blur effects are visible under the window
 - Option to add a backlight effect to the focused window using a background image blur effect spilling over the focused windows borders
 - You can use general settings across all Cinnamon components or use unique settings for each component type
@@ -43,7 +44,7 @@ Using any of the above with Blur Cinnamon may have some odd side effects that wo
 
 ## Limitations
 
-1. The Applet popup menu effects are intended to be used with the Cinnamon (6.4) theme or the Mint-Y dark desktop themes. The effects might work will with some other themes but I have not tested them so the effects might not work out just right. You can try the Mint-Y light themes but it might be hard to read the menu items without some playing around with the settings and the background image. To make sure that the blurred background does not spill over any rounded corners, the popup-menu rounded corners will be disabled when popup-menu effects are enabled. Popup-menu effects are disabled by default in this extension.
+1. The Applet popup menu effects are intended to be used with the Cinnamon (6.4) theme or the Mint-Y dark desktop themes. The effects might work will with some other themes but I have not tested them so the effects might not work out just right. You can try the Mint-Y light themes but it might be hard to read the menu items without some playing around with the settings and the background image. Blur Cinnamon Popup-menu effects are disabled by default.
 2. The Applet popup-menu effects works for all the applets that I have tested except "Cinnamenu". Cinnamenu is preventing other code from receiving the "open-state-changed" event which BlurCinnamon uses to know when to apply popup-menu theme setting and when to resize and show the blur background element. This issue is fixed in the latest Cinnamenu from [Fredcw GitHub](https://github.com/fredcw/Cinnamenu) but you will need to manually fix the current Cinnamon Spices version of Cinnamenu (see [here](https://github.com/linuxmint/cinnamon-spices-extensions/issues/873))
 3. Currently, any windows that are positioned such that they overlap with a panel or an popup-menu will not be visible beneath blurred panel/popup-menu as you might expect with a transparent panel/menu. This is because the blur effect is applied to a user interface element that floats above all windows just like the panel floats above the windows. At some point I hope to look into allowing the blur element to appear below all windows rather than above and make the a optional behavior setting.
 4. If you disable effects for any Cinnamon component under the General tab of the setting dialog while any "Use unique effect settings" options are enabled under the other tabs, the components "effect setting" options under the other tabs will still be visible, but changing those setting will have no effect until you re-enable the component under the General tab. Ideally those effect setting would only be visible when the component is enabled under the general tab but Cinnamon setting support is a bit limited in this way.

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/extension.js
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/extension.js
@@ -5,6 +5,7 @@
 // Some code bowwowed from the BlurOverview Cinnamon extension Copyright (C) 2012 Jen Bowen aka nailfarmer
 
 // Gaussian Blur (borrowed from Blur-my-shell / Aurélien Hamy) modified for Cinnamon by Kevin Langman 2024
+// Rounded Corners (borrowed from Blur-my-shell / Aurélien Hamy) modified for Cinnamon by Kevin Langman 2025
 
 // This program is free software: you can redistribute it and/or modify
 // it under the terms of the GNU General Public License as published by
@@ -389,6 +390,21 @@ class BlurBase {
       }
    }
 
+   destroy(background) {
+      if (background._blurCinnamonDimmer) {
+         background.remove_child(background._blurCinnamonDimmer);
+      }
+      let effect = this._getCornerEffect(background);
+      if (effect)
+         background.remove_effect(effect);
+      effect = this._getDesatEffect(background);
+      if (effect)
+         background.remove_effect(effect);
+      effect = this._getBlurEffect(background);
+      if (effect)
+         background.remove_effect(effect);
+   }
+
    _printActor(actor) {
       let themeNode = actor.get_theme_node();
       let margins = actor.get_margin();
@@ -635,10 +651,17 @@ class BlurPanels extends BlurBase {
    _setClip(panel){
       if (panel && panel.__blurredPanel && panel.__blurredPanel.background) {
          let actor = panel.actor;
+         let cornerEffect = this._getCornerEffect(panel.__blurredPanel.background);
          if (actor.is_visible()) {
-            panel.__blurredPanel.background.set_clip( actor.x, actor.y, actor.width, actor.height );
+            if (cornerEffect)
+               cornerEffect.clip = [actor.x+2, actor.y+2, actor.width-3, actor.height-3];
+            else
+               panel.__blurredPanel.background.set_clip( actor.x, actor.y, actor.width, actor.height );
          } else {
-            panel.__blurredPanel.background.set_clip( 0, 0, 0, 0 );
+            if (cornerEffect)
+               cornerEffect.clip = [0, 0, 0, 0];
+            else
+               panel.__blurredPanel.background.set_clip( 0, 0, 0, 0 );
          }
          if (panel._hidden || panel._disabled || global.display.get_monitor_in_fullscreen(panel.monitorIndex)) {
             panel.__blurredPanel.background.hide();
@@ -664,6 +687,9 @@ class BlurPanels extends BlurBase {
 
    // Create a new blur effect for the panel argument.
    _blurPanel(panel) {
+      let topRadius = 0;
+      let bottomRadius = 0;
+      let cornerRadius = 0;
       let panelSettings = this._getPanelSettings(panel);
       if (!panelSettings ) return;
       let [opacity, blendColor, blurType, radius, saturation] = panelSettings;
@@ -689,13 +715,25 @@ class BlurPanels extends BlurBase {
                           "background-gradient-direction: vertical; background-gradient-start: transparent; " +
                           "background-gradient-end: transparent;    background: transparent;" );
       }
+      // Determine the corner radius
+      let themeNode = actor.get_theme_node();
+      if (themeNode) {
+         // TODO: Need to be able to independently round all four corners, needs improvements to the corner effect code!
+         topRadius = themeNode.get_border_radius(St.Corner.TOPLEFT);
+         bottomRadius = themeNode.get_border_radius(St.Corner.BOTTOMLEFT);
+         cornerRadius = Math.max(topRadius, bottomRadius);
+      }
       // If blurring is required, create a background, create effect, clip background to cover the panel only
       // With this commented out, a panel with no effects applied (just made transparent) will still prevent
       // windows beneath the panels from being visible.
       //if (blurType > BlurType.None || saturation<100) {
-         let background = this._createBackgroundAndEffects(opacity, blendColor, blurType, radius, saturation);
+         let background = this._createBackgroundAndEffects(opacity, blendColor, blurType, radius, saturation, global.overlay_group, cornerRadius, topRadius!==0, bottomRadius!==0);
          blurredPanel.background = background;
-         background.set_clip( panel.actor.x, panel.actor.y, panel.actor.width, panel.actor.height );
+         let cornerEffect = this._getCornerEffect(background);
+         if (cornerEffect)
+            cornerEffect.clip = [panel.actor.x+2, panel.actor.y+2, panel.actor.width-3, panel.actor.height-3];
+         else
+            background.set_clip( panel.actor.x, panel.actor.y, panel.actor.width, panel.actor.height );
          if (!panel._hidden && !global.display.get_monitor_in_fullscreen(panel.monitorIndex)) {
             background.show();
          }
@@ -732,12 +770,7 @@ class BlurPanels extends BlurBase {
             actor.set_style_class_name(blurredPanel.original_class);
             actor.set_style_pseudo_class(blurredPanel.original_pseudo_class);
             if (blurredPanel.background) {
-               let effect = blurredPanel.background.get_effect(BLUR_EFFECT_NAME);
-               if (effect)
-                  blurredPanel.background.remove_effect(effect);
-               effect = blurredPanel.background.get_effect(DESAT_EFFECT_NAME);
-               if (effect)
-                  blurredPanel.background.remove_effect(effect);
+               super.destroy(blurredPanel.background);
                global.overlay_group.remove_actor(blurredPanel.background);
                blurredPanel.background.destroy();
             }
@@ -1237,6 +1270,7 @@ class BlurPopupMenus extends BlurBase {
       // Restore monkey patched PopupMenu open & close functions
       debugMsg( "Destroying Popup Menu object" );
       PopupMenu.PopupMenu.prototype.open = this.original_popupmenu_open;
+      super.destroy(this._background);
       global.overlay_group.remove_actor(this._background);
       this._background.destroy();
       // Remove all data in the menus associated with blurCinnamon
@@ -1274,8 +1308,6 @@ class BlurDesktop extends BlurBase {
       let dimmerColor = this._getColor( blendColor, opacity );
       this._dimmer = new Clutter.Actor({x_expand: true, y_expand: true, width: global.background_actor.width, height: global.background_actor.height, background_color: dimmerColor});
       global.background_actor.add_child(this._dimmer);
-
-      this._effects_applied = true;
       this.updateEffects();
    }
 
@@ -1363,6 +1395,9 @@ class BlurDesktop extends BlurBase {
       effect = global.background_actor.get_effect(DESAT_EFFECT_NAME);
       if (effect) {
          global.background_actor.remove_effect(effect);
+      }
+      if (this._dimmer) {
+         global.background_actor.remove_child(this._dimmer);
       }
    }
 }
@@ -1491,6 +1526,7 @@ class BlurNotifications extends BlurBase {
       MessageTray.MessageTray.prototype._showNotification = this.original_showNotification;
       MessageTray.MessageTray.prototype._hideNotification = this.original_hideNotification;
       global.overlay_group.remove_actor(this._background);
+      super.destroy(this._background);
       this._background.destroy();
    }
 }
@@ -1575,6 +1611,7 @@ class BlurTooltips extends BlurBase {
 
       this._signalManager.disconnectAllSignals();
       this._background.hide();
+      super.destroy(this._background);
       this._background.destroy();
    }
 }
@@ -1732,15 +1769,7 @@ class BlurApplications extends BlurBase {
          let data = compositor._blurCinnamonDataWindow;
          data.signalManager.disconnectAllSignals();
          compositor.remove_child(data.background);
-         let blurEffect = this._getBlurEffect(data.background);
-         if (blurEffect)
-            data.background.remove_effect(blurEffect);
-         let desatEffect = this._getDesatEffect(data.background);
-         if (desatEffect)
-            data.background.remove_effect(desatEffect);
-         let cornerEffect = this._getCornerEffect(data.background);
-         if (cornerEffect)
-            data.background.remove_effect(cornerEffect);
+         super.destroy(data.background);
          data.background.destroy();
          data.metaWindow.set_opacity(255);
          compositor._blurCinnamonDataWindow = undefined;

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
@@ -1,7 +1,7 @@
 {
     "uuid": "BlurCinnamon@klangman",
     "name": "Blur Cinnamon",
-    "version": "1.6.0",
+    "version": "1.6.1",
     "description": "Allows you to blur, colorize, desaturate and adjust the dimming of several Cinnamon Desktop components",
     "url": "https://github.com/klangman/BlurCinnamon",
     "cinnamon-version": [

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: BlurCinnamon@klangman 1.6.0\n"
+"Project-Id-Version: BlurCinnamon@klangman 1.6.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-11-30 22:15-0500\n"
+"POT-Creation-Date: 2025-12-03 23:37-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,22 +17,22 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.0/extension.js:1807
+#. 6.0/extension.js:1836
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1837
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2284
+#. 6.0/extension.js:2313
 msgid "Welcome to Blur Cinnamon"
 msgstr ""
 
-#. 6.0/extension.js:2285
+#. 6.0/extension.js:2314
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -44,15 +44,15 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:2289
+#. 6.0/extension.js:2318
 msgid "Open Blur Cinnamon Settings"
 msgstr ""
 
-#. 6.0/extension.js:2366
+#. 6.0/extension.js:2395
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:2367
+#. 6.0/extension.js:2396
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-11-30 22:15-0500\n"
+"POT-Creation-Date: 2025-12-03 23:37-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,22 +18,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.6\n"
 
-#. 6.0/extension.js:1807
+#. 6.0/extension.js:1836
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1837
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2284
+#. 6.0/extension.js:2313
 msgid "Welcome to Blur Cinnamon"
 msgstr "Benvingut al Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:2285
+#. 6.0/extension.js:2314
 #, fuzzy
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
@@ -54,15 +54,15 @@ msgstr ""
 "per defecte. També podeu realitzar canvis a les propietats dels efectes, com "
 "ara la intensitat del desenfoc, la saturació del color i l'enfoscament."
 
-#. 6.0/extension.js:2289
+#. 6.0/extension.js:2318
 msgid "Open Blur Cinnamon Settings"
 msgstr "Obre la configuració del Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:2366
+#. 6.0/extension.js:2395
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Provant els efectes del Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:2367
+#. 6.0/extension.js:2396
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/da.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.5.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-11-30 22:15-0500\n"
+"POT-Creation-Date: 2025-12-03 23:37-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -18,22 +18,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1807
+#. 6.0/extension.js:1836
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1837
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2284
+#. 6.0/extension.js:2313
 msgid "Welcome to Blur Cinnamon"
 msgstr "Velkommen til Sløret Cinnamon"
 
-#. 6.0/extension.js:2285
+#. 6.0/extension.js:2314
 #, fuzzy
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
@@ -54,15 +54,15 @@ msgstr ""
 "også foretage ændringer i effektens egenskaber, såsom sløringens intensitet, "
 "farvemætning og dæmpning."
 
-#. 6.0/extension.js:2289
+#. 6.0/extension.js:2318
 msgid "Open Blur Cinnamon Settings"
 msgstr "Åbn Sløret Cinnamon-indstillinger"
 
-#. 6.0/extension.js:2366
+#. 6.0/extension.js:2395
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Tester Sløret Cinnamons underretningseffekter"
 
-#. 6.0/extension.js:2367
+#. 6.0/extension.js:2396
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-11-30 22:15-0500\n"
+"POT-Creation-Date: 2025-12-03 23:37-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,11 +17,11 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.8\n"
 
-#. 6.0/extension.js:1807
+#. 6.0/extension.js:1836
 msgid "Error"
 msgstr "Error"
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1837
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
@@ -31,11 +31,11 @@ msgstr ""
 "tenía el foco anteriormente, por lo que no se pueden aplicar los efectos de "
 "Desenfoque Cinnamon a esa ventana"
 
-#. 6.0/extension.js:2284
+#. 6.0/extension.js:2313
 msgid "Welcome to Blur Cinnamon"
 msgstr "Bienvenido a Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:2285
+#. 6.0/extension.js:2314
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -55,15 +55,15 @@ msgstr ""
 "También puedes realizar cambios en las propiedades de los efectos, como la "
 "intensidad del desenfoque, la saturación del color y el oscurecimiento."
 
-#. 6.0/extension.js:2289
+#. 6.0/extension.js:2318
 msgid "Open Blur Cinnamon Settings"
 msgstr "Abrir configuración de Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:2366
+#. 6.0/extension.js:2395
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Probando los efectos de notificación de Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:2367
+#. 6.0/extension.js:2396
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fi.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-11-30 22:15-0500\n"
+"POT-Creation-Date: 2025-12-03 23:37-0500\n"
 "PO-Revision-Date: 2025-03-30 10:53+0300\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -18,23 +18,23 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1807
+#. 6.0/extension.js:1836
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1837
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2284
+#. 6.0/extension.js:2313
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Blur Cinnamon"
 
-#. 6.0/extension.js:2285
+#. 6.0/extension.js:2314
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -46,16 +46,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:2289
+#. 6.0/extension.js:2318
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Blur Cinnamon"
 
-#. 6.0/extension.js:2366
+#. 6.0/extension.js:2395
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:2367
+#. 6.0/extension.js:2396
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-11-30 22:15-0500\n"
+"POT-Creation-Date: 2025-12-03 23:37-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -18,23 +18,23 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1807
+#. 6.0/extension.js:1836
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1837
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2284
+#. 6.0/extension.js:2313
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Flou pour Cinnamon"
 
-#. 6.0/extension.js:2285
+#. 6.0/extension.js:2314
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -46,16 +46,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:2289
+#. 6.0/extension.js:2318
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Flou pour Cinnamon"
 
-#. 6.0/extension.js:2366
+#. 6.0/extension.js:2395
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:2367
+#. 6.0/extension.js:2396
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/hu.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-11-30 22:15-0500\n"
+"POT-Creation-Date: 2025-12-03 23:37-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,22 +18,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.8\n"
 
-#. 6.0/extension.js:1807
+#. 6.0/extension.js:1836
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1837
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2284
+#. 6.0/extension.js:2313
 msgid "Welcome to Blur Cinnamon"
 msgstr "Üdvözöljük a Cinnamon Elhomályosításában"
 
-#. 6.0/extension.js:2285
+#. 6.0/extension.js:2314
 #, fuzzy
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
@@ -54,15 +54,15 @@ msgstr ""
 "Módosíthatod az effekt tulajdonságait is, például az elmosás intenzitását, a "
 "színtelítettséget és a fényerőt."
 
-#. 6.0/extension.js:2289
+#. 6.0/extension.js:2318
 msgid "Open Blur Cinnamon Settings"
 msgstr "Nyissa meg a Cinnamon Elhomályosítása beállításait"
 
-#. 6.0/extension.js:2366
+#. 6.0/extension.js:2395
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Cinnamon Elhomályosítása értesítési effektek tesztelése"
 
-#. 6.0/extension.js:2367
+#. 6.0/extension.js:2396
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/it.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-11-30 22:15-0500\n"
+"POT-Creation-Date: 2025-12-03 23:37-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -18,23 +18,23 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1807
+#. 6.0/extension.js:1836
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1837
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2284
+#. 6.0/extension.js:2313
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Sfoca Cinnamom"
 
-#. 6.0/extension.js:2285
+#. 6.0/extension.js:2314
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -46,16 +46,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:2289
+#. 6.0/extension.js:2318
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Sfoca Cinnamom"
 
-#. 6.0/extension.js:2366
+#. 6.0/extension.js:2395
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:2367
+#. 6.0/extension.js:2396
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/nl.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-11-30 22:15-0500\n"
+"POT-Creation-Date: 2025-12-03 23:37-0500\n"
 "PO-Revision-Date: 2025-06-13 17:14+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,23 +16,23 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.0/extension.js:1807
+#. 6.0/extension.js:1836
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1837
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2284
+#. 6.0/extension.js:2313
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Vervaag Cinnamon"
 
-#. 6.0/extension.js:2285
+#. 6.0/extension.js:2314
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -44,16 +44,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:2289
+#. 6.0/extension.js:2318
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Vervaag Cinnamon"
 
-#. 6.0/extension.js:2366
+#. 6.0/extension.js:2395
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:2367
+#. 6.0/extension.js:2396
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/vi.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/vi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.5.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-11-30 22:15-0500\n"
+"POT-Creation-Date: 2025-12-03 23:37-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: loccun <huynhloc.contact@gmail.com>\n"
 "Language-Team: \n"
@@ -18,22 +18,22 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1807
+#. 6.0/extension.js:1836
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1808
+#. 6.0/extension.js:1837
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2284
+#. 6.0/extension.js:2313
 msgid "Welcome to Blur Cinnamon"
 msgstr "Chào mừng đến với Blur Cinnamon"
 
-#. 6.0/extension.js:2285
+#. 6.0/extension.js:2314
 #, fuzzy
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
@@ -53,15 +53,15 @@ msgstr ""
 "phần được bật theo mặc định. Bạn cũng có thể thay đổi các thuộc tính hiệu "
 "ứng như cường độ làm mờ, độ bão hòa màu và làm tối."
 
-#. 6.0/extension.js:2289
+#. 6.0/extension.js:2318
 msgid "Open Blur Cinnamon Settings"
 msgstr "Mở Cài đặt Blur Cinnamon"
 
-#. 6.0/extension.js:2366
+#. 6.0/extension.js:2395
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Đang thử nghiệm Hiệu ứng Thông báo Blur Cinnamon"
 
-#. 6.0/extension.js:2367
+#. 6.0/extension.js:2396
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"


### PR DESCRIPTION
- Fixed a 1.6.0 regression where the dimming of desktop effects are not removed after disabiling the desktop effects on the general page in the config window.
- Added support for rounded cinnamon panels, but currently to enable rounded corners in Cinnamon panels you need to manually edit your cinnamon.css file.