### PR TITLE
[BlurCinnamon@klangman] Version 1.7.1

### DIFF
--- a/BlurCinnamon@klangman/CHANGELOG.md
+++ b/BlurCinnamon@klangman/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## 1.7.1
+
+* Added a "Transparent" option to Panels/Menus/Tooltips/Notifications setting. This will provide a true transparent option where whatever is below the effected element will be visible (no blurring, not saturation). For panels this is no different to the Transparent Panels extension.
+* Added a "Default window settings" row to the Windows effect table. When this row is enabled, all windows will have effects applied, except application windows that match some other row in the table, in which case that rows settings will apply (a disabled row will cause the window to have no effects applied despite the "Default window settings" row being enabled).
+* Added code to improve the Cinnamon 6.6 Menu effects (sidebar transparency).
+* Added code to improve the Cinnamon 6.6 "Cinnamon" theme support (might also help with other themes that use CSS padding).
+* Added a "Custom CSS" option to the "Advanced" panel setting table. Using this option, users who know CSS can apply options to control the panels like shrinking the panel to be less then the screen width, adding rounded corners, adding borders, etc.
+* Another attempt to improve the performance of opening menus after the 1st time any particular menu is opened.
+* Fixed some blurring artifacts seen when restoring a minimized window while using the "Focused window backlight effect".
+
 ## 1.7.0
 
 * Added the ability to apply effects to Desklet backgrounds.

--- a/BlurCinnamon@klangman/README.md
+++ b/BlurCinnamon@klangman/README.md
@@ -30,6 +30,7 @@ Blurring can also be disabled if you just want a transparent or semi-transparent
 - Ability to changes the opacity of application windows so application window blur effects are visible under the window
 - Option to add a backlight effect to the focused window using a background image blur effect spilling over the focused windows borders
 - You can use general settings across all Cinnamon components or use unique settings for each component type
+- Allows you to apply custom CSS code to panels to achieve a number of custom panel effects like rounded corners, borders, changing the panel width, etc. Careful though, you can mess up your panels, but remember everything will go back to normal if you simply remove any Custom CSS settings you added to Blur Cinnamon.
 
 ## Requirements
 
@@ -43,8 +44,6 @@ If you have installed any of the following Cinnamon extensions, you should **dis
 
 Using any of the above with Blur Cinnamon may have some odd side effects that would require a Cinnamon restart to resolve.
 
-
-
 Cinnamon 6.6:  There are a few issues I need to work on for 22.3 (Cinnamon 6.6). The new menu should have the left panel changed to be transparant and the Cinnamon theme uses margins that cause Blur Cinnamon menu effects to spill over the popup's borders. I'll work on this for version 1.7.1
 
 ## Limitations
@@ -53,7 +52,7 @@ Cinnamon 6.6:  There are a few issues I need to work on for 22.3 (Cinnamon 6.6).
 2. The Applet popup-menu effects works for all the applets that I have tested except "Cinnamenu". Cinnamenu is preventing other code from receiving the "open-state-changed" event which BlurCinnamon uses to know when to apply popup-menu theme setting and when to resize and show the blur background element. This issue is fixed in the latest Cinnamenu from [Fredcw GitHub](https://github.com/fredcw/Cinnamenu) but you will need to manually fix the current Cinnamon Spices version of Cinnamenu (see [here](https://github.com/linuxmint/cinnamon-spices-extensions/issues/873))
 3. Currently, any windows that are positioned such that they overlap with a panel or an popup-menu will not be visible beneath blurred panel/popup-menu as you might expect with a transparent panel/menu. This is because the blur effect is applied to a user interface element that floats above all windows just like the panel floats above the windows. At some point I hope to look into allowing the blur element to appear below all windows rather than above and make the a optional behavior setting.
 4. If you disable effects for any Cinnamon component under the General tab of the setting dialog while any "Use unique effect settings" options are enabled under the other tabs, the components "effect setting" options under the other tabs will still be visible, but changing those setting will have no effect until you re-enable the component under the General tab. Ideally those effect setting would only be visible when the component is enabled under the general tab but Cinnamon setting support is a bit limited in this way.
-5. This extension currently does not work under Wayland, it only works under X11. The extension automatically detects wayland and disables most of the features of the extension.
+5. This extension currently does not work under Wayland, it only works under X11. The extension automatically detects Wayland and disables most of the features of the extension.
 
 ## Installation
 
@@ -63,6 +62,21 @@ Cinnamon 6.6:  There are a few issues I need to work on for 22.3 (Cinnamon 6.6).
 - Click the "Install" button on the right and then return to the "Manage" tab
 - Select the new "Blur Cinnamon" entry and then click the "+" button at the bottom of the window
 - Use the "gears" icon next to the "Blur Cinnamon" entry to open the setting window and setup the preferred behavior
+
+
+
+## Custom Panel CSS Examples:
+
+The following examples of CSS code can be applied to panels to achieve a custom panel effect.
+
+| Effect                          | Custom CSS string                               |
+| ------------------------------- | ----------------------------------------------- |
+| Grey Borders                    | border-width: 1px; border-color: rgb(70,70,70); |
+| Shrink a horizontal panel width | margin-left: 100px; margin-right: 100px;        |
+| Shrink a vertical panel height  | margin-top: 100px; margin-bottom: 100px;        |
+| Rounded the corners of a panel  | border-radius: 20px;                            |
+
+You can combine and modify the above as desired and add the result to the "Custom CSS" entry under the Panels settings. The "Enable advanced options to apply unique settings for each panel" option needs to be enabled see the panels table. Edit/add the appropriate table entry for the panel you wish to effect to modify the "Custom CSS" entry. Typos and syntax errors will typically result in the panel effects reverting to default, but other issue could result. You can always undue your effects by deleting the contents of the "Custom CSS" field in the table.
 
 ## Feedback
 

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/settings-schema.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/settings-schema.json
@@ -53,7 +53,7 @@
                     "notification-warning", "enable-notification-override", "notification-opacity", "notification-blendColor", "notification-blurType", "notification-radius", "notification-saturation", "notification-test-button",
                     "appswitcher-warning", "enable-appswitcher-override", "appswitcher-info", "window-settings-button", "appswitcher-opacity", "appswitcher-blendColor", "appswitcher-blurType", "appswitcher-radius", "appswitcher-saturation",
                     "tooltips-warning", "enable-tooltips-override", "tooltips-opacity", "tooltips-blendColor", "tooltips-blurType", "tooltips-radius", "tooltips-saturation",
-                    "windows-warning", "windows-inclusion-list", "windows-add-button", "windows-compiz-mitigation",
+                    "windows-warning", "windows-inclusion-list", "windows-label", "windows-add-button", "windows-compiz-mitigation",
                     "desklets-warning", "enable-desklets-override", "enable-desklets-unique-settings", "desklets-opacity", "desklets-blendColor", "desklets-blurType", "desklets-radius", "desklets-saturation", "desklets-list", "desklets-auto", "desklets-label",
                     "info-label"
                   ]
@@ -124,6 +124,15 @@
       "description" : "<b>Note:</b> You must configure your Desklets to be transparent! (see tooltip)",
       "tooltip": "In order for Blur Cinnamon Desklet effects to be visible, a Desklets background must be transparent. This allows the blur effect to be visible below the Desklet. Most Desklets can be configured to have transparent backgrounds. On the Desktop, right-click on a Desklet, select the \"Configure...\" menu item to open a Desklet's configuration window.",
       "dependency" : "enable-desklet-effects & component-selector=1"
+   },
+
+   "windows-label": {
+      "type" : "custom",
+      "file" : "CustomWidgets.py",
+      "widget" : "LabelWithTooltip",
+      "description" : "<b>Note:</b> Read tooltip for information about the \"Default window settings\"",
+      "tooltip": "If the special \"Default window settings\" table entry is enabled then all windows will have effects applied. If it is disabled then only the applications defined in the table will have effects applied. If the \"Enabled\" option is unchecked for a particular application then effects will be disabled even if the \"Default window settings\" row is enabled.",
+      "dependency" : "enable-window-effects & component-selector=9"
    },
 
    "info-label": {
@@ -208,7 +217,7 @@
    "enable-window-effects" : {
       "type": "switch",
       "description": "Application windows (Please read tooltip)",
-      "tooltip": "Apply effects to application window backgrounds by adding an effect actor below all existing graphical elements of affected windows. This means the effects will NOT be visible unless the application is setup to be transparent or the \"Opacity\" setting for the window is less than 100%. The application inclusion list under \"Windows\" settings is used to determine which (if any) applications will have effects applied to its windows.",
+      "tooltip": "Allow application window background effects by adding an effect actor below all existing graphical elements of affected windows. This means the effects will NOT be visible unless the application is setup to be transparent or the \"Opacity\" setting for the window is less than 100%. The table under the \"Windows\" component settings is used to determine which applications (if any) will have effects applied to its windows, enabling this option alone will not add effects to any windows.",
       "default": false
    },
    "enable-desklet-effects" : {
@@ -336,7 +345,8 @@
             {"id": "color",     "title": "Color",     "type": "string",  "default": "rgb(0,0,0)"},
             {"id": "blurtype",  "title": "Blur",      "type": "integer", "default": 2, "options": { "None": 0, "Simple": 1, "Gaussian": 2 } },
             {"id": "radius",    "title": "Intensity", "type": "integer", "default": 10,  "min": 0, "max": 100},
-            {"id": "saturation","title": "Saturation","type": "integer", "default": 100, "min": 0, "max": 100}
+            {"id": "saturation","title": "Saturation","type": "integer", "default": 100, "min": 0, "max": 100},
+            {"id": "customCSS", "title": "Custom CSS","type": "string",  "default": ""}
         ],
         "tooltip": "Defines the effects applied to different panels. If a panel does not meet the criteria of any enabled entry in this list, it will have no effects applied. The settings of the first entry in this list that can apply to a given panel will take effect. The \"Custom\" check box determines if the generic effect settings are uses or this tables custom settings. The color field is in the rgb(#,#,#) syntax and black will be used when a color is not provided or is in an incorrect syntax",
         "default" : [
@@ -554,12 +564,13 @@
         "type": "combobox",
         "default": 2,
         "options": {
-            "None": 0,
-            "Simple": 1,
-            "Gaussian": 2
+            "Transparent": 3,
+            "Transparent to Background": 0,
+            "Simple static blur": 1,
+            "Gaussian static blur": 2
         },
-        "description": "Type of blur effect",
-        "tooltip": "What type of blur algorithm should be used to blur the background",
+        "description": "Type of background effect",
+        "tooltip": "What type of background effect should be applied",
         "dependency" : "enable-panels-effects & component-selector=7 & !enable-panel-unique-settings & enable-panels-override"
     },
 
@@ -586,7 +597,7 @@
         "step" : 0.1,
         "tooltip": "Adjusts the color saturation of the background image from gray-scale to full color.",
         "default": 100,
-        "dependency" : "enable-panels-effects & component-selector=7 & !enable-panel-unique-settings & enable-panels-override"
+        "dependency" : "enable-panels-effects & component-selector=7 & !enable-panel-unique-settings & enable-panels-override & panels-blurType!=3"
     },
 
 
@@ -648,12 +659,13 @@
         "type": "combobox",
         "default": 2,
         "options": {
-            "None": 0,
-            "Simple": 1,
-            "Gaussian": 2
+            "Transparent": 3,
+            "Transparent to Background": 0,
+            "Simple static blur": 1,
+            "Gaussian static blur": 2
         },
-        "description": "Type of blur effect",
-        "tooltip": "What type of blur algorithm should be used to blur the background",
+        "description": "Type of background effect",
+        "tooltip": "What type of background effect should be applied",
         "dependency" : "enable-popup-effects & component-selector=4 & enable-popup-override"
     },
 
@@ -679,7 +691,7 @@
         "max" : 100,
         "step" : 0.1,
         "tooltip": "Adjusts the color saturation of the background image from gray-scale to full color.",
-        "dependency" : "enable-popup-effects & component-selector=4 & enable-popup-override",
+        "dependency" : "enable-popup-effects & component-selector=4 & enable-popup-override & popup-blurType!=3",
         "default": 100
     },
 
@@ -784,13 +796,14 @@
         "type": "combobox",
         "default": 2,
         "options": {
-            "None": 0,
-            "Simple": 1,
-            "Gaussian": 2
+            "Transparent": 3,
+            "Transparent to Background": 0,
+            "Simple static blur": 1,
+            "Gaussian static blur": 2
         },
-        "description": "Type of blur effect",
+        "description": "Type of background effect",
         "dependency" : "enable-notification-effects & component-selector=5 & enable-notification-override",
-        "tooltip": "What type of blur algorithm should be used to blur the background"
+        "tooltip": "What type of background effect should be applied"
     },
 
     "notification-radius": {
@@ -815,7 +828,7 @@
         "max" : 100,
         "step" : 0.1,
         "tooltip": "Adjusts the color saturation of the background image from gray-scale to full color.",
-        "dependency" : "enable-notification-effects & component-selector=5 & enable-notification-override",
+        "dependency" : "enable-notification-effects & component-selector=5 & enable-notification-override & notification-blurType!=3",
         "default": 100
     },
 
@@ -916,13 +929,14 @@
         "type": "combobox",
         "default": 2,
         "options": {
-            "None": 0,
-            "Simple": 1,
-            "Gaussian": 2
+            "Transparent": 3,
+            "Transparent to Background": 0,
+            "Simple static blur": 1,
+            "Gaussian static blur": 2
         },
-        "description": "Type of blur effect",
+        "description": "Type of background effect",
         "dependency" : "enable-tooltips-effects & component-selector=8 & enable-tooltips-override",
-        "tooltip": "What type of blur algorithm should be used to blur the background"
+        "tooltip": "What type of background effect should be applied"
     },
 
     "tooltips-radius": {
@@ -947,7 +961,7 @@
         "max" : 100,
         "step" : 0.1,
         "tooltip": "Adjusts the color saturation of the background image from gray-scale to full color.",
-        "dependency" : "enable-tooltips-effects & component-selector=8 & enable-tooltips-override",
+        "dependency" : "enable-tooltips-effects & component-selector=8 & enable-tooltips-override & tooltips-blurType!=3",
         "default": 100
     },
 
@@ -1030,7 +1044,7 @@
             {"id": "corner_top",    "title": "Rounded Top","type": "boolean", "default": true},
             {"id": "corner_bottom", "title": "Rounded Bottom","type": "boolean", "default": false}
         ],
-        "tooltip": "Defines a list of application windows where background effect will be applied and what effects will apply. When \"Custom\" is enabled the setting defined by this table will apply, otherwise the \"Generic effect settings\" will apply for the specific application. The \"Application\" field can be a WM_CLASS or a desktop file name.",
+        "tooltip": "This table controls which application windows will have effects applied and the effect settings. When \"Custom\" is enabled the setting defined by this table will apply, otherwise the \"Generic effect settings\" will apply. The \"Application\" field can be a WM_CLASS or a desktop file name.",
         "default" : [
             { "enabled": false, "application": "Alacritty.desktop",          "override": true, "opacity": 0, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100, "corner_radius": 10, "corner_top": true, "corner_bottom": false },
             { "enabled": false, "application": "com.gexperts.Tilix.desktop", "override": true, "opacity": 0, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100, "corner_radius": 10, "corner_top": true, "corner_bottom": false },

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
@@ -1,7 +1,7 @@
 {
     "uuid": "BlurCinnamon@klangman",
     "name": "Blur Cinnamon",
-    "version": "1.7.0",
+    "version": "1.7.1",
     "description": "Allows you to blur, colorize, desaturate and adjust the dimming of several Cinnamon Desktop components",
     "url": "https://github.com/klangman/BlurCinnamon",
     "cinnamon-version": [

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: BlurCinnamon@klangman 1.7.0\n"
+"Project-Id-Version: BlurCinnamon@klangman 1.7.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-12 10:26-0500\n"
+"POT-Creation-Date: 2026-01-25 17:05-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,22 +17,27 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.0/extension.js:1853
+#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
+#. 6.0/extension.js:1763
+msgid "Default window settings"
+msgstr ""
+
+#. 6.0/extension.js:1868
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1854
+#. 6.0/extension.js:1869
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2589
+#. 6.0/extension.js:2613
 msgid "Welcome to Blur Cinnamon"
 msgstr ""
 
-#. 6.0/extension.js:2590
+#. 6.0/extension.js:2614
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -44,15 +49,15 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:2594
+#. 6.0/extension.js:2618
 msgid "Open Blur Cinnamon Settings"
 msgstr ""
 
-#. 6.0/extension.js:2676
+#. 6.0/extension.js:2700
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:2677
+#. 6.0/extension.js:2701
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -177,6 +182,21 @@ msgid ""
 "below the Desklet. Most Desklets can be configured to have transparent "
 "backgrounds. On the Desktop, right-click on a Desklet, select the "
 "\"Configure...\" menu item to open a Desklet's configuration window."
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->description
+msgid ""
+"<b>Note:</b> Read tooltip for information about the \"Default window "
+"settings\""
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->tooltip
+msgid ""
+"If the special \"Default window settings\" table entry is enabled then all "
+"windows will have effects applied. If it is disabled then only the "
+"applications defined in the table will have effects applied. If the "
+"\"Enabled\" option is unchecked for a particular application then effects "
+"will be disabled even if the \"Default window settings\" row is enabled."
 msgstr ""
 
 #. 6.0->settings-schema.json->component-selector->options
@@ -336,12 +356,13 @@ msgstr ""
 
 #. 6.0->settings-schema.json->enable-window-effects->tooltip
 msgid ""
-"Apply effects to application window backgrounds by adding an effect actor "
-"below all existing graphical elements of affected windows. This means the "
-"effects will NOT be visible unless the application is setup to be "
-"transparent or the \"Opacity\" setting for the window is less than 100%. The "
-"application inclusion list under \"Windows\" settings is used to determine "
-"which (if any) applications will have effects applied to its windows."
+"Allow application window background effects by adding an effect actor below "
+"all existing graphical elements of affected windows. This means the effects "
+"will NOT be visible unless the application is setup to be transparent or the "
+"\"Opacity\" setting for the window is less than 100%. The table under the "
+"\"Windows\" component settings is used to determine which applications (if "
+"any) will have effects applied to its windows, enabling this option alone "
+"will not add effects to any windows."
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-desklet-effects->tooltip
@@ -502,6 +523,10 @@ msgstr ""
 msgid "Saturation"
 msgstr ""
 
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Custom CSS"
+msgstr ""
+
 #. 6.0->settings-schema.json->panel-unique-settings->tooltip
 msgid ""
 "Defines the effects applied to different panels. If a panel does not meet "
@@ -569,12 +594,8 @@ msgstr ""
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "None"
 msgstr ""
@@ -582,12 +603,8 @@ msgstr ""
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr ""
@@ -595,12 +612,8 @@ msgstr ""
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr ""
@@ -608,12 +621,8 @@ msgstr ""
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
-#. 6.0->settings-schema.json->panels-blurType->description
-#. 6.0->settings-schema.json->popup-blurType->description
 #. 6.0->settings-schema.json->desktop-blurType->description
-#. 6.0->settings-schema.json->notification-blurType->description
 #. 6.0->settings-schema.json->appswitcher-blurType->description
-#. 6.0->settings-schema.json->tooltips-blurType->description
 #. 6.0->settings-schema.json->desklets-blurType->description
 msgid "Type of blur effect"
 msgstr ""
@@ -621,12 +630,8 @@ msgstr ""
 #. 6.0->settings-schema.json->blurType->tooltip
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
-#. 6.0->settings-schema.json->panels-blurType->tooltip
-#. 6.0->settings-schema.json->popup-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->notification-blurType->tooltip
 #. 6.0->settings-schema.json->appswitcher-blurType->tooltip
-#. 6.0->settings-schema.json->tooltips-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr ""
@@ -684,6 +689,48 @@ msgstr ""
 msgid ""
 "Adjusts the color saturation of the background image from gray-scale to full "
 "color."
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Transparent"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Transparent to Background"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Simple static blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Gaussian static blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->description
+#. 6.0->settings-schema.json->popup-blurType->description
+#. 6.0->settings-schema.json->notification-blurType->description
+#. 6.0->settings-schema.json->tooltips-blurType->description
+msgid "Type of background effect"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->tooltip
+#. 6.0->settings-schema.json->popup-blurType->tooltip
+#. 6.0->settings-schema.json->notification-blurType->tooltip
+#. 6.0->settings-schema.json->tooltips-blurType->tooltip
+msgid "What type of background effect should be applied"
 msgstr ""
 
 #. 6.0->settings-schema.json->popup-applet-menu-effects->description
@@ -781,11 +828,10 @@ msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->tooltip
 msgid ""
-"Defines a list of application windows where background effect will be "
-"applied and what effects will apply. When \"Custom\" is enabled the setting "
-"defined by this table will apply, otherwise the \"Generic effect settings\" "
-"will apply for the specific application. The \"Application\" field can be a "
-"WM_CLASS or a desktop file name."
+"This table controls which application windows will have effects applied and "
+"the effect settings. When \"Custom\" is enabled the setting defined by this "
+"table will apply, otherwise the \"Generic effect settings\" will apply. The "
+"\"Application\" field can be a WM_CLASS or a desktop file name."
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-add-button->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-12 10:26-0500\n"
+"POT-Creation-Date: 2026-01-25 17:05-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,22 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.6\n"
 
-#. 6.0/extension.js:1853
+#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
+#. 6.0/extension.js:1763
+#, fuzzy
+msgid "Default window settings"
+msgstr "Obrir la configuració d'Alt-Tab de Cinnamon"
+
+#. 6.0/extension.js:1868
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1854
+#. 6.0/extension.js:1869
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2589
+#. 6.0/extension.js:2613
 msgid "Welcome to Blur Cinnamon"
 msgstr "Benvingut al Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:2590
+#. 6.0/extension.js:2614
 #, fuzzy
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
@@ -54,15 +60,15 @@ msgstr ""
 "per defecte. També podeu realitzar canvis a les propietats dels efectes, com "
 "ara la intensitat del desenfoc, la saturació del color i l'enfoscament."
 
-#. 6.0/extension.js:2594
+#. 6.0/extension.js:2618
 msgid "Open Blur Cinnamon Settings"
 msgstr "Obre la configuració del Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:2676
+#. 6.0/extension.js:2700
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Provant els efectes del Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:2677
+#. 6.0/extension.js:2701
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -220,6 +226,21 @@ msgid ""
 "below the Desklet. Most Desklets can be configured to have transparent "
 "backgrounds. On the Desktop, right-click on a Desklet, select the "
 "\"Configure...\" menu item to open a Desklet's configuration window."
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->description
+msgid ""
+"<b>Note:</b> Read tooltip for information about the \"Default window "
+"settings\""
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->tooltip
+msgid ""
+"If the special \"Default window settings\" table entry is enabled then all "
+"windows will have effects applied. If it is disabled then only the "
+"applications defined in the table will have effects applied. If the "
+"\"Enabled\" option is unchecked for a particular application then effects "
+"will be disabled even if the \"Default window settings\" row is enabled."
 msgstr ""
 
 #. 6.0->settings-schema.json->component-selector->options
@@ -419,12 +440,13 @@ msgstr "Notificacions emergents (Si us plau, llegiu el consell informatiu)"
 
 #. 6.0->settings-schema.json->enable-window-effects->tooltip
 msgid ""
-"Apply effects to application window backgrounds by adding an effect actor "
-"below all existing graphical elements of affected windows. This means the "
-"effects will NOT be visible unless the application is setup to be "
-"transparent or the \"Opacity\" setting for the window is less than 100%. The "
-"application inclusion list under \"Windows\" settings is used to determine "
-"which (if any) applications will have effects applied to its windows."
+"Allow application window background effects by adding an effect actor below "
+"all existing graphical elements of affected windows. This means the effects "
+"will NOT be visible unless the application is setup to be transparent or the "
+"\"Opacity\" setting for the window is less than 100%. The table under the "
+"\"Windows\" component settings is used to determine which applications (if "
+"any) will have effects applied to its windows, enabling this option alone "
+"will not add effects to any windows."
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-desklet-effects->tooltip
@@ -609,6 +631,10 @@ msgstr "Intensitat"
 msgid "Saturation"
 msgstr "Saturació"
 
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Custom CSS"
+msgstr ""
+
 #. 6.0->settings-schema.json->panel-unique-settings->tooltip
 #, fuzzy
 msgid ""
@@ -691,12 +717,8 @@ msgstr ""
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "None"
 msgstr "Cap"
@@ -704,12 +726,8 @@ msgstr "Cap"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Simple"
@@ -717,12 +735,8 @@ msgstr "Simple"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gaussià"
@@ -730,12 +744,8 @@ msgstr "Gaussià"
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
-#. 6.0->settings-schema.json->panels-blurType->description
-#. 6.0->settings-schema.json->popup-blurType->description
 #. 6.0->settings-schema.json->desktop-blurType->description
-#. 6.0->settings-schema.json->notification-blurType->description
 #. 6.0->settings-schema.json->appswitcher-blurType->description
-#. 6.0->settings-schema.json->tooltips-blurType->description
 #. 6.0->settings-schema.json->desklets-blurType->description
 msgid "Type of blur effect"
 msgstr "Tipus d'efecte de difuminat"
@@ -743,12 +753,8 @@ msgstr "Tipus d'efecte de difuminat"
 #. 6.0->settings-schema.json->blurType->tooltip
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
-#. 6.0->settings-schema.json->panels-blurType->tooltip
-#. 6.0->settings-schema.json->popup-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->notification-blurType->tooltip
 #. 6.0->settings-schema.json->appswitcher-blurType->tooltip
-#. 6.0->settings-schema.json->tooltips-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Tipus d'algorisme de difuminat que s'utilitzarà pel fons"
@@ -810,6 +816,51 @@ msgid ""
 "Adjusts the color saturation of the background image from gray-scale to full "
 "color."
 msgstr "Ajusta la saturació de color de la imatge de fons."
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Transparent"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#, fuzzy
+msgid "Transparent to Background"
+msgstr "Fons d'escriptori"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Simple static blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#, fuzzy
+msgid "Gaussian static blur"
+msgstr "Intensitat del difuminat Gaussià"
+
+#. 6.0->settings-schema.json->panels-blurType->description
+#. 6.0->settings-schema.json->popup-blurType->description
+#. 6.0->settings-schema.json->notification-blurType->description
+#. 6.0->settings-schema.json->tooltips-blurType->description
+#, fuzzy
+msgid "Type of background effect"
+msgstr "Tipus d'efecte de difuminat"
+
+#. 6.0->settings-schema.json->panels-blurType->tooltip
+#. 6.0->settings-schema.json->popup-blurType->tooltip
+#. 6.0->settings-schema.json->notification-blurType->tooltip
+#. 6.0->settings-schema.json->tooltips-blurType->tooltip
+msgid "What type of background effect should be applied"
+msgstr ""
 
 #. 6.0->settings-schema.json->popup-applet-menu-effects->description
 msgid "Apply effects to applet popup menus"
@@ -921,11 +972,10 @@ msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->tooltip
 msgid ""
-"Defines a list of application windows where background effect will be "
-"applied and what effects will apply. When \"Custom\" is enabled the setting "
-"defined by this table will apply, otherwise the \"Generic effect settings\" "
-"will apply for the specific application. The \"Application\" field can be a "
-"WM_CLASS or a desktop file name."
+"This table controls which application windows will have effects applied and "
+"the effect settings. When \"Custom\" is enabled the setting defined by this "
+"table will apply, otherwise the \"Generic effect settings\" will apply. The "
+"\"Application\" field can be a WM_CLASS or a desktop file name."
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-add-button->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/da.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.5.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-12 10:26-0500\n"
+"POT-Creation-Date: 2026-01-25 17:05-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -18,22 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1853
+#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
+#. 6.0/extension.js:1763
+#, fuzzy
+msgid "Default window settings"
+msgstr "Åbn Alt-Tab-indstillinger i Cinnamon"
+
+#. 6.0/extension.js:1868
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1854
+#. 6.0/extension.js:1869
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2589
+#. 6.0/extension.js:2613
 msgid "Welcome to Blur Cinnamon"
 msgstr "Velkommen til Sløret Cinnamon"
 
-#. 6.0/extension.js:2590
+#. 6.0/extension.js:2614
 #, fuzzy
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
@@ -54,15 +60,15 @@ msgstr ""
 "også foretage ændringer i effektens egenskaber, såsom sløringens intensitet, "
 "farvemætning og dæmpning."
 
-#. 6.0/extension.js:2594
+#. 6.0/extension.js:2618
 msgid "Open Blur Cinnamon Settings"
 msgstr "Åbn Sløret Cinnamon-indstillinger"
 
-#. 6.0/extension.js:2676
+#. 6.0/extension.js:2700
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Tester Sløret Cinnamons underretningseffekter"
 
-#. 6.0/extension.js:2677
+#. 6.0/extension.js:2701
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -226,6 +232,21 @@ msgid ""
 "below the Desklet. Most Desklets can be configured to have transparent "
 "backgrounds. On the Desktop, right-click on a Desklet, select the "
 "\"Configure...\" menu item to open a Desklet's configuration window."
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->description
+msgid ""
+"<b>Note:</b> Read tooltip for information about the \"Default window "
+"settings\""
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->tooltip
+msgid ""
+"If the special \"Default window settings\" table entry is enabled then all "
+"windows will have effects applied. If it is disabled then only the "
+"applications defined in the table will have effects applied. If the "
+"\"Enabled\" option is unchecked for a particular application then effects "
+"will be disabled even if the \"Default window settings\" row is enabled."
 msgstr ""
 
 #. 6.0->settings-schema.json->component-selector->options
@@ -423,12 +444,13 @@ msgstr "Pop op for underretninger (læs værktøjstip)"
 
 #. 6.0->settings-schema.json->enable-window-effects->tooltip
 msgid ""
-"Apply effects to application window backgrounds by adding an effect actor "
-"below all existing graphical elements of affected windows. This means the "
-"effects will NOT be visible unless the application is setup to be "
-"transparent or the \"Opacity\" setting for the window is less than 100%. The "
-"application inclusion list under \"Windows\" settings is used to determine "
-"which (if any) applications will have effects applied to its windows."
+"Allow application window background effects by adding an effect actor below "
+"all existing graphical elements of affected windows. This means the effects "
+"will NOT be visible unless the application is setup to be transparent or the "
+"\"Opacity\" setting for the window is less than 100%. The table under the "
+"\"Windows\" component settings is used to determine which applications (if "
+"any) will have effects applied to its windows, enabling this option alone "
+"will not add effects to any windows."
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-desklet-effects->tooltip
@@ -610,6 +632,10 @@ msgstr "Intensitet"
 msgid "Saturation"
 msgstr "Mætning"
 
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Custom CSS"
+msgstr ""
+
 #. 6.0->settings-schema.json->panel-unique-settings->tooltip
 #, fuzzy
 msgid ""
@@ -693,12 +719,8 @@ msgstr ""
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "None"
 msgstr "Ingen"
@@ -706,12 +728,8 @@ msgstr "Ingen"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Simpel"
@@ -719,12 +737,8 @@ msgstr "Simpel"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gaussisk"
@@ -732,12 +746,8 @@ msgstr "Gaussisk"
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
-#. 6.0->settings-schema.json->panels-blurType->description
-#. 6.0->settings-schema.json->popup-blurType->description
 #. 6.0->settings-schema.json->desktop-blurType->description
-#. 6.0->settings-schema.json->notification-blurType->description
 #. 6.0->settings-schema.json->appswitcher-blurType->description
-#. 6.0->settings-schema.json->tooltips-blurType->description
 #. 6.0->settings-schema.json->desklets-blurType->description
 msgid "Type of blur effect"
 msgstr "Type af sløringseffekt"
@@ -745,12 +755,8 @@ msgstr "Type af sløringseffekt"
 #. 6.0->settings-schema.json->blurType->tooltip
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
-#. 6.0->settings-schema.json->panels-blurType->tooltip
-#. 6.0->settings-schema.json->popup-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->notification-blurType->tooltip
 #. 6.0->settings-schema.json->appswitcher-blurType->tooltip
-#. 6.0->settings-schema.json->tooltips-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Hvilken type sløringsalgoritme skal bruges til at sløre baggrunden."
@@ -812,6 +818,51 @@ msgid ""
 "Adjusts the color saturation of the background image from gray-scale to full "
 "color."
 msgstr "Justerer baggrundsbilledets farvemætning."
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Transparent"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#, fuzzy
+msgid "Transparent to Background"
+msgstr "Skrivebordsbaggrund"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Simple static blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#, fuzzy
+msgid "Gaussian static blur"
+msgstr "Gaussisk sløringsintensitet"
+
+#. 6.0->settings-schema.json->panels-blurType->description
+#. 6.0->settings-schema.json->popup-blurType->description
+#. 6.0->settings-schema.json->notification-blurType->description
+#. 6.0->settings-schema.json->tooltips-blurType->description
+#, fuzzy
+msgid "Type of background effect"
+msgstr "Type af sløringseffekt"
+
+#. 6.0->settings-schema.json->panels-blurType->tooltip
+#. 6.0->settings-schema.json->popup-blurType->tooltip
+#. 6.0->settings-schema.json->notification-blurType->tooltip
+#. 6.0->settings-schema.json->tooltips-blurType->tooltip
+msgid "What type of background effect should be applied"
+msgstr ""
 
 #. 6.0->settings-schema.json->popup-applet-menu-effects->description
 msgid "Apply effects to applet popup menus"
@@ -922,11 +973,10 @@ msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->tooltip
 msgid ""
-"Defines a list of application windows where background effect will be "
-"applied and what effects will apply. When \"Custom\" is enabled the setting "
-"defined by this table will apply, otherwise the \"Generic effect settings\" "
-"will apply for the specific application. The \"Application\" field can be a "
-"WM_CLASS or a desktop file name."
+"This table controls which application windows will have effects applied and "
+"the effect settings. When \"Custom\" is enabled the setting defined by this "
+"table will apply, otherwise the \"Generic effect settings\" will apply. The "
+"\"Application\" field can be a WM_CLASS or a desktop file name."
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-add-button->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-12 10:26-0500\n"
+"POT-Creation-Date: 2026-01-25 17:05-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,11 +17,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.8\n"
 
-#. 6.0/extension.js:1853
+#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
+#. 6.0/extension.js:1763
+#, fuzzy
+msgid "Default window settings"
+msgstr "Abrir la configuración de Cinnamon con Alt-Tab"
+
+#. 6.0/extension.js:1868
 msgid "Error"
 msgstr "Error"
 
-#. 6.0/extension.js:1854
+#. 6.0/extension.js:1869
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
@@ -31,11 +37,11 @@ msgstr ""
 "tenía el foco anteriormente, por lo que no se pueden aplicar los efectos de "
 "Desenfoque Cinnamon a esa ventana"
 
-#. 6.0/extension.js:2589
+#. 6.0/extension.js:2613
 msgid "Welcome to Blur Cinnamon"
 msgstr "Bienvenido a Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:2590
+#. 6.0/extension.js:2614
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -55,15 +61,15 @@ msgstr ""
 "También puedes realizar cambios en las propiedades de los efectos, como la "
 "intensidad del desenfoque, la saturación del color y el oscurecimiento."
 
-#. 6.0/extension.js:2594
+#. 6.0/extension.js:2618
 msgid "Open Blur Cinnamon Settings"
 msgstr "Abrir configuración de Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:2676
+#. 6.0/extension.js:2700
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Probando los efectos de notificación de Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:2677
+#. 6.0/extension.js:2701
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -228,6 +234,21 @@ msgstr ""
 "haga clic con el botón derecho del ratón en un Desklet, seleccione el "
 "elemento del menú \"Configurar...\" para abrir la ventana de configuración "
 "del Desklet."
+
+#. 6.0->settings-schema.json->windows-label->description
+msgid ""
+"<b>Note:</b> Read tooltip for information about the \"Default window "
+"settings\""
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->tooltip
+msgid ""
+"If the special \"Default window settings\" table entry is enabled then all "
+"windows will have effects applied. If it is disabled then only the "
+"applications defined in the table will have effects applied. If the "
+"\"Enabled\" option is unchecked for a particular application then effects "
+"will be disabled even if the \"Default window settings\" row is enabled."
+msgstr ""
 
 #. 6.0->settings-schema.json->component-selector->options
 msgid "Alt-Tab"
@@ -434,13 +455,15 @@ msgid "Application windows (Please read tooltip)"
 msgstr "Ventanas de aplicación (lea la información sobre herramientas)"
 
 #. 6.0->settings-schema.json->enable-window-effects->tooltip
+#, fuzzy
 msgid ""
-"Apply effects to application window backgrounds by adding an effect actor "
-"below all existing graphical elements of affected windows. This means the "
-"effects will NOT be visible unless the application is setup to be "
-"transparent or the \"Opacity\" setting for the window is less than 100%. The "
-"application inclusion list under \"Windows\" settings is used to determine "
-"which (if any) applications will have effects applied to its windows."
+"Allow application window background effects by adding an effect actor below "
+"all existing graphical elements of affected windows. This means the effects "
+"will NOT be visible unless the application is setup to be transparent or the "
+"\"Opacity\" setting for the window is less than 100%. The table under the "
+"\"Windows\" component settings is used to determine which applications (if "
+"any) will have effects applied to its windows, enabling this option alone "
+"will not add effects to any windows."
 msgstr ""
 "Aplica efectos al fondo de las ventanas de la aplicación añadiendo un actor "
 "de efectos debajo de todos los elementos gráficos existentes de las ventanas "
@@ -641,6 +664,11 @@ msgstr "Intensidad"
 msgid "Saturation"
 msgstr "Saturación"
 
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+#, fuzzy
+msgid "Custom CSS"
+msgstr "Personalizado"
+
 #. 6.0->settings-schema.json->panel-unique-settings->tooltip
 msgid ""
 "Defines the effects applied to different panels. If a panel does not meet "
@@ -724,12 +752,8 @@ msgstr ""
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "None"
 msgstr "Ninguno"
@@ -737,12 +761,8 @@ msgstr "Ninguno"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Sencillo"
@@ -750,12 +770,8 @@ msgstr "Sencillo"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gaussiano"
@@ -763,12 +779,8 @@ msgstr "Gaussiano"
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
-#. 6.0->settings-schema.json->panels-blurType->description
-#. 6.0->settings-schema.json->popup-blurType->description
 #. 6.0->settings-schema.json->desktop-blurType->description
-#. 6.0->settings-schema.json->notification-blurType->description
 #. 6.0->settings-schema.json->appswitcher-blurType->description
-#. 6.0->settings-schema.json->tooltips-blurType->description
 #. 6.0->settings-schema.json->desklets-blurType->description
 msgid "Type of blur effect"
 msgstr "Tipo de efecto de desenfoque"
@@ -776,12 +788,8 @@ msgstr "Tipo de efecto de desenfoque"
 #. 6.0->settings-schema.json->blurType->tooltip
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
-#. 6.0->settings-schema.json->panels-blurType->tooltip
-#. 6.0->settings-schema.json->popup-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->notification-blurType->tooltip
 #. 6.0->settings-schema.json->appswitcher-blurType->tooltip
-#. 6.0->settings-schema.json->tooltips-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr ""
@@ -845,6 +853,51 @@ msgid ""
 msgstr ""
 "Ajusta la saturación del color de la imagen de fondo, desde escala de grises "
 "hasta color completo."
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Transparent"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#, fuzzy
+msgid "Transparent to Background"
+msgstr "Fondo de escritorio"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Simple static blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#, fuzzy
+msgid "Gaussian static blur"
+msgstr "Intensidad del desenfoque gaussiano"
+
+#. 6.0->settings-schema.json->panels-blurType->description
+#. 6.0->settings-schema.json->popup-blurType->description
+#. 6.0->settings-schema.json->notification-blurType->description
+#. 6.0->settings-schema.json->tooltips-blurType->description
+#, fuzzy
+msgid "Type of background effect"
+msgstr "Tipo de efecto de desenfoque"
+
+#. 6.0->settings-schema.json->panels-blurType->tooltip
+#. 6.0->settings-schema.json->popup-blurType->tooltip
+#. 6.0->settings-schema.json->notification-blurType->tooltip
+#. 6.0->settings-schema.json->tooltips-blurType->tooltip
+msgid "What type of background effect should be applied"
+msgstr ""
 
 #. 6.0->settings-schema.json->popup-applet-menu-effects->description
 msgid "Apply effects to applet popup menus"
@@ -957,12 +1010,12 @@ msgid "Rounded Bottom"
 msgstr "Parte inferior redondeada"
 
 #. 6.0->settings-schema.json->windows-inclusion-list->tooltip
+#, fuzzy
 msgid ""
-"Defines a list of application windows where background effect will be "
-"applied and what effects will apply. When \"Custom\" is enabled the setting "
-"defined by this table will apply, otherwise the \"Generic effect settings\" "
-"will apply for the specific application. The \"Application\" field can be a "
-"WM_CLASS or a desktop file name."
+"This table controls which application windows will have effects applied and "
+"the effect settings. When \"Custom\" is enabled the setting defined by this "
+"table will apply, otherwise the \"Generic effect settings\" will apply. The "
+"\"Application\" field can be a WM_CLASS or a desktop file name."
 msgstr ""
 "Define una lista de ventanas de aplicaciones en las que se aplicará el "
 "efecto de fondo y qué efectos se aplicarán. Cuando se habilita "

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fi.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-12 10:26-0500\n"
+"POT-Creation-Date: 2026-01-25 17:05-0500\n"
 "PO-Revision-Date: 2025-03-30 10:53+0300\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -18,23 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1853
+#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
+#. 6.0/extension.js:1763
+msgid "Default window settings"
+msgstr ""
+
+#. 6.0/extension.js:1868
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1854
+#. 6.0/extension.js:1869
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2589
+#. 6.0/extension.js:2613
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Blur Cinnamon"
 
-#. 6.0/extension.js:2590
+#. 6.0/extension.js:2614
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -46,16 +51,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:2594
+#. 6.0/extension.js:2618
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Blur Cinnamon"
 
-#. 6.0/extension.js:2676
+#. 6.0/extension.js:2700
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:2677
+#. 6.0/extension.js:2701
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -206,6 +211,21 @@ msgid ""
 "below the Desklet. Most Desklets can be configured to have transparent "
 "backgrounds. On the Desktop, right-click on a Desklet, select the "
 "\"Configure...\" menu item to open a Desklet's configuration window."
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->description
+msgid ""
+"<b>Note:</b> Read tooltip for information about the \"Default window "
+"settings\""
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->tooltip
+msgid ""
+"If the special \"Default window settings\" table entry is enabled then all "
+"windows will have effects applied. If it is disabled then only the "
+"applications defined in the table will have effects applied. If the "
+"\"Enabled\" option is unchecked for a particular application then effects "
+"will be disabled even if the \"Default window settings\" row is enabled."
 msgstr ""
 
 #. 6.0->settings-schema.json->component-selector->options
@@ -403,12 +423,13 @@ msgstr "Ponnahdusvalikot (lue työkaluvihje)"
 
 #. 6.0->settings-schema.json->enable-window-effects->tooltip
 msgid ""
-"Apply effects to application window backgrounds by adding an effect actor "
-"below all existing graphical elements of affected windows. This means the "
-"effects will NOT be visible unless the application is setup to be "
-"transparent or the \"Opacity\" setting for the window is less than 100%. The "
-"application inclusion list under \"Windows\" settings is used to determine "
-"which (if any) applications will have effects applied to its windows."
+"Allow application window background effects by adding an effect actor below "
+"all existing graphical elements of affected windows. This means the effects "
+"will NOT be visible unless the application is setup to be transparent or the "
+"\"Opacity\" setting for the window is less than 100%. The table under the "
+"\"Windows\" component settings is used to determine which applications (if "
+"any) will have effects applied to its windows, enabling this option alone "
+"will not add effects to any windows."
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-desklet-effects->tooltip
@@ -595,6 +616,10 @@ msgstr "Vahvuus"
 msgid "Saturation"
 msgstr "Kylläisyys"
 
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Custom CSS"
+msgstr ""
+
 #. 6.0->settings-schema.json->panel-unique-settings->tooltip
 #, fuzzy
 msgid ""
@@ -671,12 +696,8 @@ msgstr ""
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "None"
 msgstr "Ei mitään"
@@ -684,12 +705,8 @@ msgstr "Ei mitään"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Vakio"
@@ -697,12 +714,8 @@ msgstr "Vakio"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gaussian"
@@ -710,12 +723,8 @@ msgstr "Gaussian"
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
-#. 6.0->settings-schema.json->panels-blurType->description
-#. 6.0->settings-schema.json->popup-blurType->description
 #. 6.0->settings-schema.json->desktop-blurType->description
-#. 6.0->settings-schema.json->notification-blurType->description
 #. 6.0->settings-schema.json->appswitcher-blurType->description
-#. 6.0->settings-schema.json->tooltips-blurType->description
 #. 6.0->settings-schema.json->desklets-blurType->description
 msgid "Type of blur effect"
 msgstr "Sumeustehoste"
@@ -723,12 +732,8 @@ msgstr "Sumeustehoste"
 #. 6.0->settings-schema.json->blurType->tooltip
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
-#. 6.0->settings-schema.json->panels-blurType->tooltip
-#. 6.0->settings-schema.json->popup-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->notification-blurType->tooltip
 #. 6.0->settings-schema.json->appswitcher-blurType->tooltip
-#. 6.0->settings-schema.json->tooltips-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Mitä sumennusalgoritmia tulisi käyttää taustan sumentamiseen"
@@ -788,6 +793,51 @@ msgid ""
 "Adjusts the color saturation of the background image from gray-scale to full "
 "color."
 msgstr "Säätää taustakuvan värikylläisyyttä."
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Transparent"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#, fuzzy
+msgid "Transparent to Background"
+msgstr "Taustakuva"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Simple static blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#, fuzzy
+msgid "Gaussian static blur"
+msgstr "Sumennuksen voimakkuus"
+
+#. 6.0->settings-schema.json->panels-blurType->description
+#. 6.0->settings-schema.json->popup-blurType->description
+#. 6.0->settings-schema.json->notification-blurType->description
+#. 6.0->settings-schema.json->tooltips-blurType->description
+#, fuzzy
+msgid "Type of background effect"
+msgstr "Sumeustehoste"
+
+#. 6.0->settings-schema.json->panels-blurType->tooltip
+#. 6.0->settings-schema.json->popup-blurType->tooltip
+#. 6.0->settings-schema.json->notification-blurType->tooltip
+#. 6.0->settings-schema.json->tooltips-blurType->tooltip
+msgid "What type of background effect should be applied"
+msgstr ""
 
 #. 6.0->settings-schema.json->popup-applet-menu-effects->description
 msgid "Apply effects to applet popup menus"
@@ -894,11 +944,10 @@ msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->tooltip
 msgid ""
-"Defines a list of application windows where background effect will be "
-"applied and what effects will apply. When \"Custom\" is enabled the setting "
-"defined by this table will apply, otherwise the \"Generic effect settings\" "
-"will apply for the specific application. The \"Application\" field can be a "
-"WM_CLASS or a desktop file name."
+"This table controls which application windows will have effects applied and "
+"the effect settings. When \"Custom\" is enabled the setting defined by this "
+"table will apply, otherwise the \"Generic effect settings\" will apply. The "
+"\"Application\" field can be a WM_CLASS or a desktop file name."
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-add-button->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-12 10:26-0500\n"
+"POT-Creation-Date: 2026-01-25 17:05-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -18,23 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1853
+#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
+#. 6.0/extension.js:1763
+msgid "Default window settings"
+msgstr ""
+
+#. 6.0/extension.js:1868
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1854
+#. 6.0/extension.js:1869
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2589
+#. 6.0/extension.js:2613
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Flou pour Cinnamon"
 
-#. 6.0/extension.js:2590
+#. 6.0/extension.js:2614
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -46,16 +51,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:2594
+#. 6.0/extension.js:2618
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Flou pour Cinnamon"
 
-#. 6.0/extension.js:2676
+#. 6.0/extension.js:2700
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:2677
+#. 6.0/extension.js:2701
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -218,6 +223,21 @@ msgid ""
 "below the Desklet. Most Desklets can be configured to have transparent "
 "backgrounds. On the Desktop, right-click on a Desklet, select the "
 "\"Configure...\" menu item to open a Desklet's configuration window."
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->description
+msgid ""
+"<b>Note:</b> Read tooltip for information about the \"Default window "
+"settings\""
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->tooltip
+msgid ""
+"If the special \"Default window settings\" table entry is enabled then all "
+"windows will have effects applied. If it is disabled then only the "
+"applications defined in the table will have effects applied. If the "
+"\"Enabled\" option is unchecked for a particular application then effects "
+"will be disabled even if the \"Default window settings\" row is enabled."
 msgstr ""
 
 #. 6.0->settings-schema.json->component-selector->options
@@ -424,12 +444,13 @@ msgstr "Menu principal (Veuillez lire l'infobulle)"
 
 #. 6.0->settings-schema.json->enable-window-effects->tooltip
 msgid ""
-"Apply effects to application window backgrounds by adding an effect actor "
-"below all existing graphical elements of affected windows. This means the "
-"effects will NOT be visible unless the application is setup to be "
-"transparent or the \"Opacity\" setting for the window is less than 100%. The "
-"application inclusion list under \"Windows\" settings is used to determine "
-"which (if any) applications will have effects applied to its windows."
+"Allow application window background effects by adding an effect actor below "
+"all existing graphical elements of affected windows. This means the effects "
+"will NOT be visible unless the application is setup to be transparent or the "
+"\"Opacity\" setting for the window is less than 100%. The table under the "
+"\"Windows\" component settings is used to determine which applications (if "
+"any) will have effects applied to its windows, enabling this option alone "
+"will not add effects to any windows."
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-desklet-effects->tooltip
@@ -623,6 +644,10 @@ msgstr "Intensité"
 msgid "Saturation"
 msgstr ""
 
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Custom CSS"
+msgstr ""
+
 #. 6.0->settings-schema.json->panel-unique-settings->tooltip
 #, fuzzy
 msgid ""
@@ -701,12 +726,8 @@ msgstr ""
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "None"
 msgstr "Aucun"
@@ -714,12 +735,8 @@ msgstr "Aucun"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Simple"
@@ -727,12 +744,8 @@ msgstr "Simple"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gaussien"
@@ -740,12 +753,8 @@ msgstr "Gaussien"
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
-#. 6.0->settings-schema.json->panels-blurType->description
-#. 6.0->settings-schema.json->popup-blurType->description
 #. 6.0->settings-schema.json->desktop-blurType->description
-#. 6.0->settings-schema.json->notification-blurType->description
 #. 6.0->settings-schema.json->appswitcher-blurType->description
-#. 6.0->settings-schema.json->tooltips-blurType->description
 #. 6.0->settings-schema.json->desklets-blurType->description
 msgid "Type of blur effect"
 msgstr "Type d'effet de flou"
@@ -753,12 +762,8 @@ msgstr "Type d'effet de flou"
 #. 6.0->settings-schema.json->blurType->tooltip
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
-#. 6.0->settings-schema.json->panels-blurType->tooltip
-#. 6.0->settings-schema.json->popup-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->notification-blurType->tooltip
 #. 6.0->settings-schema.json->appswitcher-blurType->tooltip
-#. 6.0->settings-schema.json->tooltips-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Type d'algorithme à utiliser pour rendre l'arrière-plan flou"
@@ -818,6 +823,50 @@ msgstr ""
 msgid ""
 "Adjusts the color saturation of the background image from gray-scale to full "
 "color."
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Transparent"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Transparent to Background"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Simple static blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#, fuzzy
+msgid "Gaussian static blur"
+msgstr "Intensité du flou gaussien"
+
+#. 6.0->settings-schema.json->panels-blurType->description
+#. 6.0->settings-schema.json->popup-blurType->description
+#. 6.0->settings-schema.json->notification-blurType->description
+#. 6.0->settings-schema.json->tooltips-blurType->description
+#, fuzzy
+msgid "Type of background effect"
+msgstr "Type d'effet de flou"
+
+#. 6.0->settings-schema.json->panels-blurType->tooltip
+#. 6.0->settings-schema.json->popup-blurType->tooltip
+#. 6.0->settings-schema.json->notification-blurType->tooltip
+#. 6.0->settings-schema.json->tooltips-blurType->tooltip
+msgid "What type of background effect should be applied"
 msgstr ""
 
 #. 6.0->settings-schema.json->popup-applet-menu-effects->description
@@ -923,11 +972,10 @@ msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->tooltip
 msgid ""
-"Defines a list of application windows where background effect will be "
-"applied and what effects will apply. When \"Custom\" is enabled the setting "
-"defined by this table will apply, otherwise the \"Generic effect settings\" "
-"will apply for the specific application. The \"Application\" field can be a "
-"WM_CLASS or a desktop file name."
+"This table controls which application windows will have effects applied and "
+"the effect settings. When \"Custom\" is enabled the setting defined by this "
+"table will apply, otherwise the \"Generic effect settings\" will apply. The "
+"\"Application\" field can be a WM_CLASS or a desktop file name."
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-add-button->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/hu.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-12 10:26-0500\n"
+"POT-Creation-Date: 2026-01-25 17:05-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,11 +18,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.8\n"
 
-#. 6.0/extension.js:1853
+#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
+#. 6.0/extension.js:1763
+#, fuzzy
+msgid "Default window settings"
+msgstr "Nyissa meg az Alt-Tab Cinnamon beállításokat"
+
+#. 6.0/extension.js:1868
 msgid "Error"
 msgstr "Hiba"
 
-#. 6.0/extension.js:1854
+#. 6.0/extension.js:1869
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
@@ -32,11 +38,11 @@ msgstr ""
 "WM_CLASS osztályát, ezért a Cinnamon Elhomályosítása effektek nem "
 "alkalmazhatók erre az ablakra"
 
-#. 6.0/extension.js:2589
+#. 6.0/extension.js:2613
 msgid "Welcome to Blur Cinnamon"
 msgstr "Üdvözöljük a Cinnamon Elhomályosításában"
 
-#. 6.0/extension.js:2590
+#. 6.0/extension.js:2614
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -56,15 +62,15 @@ msgstr ""
 "Módosíthatod az effektek tulajdonságait is, például az elmosás intenzitását, "
 "a színtelítettséget és a fényerőt."
 
-#. 6.0/extension.js:2594
+#. 6.0/extension.js:2618
 msgid "Open Blur Cinnamon Settings"
 msgstr "Nyissa meg a Cinnamon Elhomályosítása beállításait"
 
-#. 6.0/extension.js:2676
+#. 6.0/extension.js:2700
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Cinnamon Elhomályosítása értesítési effektek tesztelése"
 
-#. 6.0/extension.js:2677
+#. 6.0/extension.js:2701
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -231,6 +237,21 @@ msgid ""
 "below the Desklet. Most Desklets can be configured to have transparent "
 "backgrounds. On the Desktop, right-click on a Desklet, select the "
 "\"Configure...\" menu item to open a Desklet's configuration window."
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->description
+msgid ""
+"<b>Note:</b> Read tooltip for information about the \"Default window "
+"settings\""
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->tooltip
+msgid ""
+"If the special \"Default window settings\" table entry is enabled then all "
+"windows will have effects applied. If it is disabled then only the "
+"applications defined in the table will have effects applied. If the "
+"\"Enabled\" option is unchecked for a particular application then effects "
+"will be disabled even if the \"Default window settings\" row is enabled."
 msgstr ""
 
 #. 6.0->settings-schema.json->component-selector->options
@@ -421,12 +442,13 @@ msgstr "Alkalmazásablakok (Kérjük, olvassa el az elemleírást)"
 #. 6.0->settings-schema.json->enable-window-effects->tooltip
 #, fuzzy
 msgid ""
-"Apply effects to application window backgrounds by adding an effect actor "
-"below all existing graphical elements of affected windows. This means the "
-"effects will NOT be visible unless the application is setup to be "
-"transparent or the \"Opacity\" setting for the window is less than 100%. The "
-"application inclusion list under \"Windows\" settings is used to determine "
-"which (if any) applications will have effects applied to its windows."
+"Allow application window background effects by adding an effect actor below "
+"all existing graphical elements of affected windows. This means the effects "
+"will NOT be visible unless the application is setup to be transparent or the "
+"\"Opacity\" setting for the window is less than 100%. The table under the "
+"\"Windows\" component settings is used to determine which applications (if "
+"any) will have effects applied to its windows, enabling this option alone "
+"will not add effects to any windows."
 msgstr ""
 "Effektusok alkalmazása az alkalmazásablakok hátterére úgy, hogy effektusokat "
 "ad hozzá egy effektus-aktorhoz az érintett ablakok összes meglévő grafikus "
@@ -617,6 +639,11 @@ msgstr "Intenzitás"
 msgid "Saturation"
 msgstr "Telítettség"
 
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+#, fuzzy
+msgid "Custom CSS"
+msgstr "Egyéni"
+
 #. 6.0->settings-schema.json->panel-unique-settings->tooltip
 #, fuzzy
 msgid ""
@@ -699,12 +726,8 @@ msgstr ""
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "None"
 msgstr "Semmi"
@@ -712,12 +735,8 @@ msgstr "Semmi"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Egyszerű"
@@ -725,12 +744,8 @@ msgstr "Egyszerű"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gauss-féle"
@@ -738,12 +753,8 @@ msgstr "Gauss-féle"
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
-#. 6.0->settings-schema.json->panels-blurType->description
-#. 6.0->settings-schema.json->popup-blurType->description
 #. 6.0->settings-schema.json->desktop-blurType->description
-#. 6.0->settings-schema.json->notification-blurType->description
 #. 6.0->settings-schema.json->appswitcher-blurType->description
-#. 6.0->settings-schema.json->tooltips-blurType->description
 #. 6.0->settings-schema.json->desklets-blurType->description
 msgid "Type of blur effect"
 msgstr "Az elmosódási hatás típusa"
@@ -751,12 +762,8 @@ msgstr "Az elmosódási hatás típusa"
 #. 6.0->settings-schema.json->blurType->tooltip
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
-#. 6.0->settings-schema.json->panels-blurType->tooltip
-#. 6.0->settings-schema.json->popup-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->notification-blurType->tooltip
 #. 6.0->settings-schema.json->appswitcher-blurType->tooltip
-#. 6.0->settings-schema.json->tooltips-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr ""
@@ -819,6 +826,51 @@ msgid ""
 "Adjusts the color saturation of the background image from gray-scale to full "
 "color."
 msgstr "Beállítja a háttérkép színtelítettségét."
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Transparent"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#, fuzzy
+msgid "Transparent to Background"
+msgstr "Asztal háttér"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Simple static blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#, fuzzy
+msgid "Gaussian static blur"
+msgstr "Gauss-elmosódás intenzitása"
+
+#. 6.0->settings-schema.json->panels-blurType->description
+#. 6.0->settings-schema.json->popup-blurType->description
+#. 6.0->settings-schema.json->notification-blurType->description
+#. 6.0->settings-schema.json->tooltips-blurType->description
+#, fuzzy
+msgid "Type of background effect"
+msgstr "Az elmosódási hatás típusa"
+
+#. 6.0->settings-schema.json->panels-blurType->tooltip
+#. 6.0->settings-schema.json->popup-blurType->tooltip
+#. 6.0->settings-schema.json->notification-blurType->tooltip
+#. 6.0->settings-schema.json->tooltips-blurType->tooltip
+msgid "What type of background effect should be applied"
+msgstr ""
 
 #. 6.0->settings-schema.json->popup-applet-menu-effects->description
 msgid "Apply effects to applet popup menus"
@@ -931,11 +983,10 @@ msgstr "Lekerekített alj"
 #. 6.0->settings-schema.json->windows-inclusion-list->tooltip
 #, fuzzy
 msgid ""
-"Defines a list of application windows where background effect will be "
-"applied and what effects will apply. When \"Custom\" is enabled the setting "
-"defined by this table will apply, otherwise the \"Generic effect settings\" "
-"will apply for the specific application. The \"Application\" field can be a "
-"WM_CLASS or a desktop file name."
+"This table controls which application windows will have effects applied and "
+"the effect settings. When \"Custom\" is enabled the setting defined by this "
+"table will apply, otherwise the \"Generic effect settings\" will apply. The "
+"\"Application\" field can be a WM_CLASS or a desktop file name."
 msgstr ""
 "Meghatározza azon alkalmazásablakok listáját, ahol a háttéreffektus "
 "alkalmazásra kerül, és milyen effektusok érvényesek. Ha az „Egyéni” "

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/it.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-12 10:26-0500\n"
+"POT-Creation-Date: 2026-01-25 17:05-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -18,23 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1853
+#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
+#. 6.0/extension.js:1763
+msgid "Default window settings"
+msgstr ""
+
+#. 6.0/extension.js:1868
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1854
+#. 6.0/extension.js:1869
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2589
+#. 6.0/extension.js:2613
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Sfoca Cinnamom"
 
-#. 6.0/extension.js:2590
+#. 6.0/extension.js:2614
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -46,16 +51,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:2594
+#. 6.0/extension.js:2618
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Sfoca Cinnamom"
 
-#. 6.0/extension.js:2676
+#. 6.0/extension.js:2700
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:2677
+#. 6.0/extension.js:2701
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -219,6 +224,21 @@ msgid ""
 "below the Desklet. Most Desklets can be configured to have transparent "
 "backgrounds. On the Desktop, right-click on a Desklet, select the "
 "\"Configure...\" menu item to open a Desklet's configuration window."
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->description
+msgid ""
+"<b>Note:</b> Read tooltip for information about the \"Default window "
+"settings\""
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->tooltip
+msgid ""
+"If the special \"Default window settings\" table entry is enabled then all "
+"windows will have effects applied. If it is disabled then only the "
+"applications defined in the table will have effects applied. If the "
+"\"Enabled\" option is unchecked for a particular application then effects "
+"will be disabled even if the \"Default window settings\" row is enabled."
 msgstr ""
 
 #. 6.0->settings-schema.json->component-selector->options
@@ -426,12 +446,13 @@ msgstr "Menù a comparsa  (Leggi il tooltip)"
 
 #. 6.0->settings-schema.json->enable-window-effects->tooltip
 msgid ""
-"Apply effects to application window backgrounds by adding an effect actor "
-"below all existing graphical elements of affected windows. This means the "
-"effects will NOT be visible unless the application is setup to be "
-"transparent or the \"Opacity\" setting for the window is less than 100%. The "
-"application inclusion list under \"Windows\" settings is used to determine "
-"which (if any) applications will have effects applied to its windows."
+"Allow application window background effects by adding an effect actor below "
+"all existing graphical elements of affected windows. This means the effects "
+"will NOT be visible unless the application is setup to be transparent or the "
+"\"Opacity\" setting for the window is less than 100%. The table under the "
+"\"Windows\" component settings is used to determine which applications (if "
+"any) will have effects applied to its windows, enabling this option alone "
+"will not add effects to any windows."
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-desklet-effects->tooltip
@@ -621,6 +642,10 @@ msgstr "Intensità"
 msgid "Saturation"
 msgstr "Saturazione"
 
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Custom CSS"
+msgstr ""
+
 #. 6.0->settings-schema.json->panel-unique-settings->tooltip
 #, fuzzy
 msgid ""
@@ -699,12 +724,8 @@ msgstr ""
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "None"
 msgstr "Nessuno"
@@ -712,12 +733,8 @@ msgstr "Nessuno"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Semplice"
@@ -725,12 +742,8 @@ msgstr "Semplice"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gaussiana"
@@ -738,12 +751,8 @@ msgstr "Gaussiana"
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
-#. 6.0->settings-schema.json->panels-blurType->description
-#. 6.0->settings-schema.json->popup-blurType->description
 #. 6.0->settings-schema.json->desktop-blurType->description
-#. 6.0->settings-schema.json->notification-blurType->description
 #. 6.0->settings-schema.json->appswitcher-blurType->description
-#. 6.0->settings-schema.json->tooltips-blurType->description
 #. 6.0->settings-schema.json->desklets-blurType->description
 msgid "Type of blur effect"
 msgstr "Tipo di effetto sfocatura"
@@ -751,12 +760,8 @@ msgstr "Tipo di effetto sfocatura"
 #. 6.0->settings-schema.json->blurType->tooltip
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
-#. 6.0->settings-schema.json->panels-blurType->tooltip
-#. 6.0->settings-schema.json->popup-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->notification-blurType->tooltip
 #. 6.0->settings-schema.json->appswitcher-blurType->tooltip
-#. 6.0->settings-schema.json->tooltips-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr ""
@@ -820,6 +825,51 @@ msgid ""
 "Adjusts the color saturation of the background image from gray-scale to full "
 "color."
 msgstr "Regola la saturazione del colore dell'immagine di sfondo."
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Transparent"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#, fuzzy
+msgid "Transparent to Background"
+msgstr "Sfondo del desktop"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Simple static blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#, fuzzy
+msgid "Gaussian static blur"
+msgstr "Intensità della sfocatura gaussiana"
+
+#. 6.0->settings-schema.json->panels-blurType->description
+#. 6.0->settings-schema.json->popup-blurType->description
+#. 6.0->settings-schema.json->notification-blurType->description
+#. 6.0->settings-schema.json->tooltips-blurType->description
+#, fuzzy
+msgid "Type of background effect"
+msgstr "Tipo di effetto sfocatura"
+
+#. 6.0->settings-schema.json->panels-blurType->tooltip
+#. 6.0->settings-schema.json->popup-blurType->tooltip
+#. 6.0->settings-schema.json->notification-blurType->tooltip
+#. 6.0->settings-schema.json->tooltips-blurType->tooltip
+msgid "What type of background effect should be applied"
+msgstr ""
 
 #. 6.0->settings-schema.json->popup-applet-menu-effects->description
 msgid "Apply effects to applet popup menus"
@@ -932,11 +982,10 @@ msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->tooltip
 msgid ""
-"Defines a list of application windows where background effect will be "
-"applied and what effects will apply. When \"Custom\" is enabled the setting "
-"defined by this table will apply, otherwise the \"Generic effect settings\" "
-"will apply for the specific application. The \"Application\" field can be a "
-"WM_CLASS or a desktop file name."
+"This table controls which application windows will have effects applied and "
+"the effect settings. When \"Custom\" is enabled the setting defined by this "
+"table will apply, otherwise the \"Generic effect settings\" will apply. The "
+"\"Application\" field can be a WM_CLASS or a desktop file name."
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-add-button->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/nl.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-12 10:26-0500\n"
+"POT-Creation-Date: 2026-01-25 17:05-0500\n"
 "PO-Revision-Date: 2025-06-13 17:14+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,23 +16,28 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.0/extension.js:1853
+#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
+#. 6.0/extension.js:1763
+msgid "Default window settings"
+msgstr ""
+
+#. 6.0/extension.js:1868
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1854
+#. 6.0/extension.js:1869
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2589
+#. 6.0/extension.js:2613
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Vervaag Cinnamon"
 
-#. 6.0/extension.js:2590
+#. 6.0/extension.js:2614
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -44,16 +49,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:2594
+#. 6.0/extension.js:2618
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Vervaag Cinnamon"
 
-#. 6.0/extension.js:2676
+#. 6.0/extension.js:2700
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:2677
+#. 6.0/extension.js:2701
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -217,6 +222,21 @@ msgid ""
 "below the Desklet. Most Desklets can be configured to have transparent "
 "backgrounds. On the Desktop, right-click on a Desklet, select the "
 "\"Configure...\" menu item to open a Desklet's configuration window."
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->description
+msgid ""
+"<b>Note:</b> Read tooltip for information about the \"Default window "
+"settings\""
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->tooltip
+msgid ""
+"If the special \"Default window settings\" table entry is enabled then all "
+"windows will have effects applied. If it is disabled then only the "
+"applications defined in the table will have effects applied. If the "
+"\"Enabled\" option is unchecked for a particular application then effects "
+"will be disabled even if the \"Default window settings\" row is enabled."
 msgstr ""
 
 #. 6.0->settings-schema.json->component-selector->options
@@ -424,12 +444,13 @@ msgstr "Pop-upmenu’s (lees de tooltip)"
 
 #. 6.0->settings-schema.json->enable-window-effects->tooltip
 msgid ""
-"Apply effects to application window backgrounds by adding an effect actor "
-"below all existing graphical elements of affected windows. This means the "
-"effects will NOT be visible unless the application is setup to be "
-"transparent or the \"Opacity\" setting for the window is less than 100%. The "
-"application inclusion list under \"Windows\" settings is used to determine "
-"which (if any) applications will have effects applied to its windows."
+"Allow application window background effects by adding an effect actor below "
+"all existing graphical elements of affected windows. This means the effects "
+"will NOT be visible unless the application is setup to be transparent or the "
+"\"Opacity\" setting for the window is less than 100%. The table under the "
+"\"Windows\" component settings is used to determine which applications (if "
+"any) will have effects applied to its windows, enabling this option alone "
+"will not add effects to any windows."
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-desklet-effects->tooltip
@@ -620,6 +641,10 @@ msgstr "Intensiteit"
 msgid "Saturation"
 msgstr "Verzadiging"
 
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Custom CSS"
+msgstr ""
+
 #. 6.0->settings-schema.json->panel-unique-settings->tooltip
 #, fuzzy
 msgid ""
@@ -698,12 +723,8 @@ msgstr ""
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "None"
 msgstr "Geen"
@@ -711,12 +732,8 @@ msgstr "Geen"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Eenvoudig"
@@ -724,12 +741,8 @@ msgstr "Eenvoudig"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gaussiaans"
@@ -737,12 +750,8 @@ msgstr "Gaussiaans"
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
-#. 6.0->settings-schema.json->panels-blurType->description
-#. 6.0->settings-schema.json->popup-blurType->description
 #. 6.0->settings-schema.json->desktop-blurType->description
-#. 6.0->settings-schema.json->notification-blurType->description
 #. 6.0->settings-schema.json->appswitcher-blurType->description
-#. 6.0->settings-schema.json->tooltips-blurType->description
 #. 6.0->settings-schema.json->desklets-blurType->description
 msgid "Type of blur effect"
 msgstr "Type van het vervagingseffect"
@@ -750,12 +759,8 @@ msgstr "Type van het vervagingseffect"
 #. 6.0->settings-schema.json->blurType->tooltip
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
-#. 6.0->settings-schema.json->panels-blurType->tooltip
-#. 6.0->settings-schema.json->popup-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->notification-blurType->tooltip
 #. 6.0->settings-schema.json->appswitcher-blurType->tooltip
-#. 6.0->settings-schema.json->tooltips-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Welk type algoritme wordt gebruikt om de achtergrond te vervagen."
@@ -817,6 +822,51 @@ msgid ""
 "Adjusts the color saturation of the background image from gray-scale to full "
 "color."
 msgstr "Past de kleurverzadiging van de achtergrondafbeelding aan."
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Transparent"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#, fuzzy
+msgid "Transparent to Background"
+msgstr "Bureaubladachtergrond"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Simple static blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#, fuzzy
+msgid "Gaussian static blur"
+msgstr "Gaussiaanse vervagingsintensiteit"
+
+#. 6.0->settings-schema.json->panels-blurType->description
+#. 6.0->settings-schema.json->popup-blurType->description
+#. 6.0->settings-schema.json->notification-blurType->description
+#. 6.0->settings-schema.json->tooltips-blurType->description
+#, fuzzy
+msgid "Type of background effect"
+msgstr "Type van het vervagingseffect"
+
+#. 6.0->settings-schema.json->panels-blurType->tooltip
+#. 6.0->settings-schema.json->popup-blurType->tooltip
+#. 6.0->settings-schema.json->notification-blurType->tooltip
+#. 6.0->settings-schema.json->tooltips-blurType->tooltip
+msgid "What type of background effect should be applied"
+msgstr ""
 
 #. 6.0->settings-schema.json->popup-applet-menu-effects->description
 msgid "Apply effects to applet popup menus"
@@ -926,11 +976,10 @@ msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->tooltip
 msgid ""
-"Defines a list of application windows where background effect will be "
-"applied and what effects will apply. When \"Custom\" is enabled the setting "
-"defined by this table will apply, otherwise the \"Generic effect settings\" "
-"will apply for the specific application. The \"Application\" field can be a "
-"WM_CLASS or a desktop file name."
+"This table controls which application windows will have effects applied and "
+"the effect settings. When \"Custom\" is enabled the setting defined by this "
+"table will apply, otherwise the \"Generic effect settings\" will apply. The "
+"\"Application\" field can be a WM_CLASS or a desktop file name."
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-add-button->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/vi.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/vi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.5.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-12 10:26-0500\n"
+"POT-Creation-Date: 2026-01-25 17:05-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: loccun <huynhloc.contact@gmail.com>\n"
 "Language-Team: \n"
@@ -18,22 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1853
+#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
+#. 6.0/extension.js:1763
+#, fuzzy
+msgid "Default window settings"
+msgstr "Mở cài đặt Alt-Tab Cinnamon"
+
+#. 6.0/extension.js:1868
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1854
+#. 6.0/extension.js:1869
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2589
+#. 6.0/extension.js:2613
 msgid "Welcome to Blur Cinnamon"
 msgstr "Chào mừng đến với Blur Cinnamon"
 
-#. 6.0/extension.js:2590
+#. 6.0/extension.js:2614
 #, fuzzy
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
@@ -53,15 +59,15 @@ msgstr ""
 "phần được bật theo mặc định. Bạn cũng có thể thay đổi các thuộc tính hiệu "
 "ứng như cường độ làm mờ, độ bão hòa màu và làm tối."
 
-#. 6.0/extension.js:2594
+#. 6.0/extension.js:2618
 msgid "Open Blur Cinnamon Settings"
 msgstr "Mở Cài đặt Blur Cinnamon"
 
-#. 6.0/extension.js:2676
+#. 6.0/extension.js:2700
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Đang thử nghiệm Hiệu ứng Thông báo Blur Cinnamon"
 
-#. 6.0/extension.js:2677
+#. 6.0/extension.js:2701
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -208,6 +214,21 @@ msgid ""
 "below the Desklet. Most Desklets can be configured to have transparent "
 "backgrounds. On the Desktop, right-click on a Desklet, select the "
 "\"Configure...\" menu item to open a Desklet's configuration window."
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->description
+msgid ""
+"<b>Note:</b> Read tooltip for information about the \"Default window "
+"settings\""
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-label->tooltip
+msgid ""
+"If the special \"Default window settings\" table entry is enabled then all "
+"windows will have effects applied. If it is disabled then only the "
+"applications defined in the table will have effects applied. If the "
+"\"Enabled\" option is unchecked for a particular application then effects "
+"will be disabled even if the \"Default window settings\" row is enabled."
 msgstr ""
 
 #. 6.0->settings-schema.json->component-selector->options
@@ -402,12 +423,13 @@ msgstr "Thông báo bật lên (Vui lòng đọc chú giải công cụ)"
 
 #. 6.0->settings-schema.json->enable-window-effects->tooltip
 msgid ""
-"Apply effects to application window backgrounds by adding an effect actor "
-"below all existing graphical elements of affected windows. This means the "
-"effects will NOT be visible unless the application is setup to be "
-"transparent or the \"Opacity\" setting for the window is less than 100%. The "
-"application inclusion list under \"Windows\" settings is used to determine "
-"which (if any) applications will have effects applied to its windows."
+"Allow application window background effects by adding an effect actor below "
+"all existing graphical elements of affected windows. This means the effects "
+"will NOT be visible unless the application is setup to be transparent or the "
+"\"Opacity\" setting for the window is less than 100%. The table under the "
+"\"Windows\" component settings is used to determine which applications (if "
+"any) will have effects applied to its windows, enabling this option alone "
+"will not add effects to any windows."
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-desklet-effects->tooltip
@@ -587,6 +609,10 @@ msgstr "Cường độ"
 msgid "Saturation"
 msgstr "Độ bão hòa"
 
+#. 6.0->settings-schema.json->panel-unique-settings->columns->title
+msgid "Custom CSS"
+msgstr ""
+
 #. 6.0->settings-schema.json->panel-unique-settings->tooltip
 #, fuzzy
 msgid ""
@@ -670,12 +696,8 @@ msgstr ""
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "None"
 msgstr "Không"
@@ -683,12 +705,8 @@ msgstr "Không"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Đơn giản"
@@ -696,12 +714,8 @@ msgstr "Đơn giản"
 #. 6.0->settings-schema.json->blurType->options
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
-#. 6.0->settings-schema.json->panels-blurType->options
-#. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->notification-blurType->options
 #. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->tooltips-blurType->options
 #. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gaussian"
@@ -709,12 +723,8 @@ msgstr "Gaussian"
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
-#. 6.0->settings-schema.json->panels-blurType->description
-#. 6.0->settings-schema.json->popup-blurType->description
 #. 6.0->settings-schema.json->desktop-blurType->description
-#. 6.0->settings-schema.json->notification-blurType->description
 #. 6.0->settings-schema.json->appswitcher-blurType->description
-#. 6.0->settings-schema.json->tooltips-blurType->description
 #. 6.0->settings-schema.json->desklets-blurType->description
 msgid "Type of blur effect"
 msgstr "Loại hiệu ứng làm mờ"
@@ -722,12 +732,8 @@ msgstr "Loại hiệu ứng làm mờ"
 #. 6.0->settings-schema.json->blurType->tooltip
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
-#. 6.0->settings-schema.json->panels-blurType->tooltip
-#. 6.0->settings-schema.json->popup-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->notification-blurType->tooltip
 #. 6.0->settings-schema.json->appswitcher-blurType->tooltip
-#. 6.0->settings-schema.json->tooltips-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Loại thuật toán làm mờ nào nên được sử dụng để làm mờ nền"
@@ -789,6 +795,51 @@ msgid ""
 "Adjusts the color saturation of the background image from gray-scale to full "
 "color."
 msgstr "Điều chỉnh độ bão hòa màu của hình nền."
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Transparent"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#, fuzzy
+msgid "Transparent to Background"
+msgstr "Nền màn hình"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+msgid "Simple static blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#, fuzzy
+msgid "Gaussian static blur"
+msgstr "Cường độ làm mờ Gaussian"
+
+#. 6.0->settings-schema.json->panels-blurType->description
+#. 6.0->settings-schema.json->popup-blurType->description
+#. 6.0->settings-schema.json->notification-blurType->description
+#. 6.0->settings-schema.json->tooltips-blurType->description
+#, fuzzy
+msgid "Type of background effect"
+msgstr "Loại hiệu ứng làm mờ"
+
+#. 6.0->settings-schema.json->panels-blurType->tooltip
+#. 6.0->settings-schema.json->popup-blurType->tooltip
+#. 6.0->settings-schema.json->notification-blurType->tooltip
+#. 6.0->settings-schema.json->tooltips-blurType->tooltip
+msgid "What type of background effect should be applied"
+msgstr ""
 
 #. 6.0->settings-schema.json->popup-applet-menu-effects->description
 msgid "Apply effects to applet popup menus"
@@ -897,11 +948,10 @@ msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->tooltip
 msgid ""
-"Defines a list of application windows where background effect will be "
-"applied and what effects will apply. When \"Custom\" is enabled the setting "
-"defined by this table will apply, otherwise the \"Generic effect settings\" "
-"will apply for the specific application. The \"Application\" field can be a "
-"WM_CLASS or a desktop file name."
+"This table controls which application windows will have effects applied and "
+"the effect settings. When \"Custom\" is enabled the setting defined by this "
+"table will apply, otherwise the \"Generic effect settings\" will apply. The "
+"\"Application\" field can be a WM_CLASS or a desktop file name."
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-add-button->description


### PR DESCRIPTION
- Added a "Transparent" option to Panels/Menus/Tooltips/Notifications setting. This will provide a true transparent option where whatever is below the effected element will be visible (no blurring, not saturation). For panels this is no different to the Transparent Panels extension.
- Added a "Default window settings" row to the Windows effect table. When this row is enabled, all windows will have effects applied, except application windows that match some other row in the table, in which case that rows settings will apply (a disabled row will cause the window to have no effects applied despite the "Default window settings" row being enabled).
- Added code to improve the Cinnamon 6.6 Menu effects (sidebar transparency).
- Added code to improve the Cinnamon 6.6 "Cinnamon" theme support (might also help with other themes that use CSS padding).
- Added a "Custom CSS" option to the "Advanced" panel setting table. Using this option, users who know CSS can apply options to control the panels like shrinking the panel to be less then the screen width, adding rounded corners, adding borders, etc.
- Another attempt to improve the performance of opening menus after the 1st time any particular menu is opened.
- Fixed some blurring artifacts seen when restoring a minimized window while using the "Focused window backlight effect".