### PR TITLE
[BlurCinnamon@klangman] Version 1.7.2

### DIFF
--- a/BlurCinnamon@klangman/CHANGELOG.md
+++ b/BlurCinnamon@klangman/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.7.2
+
+* Added a panel settings option to "Brighten" (dim=0 and saturation=100) a panel when the mouse is hovering over a panel (disabled by default)
+* Fixed an issue where the 6.6 Menu sidebar was not maintaining its transparency after changing the "Maximum sidebar width" menu option.
+* Fixed an issue with the standard cinnamon minimize animation when a window has a blurred background applied.
+
 ## 1.7.1
 
 * Added a "Transparent" option to Panels/Menus/Tooltips/Notifications setting. This will provide a true transparent option where whatever is below the effected element will be visible (no blurring, not saturation). For panels this is no different to the Transparent Panels extension.

--- a/BlurCinnamon@klangman/README.md
+++ b/BlurCinnamon@klangman/README.md
@@ -19,6 +19,8 @@ Cinnamon components you can apply effects to (currently):
 
 Blurring can also be disabled if you just want a transparent or semi-transparent effect without blurring for Panels, Applet popup menu or the Expo.
 
+A traditional transparent effect (where you can seen more than just the desktop background) is possible for Panels/Menus/Notifications/Toolips but no saturation or blurring effects are possible in this mode. You must enable the  "Use unique effect settings" option and then change the "Type of background effect" to "Transparent".
+
 ## Features
 
 - Gaussian blur algorithm (borrowed from the Gnome extension Blur-my-Shell) with a user configurable intensity
@@ -44,15 +46,14 @@ If you have installed any of the following Cinnamon extensions, you should **dis
 
 Using any of the above with Blur Cinnamon may have some odd side effects that would require a Cinnamon restart to resolve.
 
-Cinnamon 6.6:  There are a few issues I need to work on for 22.3 (Cinnamon 6.6). The new menu should have the left panel changed to be transparant and the Cinnamon theme uses margins that cause Blur Cinnamon menu effects to spill over the popup's borders. I'll work on this for version 1.7.1
-
 ## Limitations
 
 1. The Applet popup menu effects are intended to be used with the Cinnamon (6.4) theme or the Mint-Y dark desktop themes. The effects might work will with some other themes but I have not tested them so the effects might not work out just right. You can try the Mint-Y light themes but it might be hard to read the menu items without some playing around with the settings and the background image. Blur Cinnamon Popup-menu effects are disabled by default.
-2. The Applet popup-menu effects works for all the applets that I have tested except "Cinnamenu". Cinnamenu is preventing other code from receiving the "open-state-changed" event which BlurCinnamon uses to know when to apply popup-menu theme setting and when to resize and show the blur background element. This issue is fixed in the latest Cinnamenu from [Fredcw GitHub](https://github.com/fredcw/Cinnamenu) but you will need to manually fix the current Cinnamon Spices version of Cinnamenu (see [here](https://github.com/linuxmint/cinnamon-spices-extensions/issues/873))
-3. Currently, any windows that are positioned such that they overlap with a panel or an popup-menu will not be visible beneath blurred panel/popup-menu as you might expect with a transparent panel/menu. This is because the blur effect is applied to a user interface element that floats above all windows just like the panel floats above the windows. At some point I hope to look into allowing the blur element to appear below all windows rather than above and make the a optional behavior setting.
-4. If you disable effects for any Cinnamon component under the General tab of the setting dialog while any "Use unique effect settings" options are enabled under the other tabs, the components "effect setting" options under the other tabs will still be visible, but changing those setting will have no effect until you re-enable the component under the General tab. Ideally those effect setting would only be visible when the component is enabled under the general tab but Cinnamon setting support is a bit limited in this way.
-5. This extension currently does not work under Wayland, it only works under X11. The extension automatically detects Wayland and disables most of the features of the extension.
+2. The Applet popup-menu effects works for all the applets that I have tested except "Cinnamenu". Cinnamenu is preventing other code from receiving the "open-state-changed" event which Blur Cinnamon uses to know when to apply popup-menu theme setting and when to resize and show the blur background element. This issue is fixed in the latest Cinnamenu from [Fredcw GitHub](https://github.com/fredcw/Cinnamenu) but you will need to manually fix the current Cinnamon Spices version of Cinnamenu (see [here](https://github.com/linuxmint/cinnamon-spices-extensions/issues/873))
+3. Currently Blur Cinnamon uses "Static Blurring", meaning only a blurred copy of the desktop background image is visible below effected components (i.e Panels, Menus, Tooltips and Windows). I am looking for a way to implement "Dynamic Blurring" but so far I have not been successful.
+4. This extension currently does not work under Wayland, it only works under X11. The extension automatically detects Wayland and disables most of the features of the extension.
+
+
 
 ## Installation
 
@@ -63,20 +64,30 @@ Cinnamon 6.6:  There are a few issues I need to work on for 22.3 (Cinnamon 6.6).
 - Select the new "Blur Cinnamon" entry and then click the "+" button at the bottom of the window
 - Use the "gears" icon next to the "Blur Cinnamon" entry to open the setting window and setup the preferred behavior
 
-
-
 ## Custom Panel CSS Examples:
 
 The following examples of CSS code can be applied to panels to achieve a custom panel effect.
 
-| Effect                          | Custom CSS string                               |
-| ------------------------------- | ----------------------------------------------- |
-| Grey Borders                    | border-width: 1px; border-color: rgb(70,70,70); |
-| Shrink a horizontal panel width | margin-left: 100px; margin-right: 100px;        |
-| Shrink a vertical panel height  | margin-top: 100px; margin-bottom: 100px;        |
-| Rounded the corners of a panel  | border-radius: 20px;                            |
+| Effect                          | Custom CSS string                                |
+| ------------------------------- | ------------------------------------------------ |
+| Grey borders (all around)       | border-width: 1px; border-color: rgb(70,70,70);  |
+| Gray top only border            | border-top: 1px; border-color: rgb(70,70,70);    |
+| Grey bottom only border         | border-bottom: 1px; border-color: rgb(70,70,70); |
+| Shrink a horizontal panel width | margin-left: 100px; margin-right: 100px;         |
+| Shrink a vertical panel height  | margin-top: 100px; margin-bottom: 100px;         |
+| Rounded the corners of a panel  | border-radius: 20px;                             |
+| Padding for horizontal panels   | padding-left: 10px; padding-right: 10px;         |
+| Padding for vertical panels     | padding-top: 10px; padding-bottom: 10px;         |
 
-You can combine and modify the above as desired and add the result to the "Custom CSS" entry under the Panels settings. The "Enable advanced options to apply unique settings for each panel" option needs to be enabled see the panels table. Edit/add the appropriate table entry for the panel you wish to effect to modify the "Custom CSS" entry. Typos and syntax errors will typically result in the panel effects reverting to default, but other issue could result. You can always undue your effects by deleting the contents of the "Custom CSS" field in the table.
+You can combine and modify the above as desired and add the result to the "Custom CSS" entry within the panels table under the Panels settings. The "Use unique effect settings for the Panels" and the "Enable advanced options to apply unique settings for each panel" options must to be enabled see the panels table. Edit/add the appropriate table entry for the panel you wish to effect then modify the "Custom CSS" entry. Typos and syntax errors will typically result in the panel effects reverting to default, but other issue could result. You can always undue your effects by deleting the contents of the "Custom CSS" field in the table. Not all CSS options will work, it's limited to the CSS that is supported by Cinnamon and further limited by hard-coded settings used by the Cinnamon panels code.
+
+Here is the CSS setting I use on my bottom panel to get a centered panel with rounded corners and a grey border:
+
+```
+padding-left: 10px; padding-right: 10px; border-radius: 20px; border-width: 1px; border-color: rgb(40,40,40); margin-left: 200px; margin-right: 200px;
+```
+
+The border radius rounds the corners, the padding adds space on each end of the panel to accommodate the rounded corners better, and the margins shrink the panel so that it does not fill the width of the screen resulting in a centered panel. 
 
 ## Feedback
 

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/settings-schema.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/settings-schema.json
@@ -47,7 +47,7 @@
          "title" : "Component Specific Settings",
          "keys" : [ "overview-warning", "enable-overview-override",  "overview-opacity", "overview-blendColor", "overview-blurType", "overview-radius", "overview-saturation",
                     "expo-warning", "enable-expo-override", "expo-opacity", "expo-blendColor", "expo-blurType", "expo-radius", "expo-saturation",
-                    "panel-warning", "enable-panels-override", "allow-transparent-color-panels", "no-panel-effects-maximized", "enable-panel-unique-settings", "panels-opacity", "panels-blendColor", "panels-blurType", "panels-radius", "panels-saturation", "panel-unique-settings",
+                    "panel-warning", "enable-panels-override", "allow-transparent-color-panels", "no-panel-effects-maximized", "hover-brighten-panels", "enable-panel-unique-settings", "panels-opacity", "panels-blendColor", "panels-blurType", "panels-radius", "panels-saturation", "panel-unique-settings",
                     "popup-warning", "enable-popup-override", "popup-applet-menu-effects", "popup-panel-menu-effects", "popup-title-menu-effects", "allow-transparent-color-popup", "popup-opacity", "popup-accent-opacity", "popup-blendColor", "popup-blurType", "popup-radius", "popup-saturation",
                     "desktop-warning", "enable-desktop-override", "desktop-without-focus", "desktop-with-focus", "desktop-opacity", "desktop-blendColor", "desktop-blurType", "desktop-radius", "desktop-saturation",
                     "notification-warning", "enable-notification-override", "notification-opacity", "notification-blendColor", "notification-blurType", "notification-radius", "notification-saturation", "notification-test-button",
@@ -362,6 +362,14 @@
         "description": "Restore theme settings when a window is maximized",
         "dependency" : "enable-panels-effects & component-selector=7",
         "tooltip": "Restore the themes panel settings when any window is maximized on the same monitor as the panel. For most themes this will restore a solid panel background when a window is maximized. Note: This does not remove the blurring, so if your theme uses a transparent panel then this setting may have no effect.",
+        "default": false
+    },
+
+    "hover-brighten-panels" : {
+        "type": "switch",
+        "description": "Brighten panel when mouse is hovering a panel",
+        "dependency" : "enable-panels-effects & component-selector=7",
+        "tooltip": "While the mouse is hovering over a panel, set the panels dimming to 0 and the saturation to 100 so that the panel appears brighter. This setting is only effective when either dimming is greater than 0 or saturation is less than 100.",
         "default": false
     },
 

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
@@ -1,7 +1,7 @@
 {
     "uuid": "BlurCinnamon@klangman",
     "name": "Blur Cinnamon",
-    "version": "1.7.1",
+    "version": "1.7.2",
     "description": "Allows you to blur, colorize, desaturate and adjust the dimming of several Cinnamon Desktop components",
     "url": "https://github.com/klangman/BlurCinnamon",
     "cinnamon-version": [

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: BlurCinnamon@klangman 1.7.1\n"
+"Project-Id-Version: BlurCinnamon@klangman 1.7.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-25 17:05-0500\n"
+"POT-Creation-Date: 2026-02-05 19:13-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,27 +17,27 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
-#. 6.0/extension.js:1763
+#. 6.0/extension.js:1710 6.0/extension.js:1713 6.0/extension.js:1765
+#. 6.0/extension.js:1829
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:1868
+#. 6.0/extension.js:1942
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1869
+#. 6.0/extension.js:1943
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2613
+#. 6.0/extension.js:2688
 msgid "Welcome to Blur Cinnamon"
 msgstr ""
 
-#. 6.0/extension.js:2614
+#. 6.0/extension.js:2689
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -49,15 +49,15 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:2618
+#. 6.0/extension.js:2693
 msgid "Open Blur Cinnamon Settings"
 msgstr ""
 
-#. 6.0/extension.js:2700
+#. 6.0/extension.js:2775
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:2701
+#. 6.0/extension.js:2776
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -549,6 +549,18 @@ msgid ""
 "background when a window is maximized. Note: This does not remove the "
 "blurring, so if your theme uses a transparent panel then this setting may "
 "have no effect."
+msgstr ""
+
+#. 6.0->settings-schema.json->hover-brighten-panels->description
+msgid "Brighten panel when mouse is hovering a panel"
+msgstr ""
+
+#. 6.0->settings-schema.json->hover-brighten-panels->tooltip
+msgid ""
+"While the mouse is hovering over a panel, set the panels dimming to 0 and "
+"the saturation to 100 so that the panel appears brighter. This setting is "
+"only effective when either dimming is greater than 0 or saturation is less "
+"than 100."
 msgstr ""
 
 #. 6.0->settings-schema.json->opacity->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-25 17:05-0500\n"
+"POT-Creation-Date: 2026-02-05 19:13-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.6\n"
 
-#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
-#. 6.0/extension.js:1763
+#. 6.0/extension.js:1710 6.0/extension.js:1713 6.0/extension.js:1765
+#. 6.0/extension.js:1829
 #, fuzzy
 msgid "Default window settings"
 msgstr "Obrir la configuració d'Alt-Tab de Cinnamon"
 
-#. 6.0/extension.js:1868
+#. 6.0/extension.js:1942
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1869
+#. 6.0/extension.js:1943
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2613
+#. 6.0/extension.js:2688
 msgid "Welcome to Blur Cinnamon"
 msgstr "Benvingut al Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:2614
+#. 6.0/extension.js:2689
 #, fuzzy
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
@@ -60,15 +60,15 @@ msgstr ""
 "per defecte. També podeu realitzar canvis a les propietats dels efectes, com "
 "ara la intensitat del desenfoc, la saturació del color i l'enfoscament."
 
-#. 6.0/extension.js:2618
+#. 6.0/extension.js:2693
 msgid "Open Blur Cinnamon Settings"
 msgstr "Obre la configuració del Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:2700
+#. 6.0/extension.js:2775
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Provant els efectes del Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:2701
+#. 6.0/extension.js:2776
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -669,6 +669,18 @@ msgstr ""
 "això restaurarà un color de fons del tauler sòlid en maximitzar una "
 "finestra. Nota: no elimina el desenfoc, motiu pel qual si utilitzeu un "
 "tauler transparent aquesta opció pot no fer efecte."
+
+#. 6.0->settings-schema.json->hover-brighten-panels->description
+msgid "Brighten panel when mouse is hovering a panel"
+msgstr ""
+
+#. 6.0->settings-schema.json->hover-brighten-panels->tooltip
+msgid ""
+"While the mouse is hovering over a panel, set the panels dimming to 0 and "
+"the saturation to 100 so that the panel appears brighter. This setting is "
+"only effective when either dimming is greater than 0 or saturation is less "
+"than 100."
+msgstr ""
 
 #. 6.0->settings-schema.json->opacity->description
 #. 6.0->settings-schema.json->overview-opacity->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/da.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.5.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-25 17:05-0500\n"
+"POT-Creation-Date: 2026-02-05 19:13-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
-#. 6.0/extension.js:1763
+#. 6.0/extension.js:1710 6.0/extension.js:1713 6.0/extension.js:1765
+#. 6.0/extension.js:1829
 #, fuzzy
 msgid "Default window settings"
 msgstr "Åbn Alt-Tab-indstillinger i Cinnamon"
 
-#. 6.0/extension.js:1868
+#. 6.0/extension.js:1942
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1869
+#. 6.0/extension.js:1943
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2613
+#. 6.0/extension.js:2688
 msgid "Welcome to Blur Cinnamon"
 msgstr "Velkommen til Sløret Cinnamon"
 
-#. 6.0/extension.js:2614
+#. 6.0/extension.js:2689
 #, fuzzy
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
@@ -60,15 +60,15 @@ msgstr ""
 "også foretage ændringer i effektens egenskaber, såsom sløringens intensitet, "
 "farvemætning og dæmpning."
 
-#. 6.0/extension.js:2618
+#. 6.0/extension.js:2693
 msgid "Open Blur Cinnamon Settings"
 msgstr "Åbn Sløret Cinnamon-indstillinger"
 
-#. 6.0/extension.js:2700
+#. 6.0/extension.js:2775
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Tester Sløret Cinnamons underretningseffekter"
 
-#. 6.0/extension.js:2701
+#. 6.0/extension.js:2776
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -671,6 +671,18 @@ msgstr ""
 "panelbaggrund, når et vindue maksimeres. Bemærk: Dette fjerner ikke "
 "sløringen, så hvis dit tema bruger et gennemsigtigt panel, har denne "
 "indstilling muligvis ingen effekt."
+
+#. 6.0->settings-schema.json->hover-brighten-panels->description
+msgid "Brighten panel when mouse is hovering a panel"
+msgstr ""
+
+#. 6.0->settings-schema.json->hover-brighten-panels->tooltip
+msgid ""
+"While the mouse is hovering over a panel, set the panels dimming to 0 and "
+"the saturation to 100 so that the panel appears brighter. This setting is "
+"only effective when either dimming is greater than 0 or saturation is less "
+"than 100."
+msgstr ""
 
 #. 6.0->settings-schema.json->opacity->description
 #. 6.0->settings-schema.json->overview-opacity->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-25 17:05-0500\n"
+"POT-Creation-Date: 2026-02-05 19:13-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,16 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.8\n"
 
-#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
-#. 6.0/extension.js:1763
+#. 6.0/extension.js:1710 6.0/extension.js:1713 6.0/extension.js:1765
+#. 6.0/extension.js:1829
 msgid "Default window settings"
 msgstr "Configuración predeterminada de la ventana"
 
-#. 6.0/extension.js:1868
+#. 6.0/extension.js:1942
 msgid "Error"
 msgstr "Error"
 
-#. 6.0/extension.js:1869
+#. 6.0/extension.js:1943
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
@@ -36,11 +36,11 @@ msgstr ""
 "tenía el foco anteriormente, por lo que no se pueden aplicar los efectos de "
 "Desenfoque Cinnamon a esa ventana"
 
-#. 6.0/extension.js:2613
+#. 6.0/extension.js:2688
 msgid "Welcome to Blur Cinnamon"
 msgstr "Bienvenido a Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:2614
+#. 6.0/extension.js:2689
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -60,15 +60,15 @@ msgstr ""
 "También puedes realizar cambios en las propiedades de los efectos, como la "
 "intensidad del desenfoque, la saturación del color y el oscurecimiento."
 
-#. 6.0/extension.js:2618
+#. 6.0/extension.js:2693
 msgid "Open Blur Cinnamon Settings"
 msgstr "Abrir configuración de Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:2700
+#. 6.0/extension.js:2775
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Probando los efectos de notificación de Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:2701
+#. 6.0/extension.js:2776
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -711,6 +711,18 @@ msgstr ""
 "restaurará un fondo sólido del panel cuando se maximiza una ventana. Nota: "
 "Esto no elimina el desenfoque, por lo que si su tema utiliza un panel "
 "transparente, es posible que esta configuración no tenga ningún efecto."
+
+#. 6.0->settings-schema.json->hover-brighten-panels->description
+msgid "Brighten panel when mouse is hovering a panel"
+msgstr ""
+
+#. 6.0->settings-schema.json->hover-brighten-panels->tooltip
+msgid ""
+"While the mouse is hovering over a panel, set the panels dimming to 0 and "
+"the saturation to 100 so that the panel appears brighter. This setting is "
+"only effective when either dimming is greater than 0 or saturation is less "
+"than 100."
+msgstr ""
 
 #. 6.0->settings-schema.json->opacity->description
 #. 6.0->settings-schema.json->overview-opacity->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fi.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-25 17:05-0500\n"
+"POT-Creation-Date: 2026-02-05 19:13-0500\n"
 "PO-Revision-Date: 2025-03-30 10:53+0300\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
-#. 6.0/extension.js:1763
+#. 6.0/extension.js:1710 6.0/extension.js:1713 6.0/extension.js:1765
+#. 6.0/extension.js:1829
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:1868
+#. 6.0/extension.js:1942
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1869
+#. 6.0/extension.js:1943
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2613
+#. 6.0/extension.js:2688
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Blur Cinnamon"
 
-#. 6.0/extension.js:2614
+#. 6.0/extension.js:2689
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -51,16 +51,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:2618
+#. 6.0/extension.js:2693
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Blur Cinnamon"
 
-#. 6.0/extension.js:2700
+#. 6.0/extension.js:2775
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:2701
+#. 6.0/extension.js:2776
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -647,6 +647,18 @@ msgid ""
 "background when a window is maximized. Note: This does not remove the "
 "blurring, so if your theme uses a transparent panel then this setting may "
 "have no effect."
+msgstr ""
+
+#. 6.0->settings-schema.json->hover-brighten-panels->description
+msgid "Brighten panel when mouse is hovering a panel"
+msgstr ""
+
+#. 6.0->settings-schema.json->hover-brighten-panels->tooltip
+msgid ""
+"While the mouse is hovering over a panel, set the panels dimming to 0 and "
+"the saturation to 100 so that the panel appears brighter. This setting is "
+"only effective when either dimming is greater than 0 or saturation is less "
+"than 100."
 msgstr ""
 
 #. 6.0->settings-schema.json->opacity->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-25 17:05-0500\n"
+"POT-Creation-Date: 2026-02-05 19:13-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
-#. 6.0/extension.js:1763
+#. 6.0/extension.js:1710 6.0/extension.js:1713 6.0/extension.js:1765
+#. 6.0/extension.js:1829
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:1868
+#. 6.0/extension.js:1942
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1869
+#. 6.0/extension.js:1943
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2613
+#. 6.0/extension.js:2688
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Flou pour Cinnamon"
 
-#. 6.0/extension.js:2614
+#. 6.0/extension.js:2689
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -51,16 +51,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:2618
+#. 6.0/extension.js:2693
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Flou pour Cinnamon"
 
-#. 6.0/extension.js:2700
+#. 6.0/extension.js:2775
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:2701
+#. 6.0/extension.js:2776
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -677,6 +677,18 @@ msgid ""
 "background when a window is maximized. Note: This does not remove the "
 "blurring, so if your theme uses a transparent panel then this setting may "
 "have no effect."
+msgstr ""
+
+#. 6.0->settings-schema.json->hover-brighten-panels->description
+msgid "Brighten panel when mouse is hovering a panel"
+msgstr ""
+
+#. 6.0->settings-schema.json->hover-brighten-panels->tooltip
+msgid ""
+"While the mouse is hovering over a panel, set the panels dimming to 0 and "
+"the saturation to 100 so that the panel appears brighter. This setting is "
+"only effective when either dimming is greater than 0 or saturation is less "
+"than 100."
 msgstr ""
 
 #. 6.0->settings-schema.json->opacity->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/hu.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-25 17:05-0500\n"
+"POT-Creation-Date: 2026-02-05 19:13-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,17 +18,17 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.8\n"
 
-#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
-#. 6.0/extension.js:1763
+#. 6.0/extension.js:1710 6.0/extension.js:1713 6.0/extension.js:1765
+#. 6.0/extension.js:1829
 #, fuzzy
 msgid "Default window settings"
 msgstr "Nyissa meg az Alt-Tab Cinnamon beállításokat"
 
-#. 6.0/extension.js:1868
+#. 6.0/extension.js:1942
 msgid "Error"
 msgstr "Hiba"
 
-#. 6.0/extension.js:1869
+#. 6.0/extension.js:1943
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
@@ -38,11 +38,11 @@ msgstr ""
 "WM_CLASS osztályát, ezért a Cinnamon Elhomályosítása effektek nem "
 "alkalmazhatók erre az ablakra"
 
-#. 6.0/extension.js:2613
+#. 6.0/extension.js:2688
 msgid "Welcome to Blur Cinnamon"
 msgstr "Üdvözöljük a Cinnamon Elhomályosításában"
 
-#. 6.0/extension.js:2614
+#. 6.0/extension.js:2689
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -62,15 +62,15 @@ msgstr ""
 "Módosíthatod az effektek tulajdonságait is, például az elmosás intenzitását, "
 "a színtelítettséget és a fényerőt."
 
-#. 6.0/extension.js:2618
+#. 6.0/extension.js:2693
 msgid "Open Blur Cinnamon Settings"
 msgstr "Nyissa meg a Cinnamon Elhomályosítása beállításait"
 
-#. 6.0/extension.js:2700
+#. 6.0/extension.js:2775
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Cinnamon Elhomályosítása értesítési effektek tesztelése"
 
-#. 6.0/extension.js:2701
+#. 6.0/extension.js:2776
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -679,6 +679,18 @@ msgstr ""
 "visszaállítja a panel hátterének egyszínűségét, amikor az ablak "
 "maximalizált. Megjegyzés: Ez nem szünteti meg az elmosódást, így ha a téma "
 "átlátszó panelt használ, akkor ennek a beállításnak lehet, hogy nincs hatása."
+
+#. 6.0->settings-schema.json->hover-brighten-panels->description
+msgid "Brighten panel when mouse is hovering a panel"
+msgstr ""
+
+#. 6.0->settings-schema.json->hover-brighten-panels->tooltip
+msgid ""
+"While the mouse is hovering over a panel, set the panels dimming to 0 and "
+"the saturation to 100 so that the panel appears brighter. This setting is "
+"only effective when either dimming is greater than 0 or saturation is less "
+"than 100."
+msgstr ""
 
 #. 6.0->settings-schema.json->opacity->description
 #. 6.0->settings-schema.json->overview-opacity->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/it.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-25 17:05-0500\n"
+"POT-Creation-Date: 2026-02-05 19:13-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
-#. 6.0/extension.js:1763
+#. 6.0/extension.js:1710 6.0/extension.js:1713 6.0/extension.js:1765
+#. 6.0/extension.js:1829
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:1868
+#. 6.0/extension.js:1942
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1869
+#. 6.0/extension.js:1943
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2613
+#. 6.0/extension.js:2688
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Sfoca Cinnamom"
 
-#. 6.0/extension.js:2614
+#. 6.0/extension.js:2689
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -51,16 +51,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:2618
+#. 6.0/extension.js:2693
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Sfoca Cinnamom"
 
-#. 6.0/extension.js:2700
+#. 6.0/extension.js:2775
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:2701
+#. 6.0/extension.js:2776
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -675,6 +675,18 @@ msgid ""
 "background when a window is maximized. Note: This does not remove the "
 "blurring, so if your theme uses a transparent panel then this setting may "
 "have no effect."
+msgstr ""
+
+#. 6.0->settings-schema.json->hover-brighten-panels->description
+msgid "Brighten panel when mouse is hovering a panel"
+msgstr ""
+
+#. 6.0->settings-schema.json->hover-brighten-panels->tooltip
+msgid ""
+"While the mouse is hovering over a panel, set the panels dimming to 0 and "
+"the saturation to 100 so that the panel appears brighter. This setting is "
+"only effective when either dimming is greater than 0 or saturation is less "
+"than 100."
 msgstr ""
 
 #. 6.0->settings-schema.json->opacity->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/nl.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-25 17:05-0500\n"
+"POT-Creation-Date: 2026-02-05 19:13-0500\n"
 "PO-Revision-Date: 2025-06-13 17:14+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
-#. 6.0/extension.js:1763
+#. 6.0/extension.js:1710 6.0/extension.js:1713 6.0/extension.js:1765
+#. 6.0/extension.js:1829
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:1868
+#. 6.0/extension.js:1942
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1869
+#. 6.0/extension.js:1943
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2613
+#. 6.0/extension.js:2688
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Vervaag Cinnamon"
 
-#. 6.0/extension.js:2614
+#. 6.0/extension.js:2689
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -49,16 +49,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:2618
+#. 6.0/extension.js:2693
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Vervaag Cinnamon"
 
-#. 6.0/extension.js:2700
+#. 6.0/extension.js:2775
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:2701
+#. 6.0/extension.js:2776
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -674,6 +674,18 @@ msgid ""
 "background when a window is maximized. Note: This does not remove the "
 "blurring, so if your theme uses a transparent panel then this setting may "
 "have no effect."
+msgstr ""
+
+#. 6.0->settings-schema.json->hover-brighten-panels->description
+msgid "Brighten panel when mouse is hovering a panel"
+msgstr ""
+
+#. 6.0->settings-schema.json->hover-brighten-panels->tooltip
+msgid ""
+"While the mouse is hovering over a panel, set the panels dimming to 0 and "
+"the saturation to 100 so that the panel appears brighter. This setting is "
+"only effective when either dimming is greater than 0 or saturation is less "
+"than 100."
 msgstr ""
 
 #. 6.0->settings-schema.json->opacity->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/vi.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/vi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.5.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-01-25 17:05-0500\n"
+"POT-Creation-Date: 2026-02-05 19:13-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: loccun <huynhloc.contact@gmail.com>\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:1645 6.0/extension.js:1648 6.0/extension.js:1699
-#. 6.0/extension.js:1763
+#. 6.0/extension.js:1710 6.0/extension.js:1713 6.0/extension.js:1765
+#. 6.0/extension.js:1829
 #, fuzzy
 msgid "Default window settings"
 msgstr "Mở cài đặt Alt-Tab Cinnamon"
 
-#. 6.0/extension.js:1868
+#. 6.0/extension.js:1942
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:1869
+#. 6.0/extension.js:1943
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:2613
+#. 6.0/extension.js:2688
 msgid "Welcome to Blur Cinnamon"
 msgstr "Chào mừng đến với Blur Cinnamon"
 
-#. 6.0/extension.js:2614
+#. 6.0/extension.js:2689
 #, fuzzy
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
@@ -59,15 +59,15 @@ msgstr ""
 "phần được bật theo mặc định. Bạn cũng có thể thay đổi các thuộc tính hiệu "
 "ứng như cường độ làm mờ, độ bão hòa màu và làm tối."
 
-#. 6.0/extension.js:2618
+#. 6.0/extension.js:2693
 msgid "Open Blur Cinnamon Settings"
 msgstr "Mở Cài đặt Blur Cinnamon"
 
-#. 6.0/extension.js:2700
+#. 6.0/extension.js:2775
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Đang thử nghiệm Hiệu ứng Thông báo Blur Cinnamon"
 
-#. 6.0/extension.js:2701
+#. 6.0/extension.js:2776
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -648,6 +648,18 @@ msgstr ""
 "panel đặc khi một cửa sổ được phóng to. Lưu ý: Điều này không loại bỏ việc "
 "làm mờ, vì vậy nếu chủ đề của bạn sử dụng panel trong suốt thì cài đặt này "
 "có thể không có tác dụng."
+
+#. 6.0->settings-schema.json->hover-brighten-panels->description
+msgid "Brighten panel when mouse is hovering a panel"
+msgstr ""
+
+#. 6.0->settings-schema.json->hover-brighten-panels->tooltip
+msgid ""
+"While the mouse is hovering over a panel, set the panels dimming to 0 and "
+"the saturation to 100 so that the panel appears brighter. This setting is "
+"only effective when either dimming is greater than 0 or saturation is less "
+"than 100."
+msgstr ""
 
 #. 6.0->settings-schema.json->opacity->description
 #. 6.0->settings-schema.json->overview-opacity->description


### PR DESCRIPTION
- Added a panel settings option to "Brighten" (dim=0 and saturation=100) a panel when the mouse is hovering over a panel (disabled by default)
- Fixed an issue where the 6.6 Menu sidebar was not maintaining its transparency after changing the "Maximum sidebar width" menu option.
- Fixed an issue with the standard cinnamon minimize animation when a window has a blurred background applied.