### PR TITLE
[BlurCinnamon@klangman] Version 2.0.1 - performance improvement & fixes

### DIFF
--- a/BlurCinnamon@klangman/CHANGELOG.md
+++ b/BlurCinnamon@klangman/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2.0.1
+
+* Fixed graphical issue with blurred windows after the window is moved off of a dynamically blurred component and the window had been minimized in the past.
+* Added a fix to remove dynamic blur window clones when in the "show desktop" state (i.e. when using the "Show Desktop" or "Corner Bar" applets). Thanks to [dearvalentina](https://github.com/dearvalentina) for reporting the issue.
+* Fixed a performance issue with Popup menus where the responsiveness of the menu would degrade over time with each open/close sequence of a particular menu. A bunch of people reported this, but [Pilzinsel64](https://github.com/Pilzinsel64) recreate method got me to the solution.
+* Fixed missing Desklet blur actors in desklets clones (Desklet cloning is used for Dynamic blurring in Blur Cinnamon as well as in the "Desktop Cube" and "Flipper" extensions workspace switcher animations).
+* Fixed missing Desklet blur actors when using the "Corner Bar" middle click "Show the desklets" feature.
+
 ## 2.0.0
 
 * Added a "Gaussian dynamic blur" option for Menus, Panels, Notifications and Tooltips. This allows the windows that are under the blurred component to be visible in the blurred element, resulting in an effect that allows the component to appear to float above the desktop wallpaper and windows rather then a static blur effect which shows just the desktop wallpaper under the component.

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/extension.js
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/extension.js
@@ -318,8 +318,8 @@ function destroyAllWindowsClones(background) {
 // metaWindowOwner is the window that owns the background and therefore
 // only windows with a z-order below that window should be included.
 // If metaWindowOwner is null, all overlapping windows will be cloned
-function cloneWindowsForBackground(background) {
-   let currentWs = global.screen.get_active_workspace_index();
+function cloneWindowsForBackground(background, showingDesktop) {
+   let currentWs = global.workspace_manager.get_active_workspace_index();
    let [blurX, blurY, blurWidth, blurHeight] = getBackgroundClip(background);
    if (blurWidth===0 || blurHeight===0 || !background.is_mapped()) {
       debugMsg( `Blurred background is zero size or unmapped` );
@@ -330,26 +330,28 @@ function cloneWindowsForBackground(background) {
    let windowsToClone = [];
    let metaWindowOwner = background._blurCinnamonMetaWindowOwner;
 
-   // Find all windows that are visible and overlap with the passed in background
-   let windows = global.get_window_actors();
-   windows.forEach( (window) => {
-      let metaWindow = window.get_meta_window();
-      if (metaWindow && metaWindow.get_workspace() &&
-         (!metaWindowOwner || metaWindow.get_window_type() === Meta.WindowType.DESKTOP || metaWindowOwner.get_user_time() > metaWindow.get_user_time()) &&
-         (metaWindow.get_workspace().index() === currentWs || metaWindow.is_on_all_workspaces()) &&
-         !metaWindow.minimized && metaWindow.get_window_type() !== Meta.WindowType.OVERRIDE_OTHER)
-      {
-         let compositor = metaWindow.get_compositor_private();
-         let winRect = metaWindow.get_buffer_rect();
-         let winX = winRect.x;
-         let winY = winRect.y;
-         let winX2 = winRect.x + winRect.width;
-         let winY2 = winRect.y + winRect.height;
-         if (rectOverlap(winX, winY, winX2, winY2, blurX, blurY, blurX2, blurY2)) {
-            windowsToClone.push(metaWindow);
+   if (!showingDesktop) {
+      // Find all windows that are visible and overlap with the passed in background
+      let windows = global.get_window_actors();
+      windows.forEach( (window) => {
+         let metaWindow = window.get_meta_window();
+         if (metaWindow && metaWindow.get_workspace() &&
+            (!metaWindowOwner || metaWindow.get_window_type() === Meta.WindowType.DESKTOP || metaWindowOwner.get_user_time() > metaWindow.get_user_time()) &&
+            (metaWindow.get_workspace().index() === currentWs || metaWindow.is_on_all_workspaces()) &&
+            !metaWindow.minimized && metaWindow.get_window_type() !== Meta.WindowType.OVERRIDE_OTHER)
+         {
+            let compositor = metaWindow.get_compositor_private();
+            let winRect = metaWindow.get_buffer_rect();
+            let winX = winRect.x;
+            let winY = winRect.y;
+            let winX2 = winRect.x + winRect.width;
+            let winY2 = winRect.y + winRect.height;
+            if (rectOverlap(winX, winY, winX2, winY2, blurX, blurY, blurX2, blurY2)) {
+               windowsToClone.push(metaWindow);
+            }
          }
-      }
-   });
+      });
+   }
 
    let clones = background._blurCinnamonWinClones;
 
@@ -371,12 +373,7 @@ function cloneWindowsForBackground(background) {
             return;
          }
       }
-      
-      // Make sure the clones are still sorted by recently interacted with
-      //clones.sort( (a,b) => (a._metaWindow.get_user_time() - b._metaWindow.get_user_time()) );
-      // Remove any windows no longer needed
-      //for( let ci=0, wi=0 ; 
-      
+
       // There are changes to the set of clones needed, so clear all existing clones
       destroyAllWindowsClones(background);
       if (metaWindowOwner && windowsToClone.length > 0) {
@@ -404,22 +401,51 @@ class CloneManager {
    constructor() {
       this._signalManager = new SignalManager.SignalManager(null);
       this._backgrounds = [];
-      this._activeWorkspaceIdx = global.screen.get_active_workspace_index();
+      this._activeWorkspaceIdx = global.workspace_manager.get_active_workspace_index();
 
       this._signalManager.connect(global.screen, "window-added", (screen, metaWindow, monitor) => this._onWindowAppeared(metaWindow) );
       this._signalManager.connect(global.screen, "window-removed", (screen, metaWindow, monitor) => this._onWindowDisappeared(metaWindow) );
       this._signalManager.connect(global.window_manager, "switch-workspace", () => this._updateCurrentWorkspace() );
-      this._signalManager.connect(global.window_manager, "minimize", (wm, win) => this._onWindowDisappeared(win.get_meta_window()) );
-      this._signalManager.connect(global.window_manager, "unminimize", (wm, win) => this._onWindowAppeared(win.get_meta_window()) );
+      this._signalManager.connect(global.window_manager, "minimize", (wm, win) => this._onWindowMinimized(win.get_meta_window()) );
+      this._signalManager.connect(global.window_manager, "unminimize", (wm, win) => this._onWindowUnminimized(win.get_meta_window()) );
+      this._signalManager.connect(global.workspace_manager, "showing-desktop-changed", () => this._onShowingDesktopChanged() );
       this._signalManager.connect(global.display, "notify::focus-window", () => this._onFocusChanged() );
       this._signalManager.connect(global, 'scale-changed', () => this._uiScaleChanged());
       this._setupWindowListeners();
+
+      // I can't find a way to query if the desktop is showing, so I will just have to assume it is not showing at construction time
+      this.desktop_showing = false;
+   }
+
+   _onShowingDesktopChanged() {
+      this.desktop_showing = !this.desktop_showing;
+      if (this.desktop_showing) {
+         log( "Showing Desktop" );
+         this._backgrounds.forEach( (background) => destroyAllWindowsClones(background) );
+      } else {
+         log( "Showing windows" );
+         this._backgrounds.forEach( (background) => cloneWindowsForBackground(background, this.desktop_showing) );
+      }
+   }
+
+   _onWindowMinimized(metaWindow) {
+      this._onWindowDisappeared(metaWindow)
+   }
+
+   _onWindowUnminimized(metaWindow) {
+      // After unminimizing a window with a blurred background, if the window is dragged off a
+      // dynamic blurred panel the window will not get drawn correctly after it's clone is deleted
+      //  from the panels dynamic blur group. This reapplyEffect call is a workaround for this issue.
+      if (blurApplications) {
+         blurApplications.reapplyEffects(metaWindow);
+      }
+      this._onWindowAppeared(metaWindow)
    }
 
    _uiScaleChanged() {
       this._backgrounds.forEach( (background) => destroyAllWindowsClones(background) );
       // Delay creating closes to avoid issues with an instance destroy/create sequence
-      Mainloop.idle_add( () => { this._backgrounds.forEach( (background) => cloneWindowsForBackground(background) ); } );
+      Mainloop.idle_add( () => { this._backgrounds.forEach( (background) => cloneWindowsForBackground(background, this.desktop_showing) ); } );
    }
 
    getBackgroundCount() {
@@ -429,7 +455,7 @@ class CloneManager {
    backgroundClipChanged(background) {
       let idx = this._backgrounds.indexOf(background);
       if (idx!==-1) {
-         cloneWindowsForBackground(this._backgrounds[idx]);
+         cloneWindowsForBackground(this._backgrounds[idx], this.desktop_showing);
       }
    }
 
@@ -448,7 +474,7 @@ class CloneManager {
       background._blurCinnamonGroup.insert_child_below(deskletClone, background._blurCinnamonDimmer);
       background._blurCinnamonDeskletClone = deskletClone;
       background._blurCinnamonMetaWindowOwner = metaWindowOwner
-      cloneWindowsForBackground(background);
+      cloneWindowsForBackground(background, this.desktop_showing);
       this._signalManager.connect(background, "notify::mapped", () => this._onBackgroundMapped(background));
    }
 
@@ -477,7 +503,7 @@ class CloneManager {
    _onBackgroundMapped(background) {
       debugMsg( `Background ${(background.mapped)?"mapped":"unmapped"} for ${background._blurCinnamonName}` );
       if (background.mapped === true) {
-         cloneWindowsForBackground(background);
+         cloneWindowsForBackground(background, this.desktop_showing);
       } else {
          destroyAllWindowsClones(background);
       }
@@ -579,7 +605,7 @@ class CloneManager {
       this._backgrounds.forEach( (background) => {
          if (background._blurCinnamonMetaWindowOwner === window) {
             debugMsg( "Cloning windows because a blurred window has received the focus" );
-            cloneWindowsForBackground(background);
+            cloneWindowsForBackground(background, this.desktop_showing);
          }
          if (background._blurCinnamonWinClones) {
             let dimmer = background._blurCinnamonDimmer;
@@ -602,18 +628,20 @@ class CloneManager {
    }
 
    _updateCurrentWorkspace() {
-      let currentWs = global.screen.get_active_workspace_index();
+      let currentWs = global.workspace_manager.get_active_workspace_index();
       if (currentWs !== this._activeWorkspaceIdx) {
          debugMsg( `Creating clones after workspace switch from ${this._activeWorkspaceIdx} to ${currentWs}` );
          this._activeWorkspaceIdx = currentWs;
-         // Workaround for a bug
+         // After switching workspace, if a window with a blurred background is dragged off a
+         // dynamic blurred panel the window will not get drawn correctly after it's clone is deleted
+         //  from the panels dynamic blur group. This reapplyEffect call is a workaround for this issue.
          if (blurApplications) {
             blurApplications.reapplyEffects();
          }
          // Make sure we are listening for changes to windows on this (And only this) workspace
          this._setupWindowListeners();
          // Add new clones for windows on the new workspace
-         this._backgrounds.forEach( (background) => cloneWindowsForBackground(background) );
+         this._backgrounds.forEach( (background) => cloneWindowsForBackground(background, this.desktop_showing) );
       }
    }
 
@@ -997,7 +1025,7 @@ class BlurPanels extends BlurBase {
    //}
 
    _on_window_workspace_changed(screen, metaWindow, metaWorkspace) {
-      let workspace = global.screen.get_active_workspace();
+      let workspace = global.workspace_manager.get_active_workspace();
       if (workspace === metaWorkspace) {
          if (this._windowIsMaximized(metaWindow)) {
             this._setTransparencyForEachPanelOnMonitor(metaWindow.get_monitor(), false);
@@ -1072,7 +1100,7 @@ class BlurPanels extends BlurBase {
 
    // A window has changed on the one monitor so we need to setup the panels transparency of panels on that monitor
    _setupPanelTransparencyOnMonitor(monitor) {
-      let workspace = global.screen.get_active_workspace();
+      let workspace = global.workspace_manager.get_active_workspace();
       let windows = workspace.list_windows();
       let maximizedWindows = windows.filter( (window) => {return(window.get_monitor() === monitor && this._windowIsMaximized(window));} );
       this._setTransparencyForEachPanelOnMonitor(monitor, maximizedWindows.length===0);
@@ -1080,7 +1108,7 @@ class BlurPanels extends BlurBase {
 
    // Apply/Remove transparency appropriately for all blurred panels (taking maximized windows in to account)
    _setupPanelTransparencyOnAllMonitors() {
-      let workspace = global.screen.get_active_workspace();
+      let workspace = global.workspace_manager.get_active_workspace();
       let windows = workspace.list_windows();
       let maximizedWindows = windows.filter( (window) => this._windowIsMaximized(window) );
 
@@ -1791,6 +1819,7 @@ class BlurPopupMenus extends BlurBase {
          // In case we are using Dynamic Blur, destroy it
          this._destroyDynamicEffect(this._background);
       }
+      menu.blurCinnamonSignalManager.disconnect("queue-relayout", menu.actor);
       debugMsg( "unblur complete\n" );
    }
 
@@ -2423,17 +2452,28 @@ class BlurApplications extends BlurBase {
       }
    }
 
-   // This is a work-around for some issues with Dynamic Blurring after switching workspaces
-   reapplyEffects() {
-      // Go through all windows and remove then reapply effects
-      let windows = global.display.list_windows(0);
-      for (let i = 0; i < windows.length; i++) {
-         let compositor = windows[i].get_compositor_private();
+   // This is a work-around for some issues with Dynamic Blurring after switching workspaces or
+   // restoring from minimized when a panel has dynamic blur effects applied
+   reapplyEffects(metaWindow=null) {
+      if (metaWindow) {
+         let compositor = metaWindow.get_compositor_private();
          let data = compositor._blurCinnamonDataWindow;
          if (data) {
             debugMsg( "Reapplying effects to window" );
             this._unblurWindow(compositor);
-            Mainloop.idle_add( () =>  this._blurWindow(windows[i]) );
+            Mainloop.idle_add( () =>  this._blurWindow(metaWindow) );
+         }
+      } else {
+         // Go through all windows and remove then reapply effects
+         let windows = global.display.list_windows(0);
+         for (let i = 0; i < windows.length; i++) {
+            let compositor = windows[i].get_compositor_private();
+            let data = compositor._blurCinnamonDataWindow;
+            if (data) {
+               debugMsg( "Reapplying effects to window" );
+               this._unblurWindow(compositor);
+               Mainloop.idle_add( () =>  this._blurWindow(windows[i]) );
+            }
          }
       }
    }
@@ -2691,7 +2731,8 @@ class BlurDesklets extends BlurBase {
       }
       let [enabled, opacity, blendColor, blurType, radius, saturation] = this._getDeskletSettings(desklet);
       if (enabled) {
-         let background = this._createBackgroundAndEffects(opacity, blendColor, blurType, radius, saturation, global.bottom_window_group, cornerRadius, topRadius!==0, bottomRadius!==0);
+         let background = this._createBackgroundAndEffects(opacity, blendColor, blurType, radius, saturation, null, cornerRadius, topRadius!==0, bottomRadius!==0);
+         global.desklet_container.insert_child_at_index(background, 0);
          background._blurCinnamonName = "Desklet";
          desklet._blurCinnamonBackground = background;
          this._setClip(desklet);

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
@@ -1,7 +1,7 @@
 {
     "uuid": "BlurCinnamon@klangman",
     "name": "Blur Cinnamon",
-    "version": "2.0.0",
+    "version": "2.0.1",
     "description": "Allows you to blur, colorize, desaturate and adjust the dimming of several Cinnamon Desktop components",
     "url": "https://github.com/klangman/BlurCinnamon",
     "cinnamon-version": [

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: BlurCinnamon@klangman 2.0.0\n"
+"Project-Id-Version: BlurCinnamon@klangman 2.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-01 15:26-0500\n"
+"POT-Creation-Date: 2026-03-06 00:29-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,27 +17,27 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.0/extension.js:2239 6.0/extension.js:2242 6.0/extension.js:2302
-#. 6.0/extension.js:2370
+#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
+#. 6.0/extension.js:2399
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:2504
+#. 6.0/extension.js:2544
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:2505
+#. 6.0/extension.js:2545
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3260
+#. 6.0/extension.js:3301
 msgid "Welcome to Blur Cinnamon"
 msgstr ""
 
-#. 6.0/extension.js:3261
+#. 6.0/extension.js:3302
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -49,15 +49,15 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:3265
+#. 6.0/extension.js:3306
 msgid "Open Blur Cinnamon Settings"
 msgstr ""
 
-#. 6.0/extension.js:3347
+#. 6.0/extension.js:3388
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:3348
+#. 6.0/extension.js:3389
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-01 15:26-0500\n"
+"POT-Creation-Date: 2026-03-06 00:29-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.6\n"
 
-#. 6.0/extension.js:2239 6.0/extension.js:2242 6.0/extension.js:2302
-#. 6.0/extension.js:2370
+#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
+#. 6.0/extension.js:2399
 #, fuzzy
 msgid "Default window settings"
 msgstr "Obrir la configuració d'Alt-Tab de Cinnamon"
 
-#. 6.0/extension.js:2504
+#. 6.0/extension.js:2544
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:2505
+#. 6.0/extension.js:2545
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3260
+#. 6.0/extension.js:3301
 msgid "Welcome to Blur Cinnamon"
 msgstr "Benvingut al Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:3261
+#. 6.0/extension.js:3302
 #, fuzzy
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
@@ -60,15 +60,15 @@ msgstr ""
 "per defecte. També podeu realitzar canvis a les propietats dels efectes, com "
 "ara la intensitat del desenfoc, la saturació del color i l'enfoscament."
 
-#. 6.0/extension.js:3265
+#. 6.0/extension.js:3306
 msgid "Open Blur Cinnamon Settings"
 msgstr "Obre la configuració del Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:3347
+#. 6.0/extension.js:3388
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Provant els efectes del Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:3348
+#. 6.0/extension.js:3389
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/da.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.5.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-01 15:26-0500\n"
+"POT-Creation-Date: 2026-03-06 00:29-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Alan Mortensen <alanmortensen.am@gmail.com>\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2239 6.0/extension.js:2242 6.0/extension.js:2302
-#. 6.0/extension.js:2370
+#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
+#. 6.0/extension.js:2399
 #, fuzzy
 msgid "Default window settings"
 msgstr "Åbn Alt-Tab-indstillinger i Cinnamon"
 
-#. 6.0/extension.js:2504
+#. 6.0/extension.js:2544
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:2505
+#. 6.0/extension.js:2545
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3260
+#. 6.0/extension.js:3301
 msgid "Welcome to Blur Cinnamon"
 msgstr "Velkommen til Sløret Cinnamon"
 
-#. 6.0/extension.js:3261
+#. 6.0/extension.js:3302
 #, fuzzy
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
@@ -60,15 +60,15 @@ msgstr ""
 "også foretage ændringer i effektens egenskaber, såsom sløringens intensitet, "
 "farvemætning og dæmpning."
 
-#. 6.0/extension.js:3265
+#. 6.0/extension.js:3306
 msgid "Open Blur Cinnamon Settings"
 msgstr "Åbn Sløret Cinnamon-indstillinger"
 
-#. 6.0/extension.js:3347
+#. 6.0/extension.js:3388
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Tester Sløret Cinnamons underretningseffekter"
 
-#. 6.0/extension.js:3348
+#. 6.0/extension.js:3389
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-01 15:26-0500\n"
+"POT-Creation-Date: 2026-03-06 00:29-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,16 +17,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.8\n"
 
-#. 6.0/extension.js:2239 6.0/extension.js:2242 6.0/extension.js:2302
-#. 6.0/extension.js:2370
+#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
+#. 6.0/extension.js:2399
 msgid "Default window settings"
 msgstr "Configuración predeterminada de la ventana"
 
-#. 6.0/extension.js:2504
+#. 6.0/extension.js:2544
 msgid "Error"
 msgstr "Error"
 
-#. 6.0/extension.js:2505
+#. 6.0/extension.js:2545
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
@@ -36,11 +36,11 @@ msgstr ""
 "tenía el foco anteriormente, por lo que no se pueden aplicar los efectos de "
 "Desenfoque Cinnamon a esa ventana"
 
-#. 6.0/extension.js:3260
+#. 6.0/extension.js:3301
 msgid "Welcome to Blur Cinnamon"
 msgstr "Bienvenido a Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:3261
+#. 6.0/extension.js:3302
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -60,15 +60,15 @@ msgstr ""
 "También puedes realizar cambios en las propiedades de los efectos, como la "
 "intensidad del desenfoque, la saturación del color y el oscurecimiento."
 
-#. 6.0/extension.js:3265
+#. 6.0/extension.js:3306
 msgid "Open Blur Cinnamon Settings"
 msgstr "Abrir configuración de Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:3347
+#. 6.0/extension.js:3388
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Probando los efectos de notificación de Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:3348
+#. 6.0/extension.js:3389
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fi.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-01 15:26-0500\n"
+"POT-Creation-Date: 2026-03-06 00:29-0500\n"
 "PO-Revision-Date: 2025-03-30 10:53+0300\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2239 6.0/extension.js:2242 6.0/extension.js:2302
-#. 6.0/extension.js:2370
+#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
+#. 6.0/extension.js:2399
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:2504
+#. 6.0/extension.js:2544
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:2505
+#. 6.0/extension.js:2545
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3260
+#. 6.0/extension.js:3301
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Blur Cinnamon"
 
-#. 6.0/extension.js:3261
+#. 6.0/extension.js:3302
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -51,16 +51,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:3265
+#. 6.0/extension.js:3306
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Blur Cinnamon"
 
-#. 6.0/extension.js:3347
+#. 6.0/extension.js:3388
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:3348
+#. 6.0/extension.js:3389
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-01 15:26-0500\n"
+"POT-Creation-Date: 2026-03-06 00:29-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2239 6.0/extension.js:2242 6.0/extension.js:2302
-#. 6.0/extension.js:2370
+#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
+#. 6.0/extension.js:2399
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:2504
+#. 6.0/extension.js:2544
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:2505
+#. 6.0/extension.js:2545
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3260
+#. 6.0/extension.js:3301
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Flou pour Cinnamon"
 
-#. 6.0/extension.js:3261
+#. 6.0/extension.js:3302
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -51,16 +51,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:3265
+#. 6.0/extension.js:3306
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Flou pour Cinnamon"
 
-#. 6.0/extension.js:3347
+#. 6.0/extension.js:3388
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:3348
+#. 6.0/extension.js:3389
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/hu.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-01 15:26-0500\n"
+"POT-Creation-Date: 2026-03-06 00:29-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,16 +18,16 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.8\n"
 
-#. 6.0/extension.js:2239 6.0/extension.js:2242 6.0/extension.js:2302
-#. 6.0/extension.js:2370
+#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
+#. 6.0/extension.js:2399
 msgid "Default window settings"
 msgstr "Alapértelmezett ablakbeállítások"
 
-#. 6.0/extension.js:2504
+#. 6.0/extension.js:2544
 msgid "Error"
 msgstr "Hiba"
 
-#. 6.0/extension.js:2505
+#. 6.0/extension.js:2545
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
@@ -37,11 +37,11 @@ msgstr ""
 "WM_CLASS osztályát, ezért a Cinnamon Elhomályosítása effektek nem "
 "alkalmazhatók erre az ablakra"
 
-#. 6.0/extension.js:3260
+#. 6.0/extension.js:3301
 msgid "Welcome to Blur Cinnamon"
 msgstr "Üdvözöljük a Cinnamon Elhomályosításában"
 
-#. 6.0/extension.js:3261
+#. 6.0/extension.js:3302
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -61,15 +61,15 @@ msgstr ""
 "Módosíthatod az effektek tulajdonságait is, például az elmosás intenzitását, "
 "a színtelítettséget és a fényerőt."
 
-#. 6.0/extension.js:3265
+#. 6.0/extension.js:3306
 msgid "Open Blur Cinnamon Settings"
 msgstr "Nyissa meg a Cinnamon Elhomályosítása beállításait"
 
-#. 6.0/extension.js:3347
+#. 6.0/extension.js:3388
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Cinnamon Elhomályosítása értesítési effektek tesztelése"
 
-#. 6.0/extension.js:3348
+#. 6.0/extension.js:3389
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/it.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-01 15:26-0500\n"
+"POT-Creation-Date: 2026-03-06 00:29-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2239 6.0/extension.js:2242 6.0/extension.js:2302
-#. 6.0/extension.js:2370
+#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
+#. 6.0/extension.js:2399
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:2504
+#. 6.0/extension.js:2544
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:2505
+#. 6.0/extension.js:2545
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3260
+#. 6.0/extension.js:3301
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Sfoca Cinnamom"
 
-#. 6.0/extension.js:3261
+#. 6.0/extension.js:3302
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -51,16 +51,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:3265
+#. 6.0/extension.js:3306
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Sfoca Cinnamom"
 
-#. 6.0/extension.js:3347
+#. 6.0/extension.js:3388
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:3348
+#. 6.0/extension.js:3389
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/nl.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-01 15:26-0500\n"
+"POT-Creation-Date: 2026-03-06 00:29-0500\n"
 "PO-Revision-Date: 2025-06-13 17:14+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,28 +16,28 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.0/extension.js:2239 6.0/extension.js:2242 6.0/extension.js:2302
-#. 6.0/extension.js:2370
+#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
+#. 6.0/extension.js:2399
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:2504
+#. 6.0/extension.js:2544
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:2505
+#. 6.0/extension.js:2545
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3260
+#. 6.0/extension.js:3301
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Vervaag Cinnamon"
 
-#. 6.0/extension.js:3261
+#. 6.0/extension.js:3302
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
 "Timeline effects.\n"
@@ -49,16 +49,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:3265
+#. 6.0/extension.js:3306
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Vervaag Cinnamon"
 
-#. 6.0/extension.js:3347
+#. 6.0/extension.js:3388
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:3348
+#. 6.0/extension.js:3389
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/vi.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/vi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.5.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-01 15:26-0500\n"
+"POT-Creation-Date: 2026-03-06 00:29-0500\n"
 "PO-Revision-Date: \n"
 "Last-Translator: loccun <huynhloc.contact@gmail.com>\n"
 "Language-Team: \n"
@@ -18,28 +18,28 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2239 6.0/extension.js:2242 6.0/extension.js:2302
-#. 6.0/extension.js:2370
+#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
+#. 6.0/extension.js:2399
 #, fuzzy
 msgid "Default window settings"
 msgstr "Mở cài đặt Alt-Tab Cinnamon"
 
-#. 6.0/extension.js:2504
+#. 6.0/extension.js:2544
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:2505
+#. 6.0/extension.js:2545
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3260
+#. 6.0/extension.js:3301
 msgid "Welcome to Blur Cinnamon"
 msgstr "Chào mừng đến với Blur Cinnamon"
 
-#. 6.0/extension.js:3261
+#. 6.0/extension.js:3302
 #, fuzzy
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
@@ -59,15 +59,15 @@ msgstr ""
 "phần được bật theo mặc định. Bạn cũng có thể thay đổi các thuộc tính hiệu "
 "ứng như cường độ làm mờ, độ bão hòa màu và làm tối."
 
-#. 6.0/extension.js:3265
+#. 6.0/extension.js:3306
 msgid "Open Blur Cinnamon Settings"
 msgstr "Mở Cài đặt Blur Cinnamon"
 
-#. 6.0/extension.js:3347
+#. 6.0/extension.js:3388
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Đang thử nghiệm Hiệu ứng Thông báo Blur Cinnamon"
 
-#. 6.0/extension.js:3348
+#. 6.0/extension.js:3389
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"


### PR DESCRIPTION
1. Fixed graphical issue with blurred windows after the window is moved off of a dynamically blurred component and the window had been minimized in the past.
2. Added a fix to remove dynamic blur window clones when in the "show desktop" state (i.e. when using the "Show Desktop" or "Corner Bar" applets).
3. Fixed a performance issue with Popup menus where the responsiveness of the menu would degrade over time with each open/close sequence of a particular menu.
4. Fixed missing Desklet blur actors in desklets clones (Desklet cloning is used for Dynamic blurring in Blur Cinnamon as well as in the "Desktop Cube" and "Flipper" extensions workspace switcher animations).
5. Fixed missing Desklet blur actors when using the "Corner Bar" middle click "Show the desklets" feature.