### PR TITLE
Security: Insecure HTTP URLs in location service

### DIFF
--- a/cinnamon-dynamic-wallpaper@TobiZog/files/cinnamon-dynamic-wallpaper@TobiZog/5.4/src/service/location.py
+++ b/cinnamon-dynamic-wallpaper@TobiZog/files/cinnamon-dynamic-wallpaper@TobiZog/5.4/src/service/location.py
@@ -11,11 +11,11 @@ class Location():
         dict: latitude and longitude
     """
     if provider == NetworkLocationProvider.GEOJS:
-      url = "http://get.geojs.io/v1/ip/geo.json"
+      url = "https://get.geojs.io/v1/ip/geo.json"
     elif provider == NetworkLocationProvider.IPAPI:
-      url = "http://ip-api.com/json/?fields=61439"
+      url = "https://ip-api.com/json/?fields=61439"
     elif provider == NetworkLocationProvider.IPWHOIS:
-      url = "http://ipwho.is"
+      url = "https://ipwho.is"
 
     try:
       request = urllib.request.urlopen(url)


### PR DESCRIPTION
## Summary

Security: Insecure HTTP URLs in location service

## Problem

**Severity**: `High` | **File**: `cinnamon-dynamic-wallpaper@TobiZog/files/cinnamon-dynamic-wallpaper@TobiZog/5.4/src/service/location.py:L14`

The location service uses HTTP URLs instead of HTTPS for network requests to geojs.io, ip-api.com, and ipwho.is. This exposes users to potential Man-in-the-Middle (MITM) attacks where an attacker could intercept or manipulate location data.

## Solution

Replace 'http://' with 'https://' for all URL endpoints to ensure encrypted communication.

## Changes

- `cinnamon-dynamic-wallpaper@TobiZog/files/cinnamon-dynamic-wallpaper@TobiZog/5.4/src/service/location.py` (modified)