### PR TITLE
[BlurCinnamon@klangman] Version 2.5.0

### DIFF
--- a/BlurCinnamon@klangman/CHANGELOG.md
+++ b/BlurCinnamon@klangman/CHANGELOG.md
@@ -1,5 +1,20 @@
 # Changelog
 
+## 2.5.0
+
+* Added the ability to apply effects to the Classic (default) Alt-Tab switcher
+* Added the Monte Carlo Blur alorithum from Blur-my-shell as a new blur option (static and dynamic)
+* Added option to hide panels when the 3d Alt-Tab switchers are used (default enabled)
+* Implemented atrifact mitigation techniques to eliminate artifacts with Dynamic Blur for Application Windows (also removed the "experimental" label for Dynamic Application Window effects).
+* Allow Desklets to use Dynamic Blurring so that the Super+S (show desklets) option can blur background windows under desklets
+* Added option to allow theme setting to remain for Notifications and Tooltips
+* Improved how window stacking is tracked for dynamic blurring (fixes issues with showing incorrect background windows)
+* Fixed a number of issues to allow proper support for video wallpapers (i.e. Hidamari)
+* Fixes some most cases where Application Window Dynamic blurring would cause issue with moving/resizing windows
+* Fix some issues that occur after changing the UI scale and/or screen resolution
+* Better window tracking for the focused window backlight effect
+* A bunch of other fixes that I didn't remember to document
+
 ## 2.0.1
 
 * Fixed graphical issue with blurred windows after the window is moved off of a dynamically blurred component and the window had been minimized in the past.

--- a/BlurCinnamon@klangman/README.md
+++ b/BlurCinnamon@klangman/README.md
@@ -11,7 +11,7 @@ Cinnamon components you can apply effects to (currently):
 5. The Desktop background image **(#)**
 6. Desktop Notification popups **(#)**
 7. The panel tooltip popups **(#)**
-8. The Coverflow and Timeline 3D Alt-Tab switchers (not the Cinnamon default Alt-Tab switcher!)
+8. Alt-Tab switchers (the standard and 3D switchers)
 9. Application window backgrounds **(#)**
 10. Desklet backgrounds **(#)**
 
@@ -19,19 +19,21 @@ Cinnamon components you can apply effects to (currently):
 
 ## Background (Blur) Effect Options
 
-| Effect                   | Components                                     | Description                                                                                                           |
-| ------------------------ | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| None                     | Alt-Tab, Desklets, Desktop, Expo, Overview     | Will not apply any blurring, but allows you to apply other effects like dimming and desaturation.                     |
-| Transparent              | Panels, Menus, Notifications, Tooltips         | Makes the component transparent allowing whatever is under it to appear, but no blurring is applied.                  |
-| Transparent to wallpaper | Panels, Menu, Notifications, Tooltips, Windows | Applies a background to the component that shows a copy of the desktop wallpaper, no blur effects.                    |
-| Simple static blur       | Panels, Menu, Notifications, Tooltips, Windows | Uses the Cinnamon blur effect (it's very subtle) on top of the desktop wallpaper                                      |
-| Gaussian static blur     | Panels, Menu, Notifications, Tooltips, Windows | Uses a Gaussian blur effect on top of the desktop wallpaper                                                           |
-| Gaussian dynamic blur    | Panels, Menu, Notifications, Tooltips, Windows | Uses a Gaussian blur effect on top of a full desktop clone with windows and the desktop wallpaper                     |
-| Simple / Gaussian        | Alt-Tab, Desklets, Desktop, Expo, Overview     | These components can't benefit from anything other than static blurring (blur effect on top of the desktop wallpaper) |
+| Effect                          | Components                                               | Description                                                                                                           |
+| ------------------------------- | -------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| None                            | Alt-Tab, Desklets, Desktop, Expo, Overview               | Will not apply any blurring, but allows you to apply other effects like dimming and desaturation.                     |
+| Transparent                     | Panels, Menus, Notifications, Tooltips                   | Makes the component transparent allowing whatever is under it to appear, but no blurring is applied.                  |
+| Transparent to wallpaper        | Panels, Menu, Notifications, Tooltips, Windows           | Applies a background to the component that shows a copy of the desktop wallpaper, no blur effects.                    |
+| Simple static blur              | Panels, Menu, Notifications, Tooltips, Windows           | Uses the Cinnamon blur effect (it's very subtle) on top of the desktop wallpaper                                      |
+| Gaussian static blur            | Panels, Menu, Notifications, Tooltips, Windows, Desklets | Uses a Gaussian blur effect on top of the desktop wallpaper                                                           |
+| Gaussian dynamic blur           | Panels, Menu, Notifications, Tooltips, Windows, Desklets | Uses a Gaussian blur effect on top of a full desktop clone with windows and the desktop wallpaper                     |
+| Monte Carlo static blur         | Panels, Menu, Notifications, Tooltips, Windows, Desklets | Uses a Monte Carlo blur effect on top of the desktop wallpaper                                                        |
+| Monte Carlo dynamic blur        | Panels, Menu, Notifications, Tooltips, Windows, Desklets | Uses a Monte Carlo blur effect on top of a full desktop clone with windows and the desktop wallpaper                  |
+| Simple / Gaussian / Monte Carlo | Desktop, Expo, Overview                                  | These components can't benefit from anything other than static blurring (blur effect on top of the desktop wallpaper) |
 
 ## Features
 
-- Gaussian blur algorithm (borrowed from the Gnome extension Blur-my-Shell) with a user configurable intensity
+- Gaussian and Monte Carlo blur algorithms (borrowed from the Gnome extension Blur-my-Shell) with a user configurable intensity
 - Simple blur algorithm (the Cinnamon built-in algorithm) which I would only recommend for very old computers
 - Dimming overlay with user configurable color and intensity (fully-transparent to a solid color)
 - Makes the components transparent (when needed) so that the desktop background image effects are visible
@@ -41,6 +43,7 @@ Cinnamon components you can apply effects to (currently):
 - Option to add a backlight effect to the focused window using a background image blur effect spilling over the focused windows borders
 - You can use general settings across all Cinnamon components or use unique settings for each component type
 - Allows you to apply custom CSS code to panels to achieve a number of custom panel effects like rounded corners, borders, changing the panel width, etc. Careful though, you can mess up your panels, but remember everything will go back to normal if you simply remove any Custom CSS settings you added to Blur Cinnamon.
+- Support for Video Wallpaper (only tested Hidamari)
 
 ## Requirements
 
@@ -58,8 +61,7 @@ Using any of the above with Blur Cinnamon may have some odd side effects that wo
 
 1. The Applet popup menu effects are intended to be used with the Cinnamon (6.4) theme or the Mint-Y dark desktop themes. The effects might work will with some other themes but I have not tested them so the effects might not work out just right. You can try the Mint-Y light themes but it might be hard to read the menu items without some playing around with the settings and the background image. Blur Cinnamon Popup-menu effects are disabled by default.
 2. The Applet popup-menu effects works for all the applets that I have tested except "Cinnamenu". Cinnamenu is preventing other code from receiving the "open-state-changed" event which Blur Cinnamon uses to know when to apply popup-menu theme setting and when to resize and show the blur background element. This issue is fixed in the latest Cinnamenu from [Fredcw GitHub](https://github.com/fredcw/Cinnamenu) but you will need to manually fix the current Cinnamon Spices version of Cinnamenu (see [here](https://github.com/linuxmint/cinnamon-spices-extensions/issues/873))
-3. The experimental dynamic blur effect for application windows causes several artifacts and flashing graphical issues, therefore I don't recommend using this experimental option. If I can find a solution to these issues I will remove "experimental" from the description in a future release.
-4. This extension currently does not work under Wayland, it only works under X11. The extension automatically detects Wayland and disables most of the features of the extension.
+3. This extension currently does not work under Wayland, it only works under X11. The extension automatically detects Wayland and disables most of the features of the extension.
 
 ## Installation
 
@@ -69,6 +71,26 @@ Using any of the above with Blur Cinnamon may have some odd side effects that wo
 - Click the "Install" button on the right and then return to the "Manage" tab
 - Select the new "Blur Cinnamon" entry and then click the "+" button at the bottom of the window
 - Use the "gears" icon next to the "Blur Cinnamon" entry to open the setting window and setup the preferred behavior
+
+## Blurred Applciation Windows:
+
+No application windows will have effects applied even with "Application windows" support enabled on the "General setup" tab of Blur Cinnamons configuation window. 
+
+
+
+You MUST enabled specific application windows in the "Componenet specific settings" tab under the "Windows" setting page in order to have effects appled. 
+
+
+
+Even then the effects will only be visible when the application window (i.e Terminal) is configured to be transparent. 
+
+
+
+For windows that can't be configied to have transparent elements, you have the option of reducing the "Opacity" in Blur Cinnamon setting for the window, or by using the "Opacity Slider" extension. With a windows Opacity set to less than 100% you will see the Blur Cinnamon effects behind the window.
+
+
+
+There is also a "Default window settings" entry in the Blur Cinnamon Windows setting page. With this entry enabled all normal windows will have effects applied. Specific windows can still be excluded by adding table entries for the windows you what to exclude and making sure the Enabled setting for the each entry is NOT checked.
 
 ## Custom Panel CSS Examples:
 
@@ -105,6 +127,6 @@ If you like this Cinnamon extension, please give it a "star" here any maybe on m
 
 Some code was borrowed from the [BlurOverview](https://cinnamon-spices.linuxmint.com/extensions/view/72) Extension by nailfarmer.
 
-The Gaussian and rounded corner effect code was borrowed from the Gnome [Blur my shell](https://github.com/aunetx/blur-my-shell) extension by [Aurélien Hamy](https://github.com/aunetx).
+The Gaussian, Monte Carlo and rounded corner effects code was borrowed from the Gnome [Blur my shell](https://github.com/aunetx/blur-my-shell) extension by [Aurélien Hamy](https://github.com/aunetx).
 
 The Blur Cinnamon icon was generated by Google Gemini

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/extension.js
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/extension.js
@@ -20,33 +20,35 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-const Clutter        = imports.gi.Clutter;
-const St             = imports.gi.St;
-const Tweener        = imports.ui.tweener;
-const Overview       = imports.ui.overview;
-const Expo           = imports.ui.expo;
-const AppSwitcher3D  = imports.ui.appSwitcher.appSwitcher3D;
-const Settings       = imports.ui.settings;
-const SignalManager  = imports.misc.signalManager;
-const Panel          = imports.ui.panel;
-const Main           = imports.ui.main;
-const Meta           = imports.gi.Meta;
-const Mainloop       = imports.mainloop;
-const AppletManager  = imports.ui.appletManager;
-const Lang           = imports.lang;
-const UPowerGlib     = imports.gi.UPowerGlib;
-const MessageTray    = imports.ui.messageTray;
-const Util           = imports.misc.util;
-const Tooltips       = imports.ui.tooltips;
-const WindowMenu     = imports.ui.windowMenu;
-const Cinnamon       = imports.gi.Cinnamon;
-const DeskletManager = imports.ui.deskletManager;
+const Clutter         = imports.gi.Clutter;
+const St              = imports.gi.St;
+const Tweener         = imports.ui.tweener;
+const Overview        = imports.ui.overview;
+const Expo            = imports.ui.expo;
+const AppSwitcher3D   = imports.ui.appSwitcher.appSwitcher3D;
+const ClassicSwitcher = imports.ui.appSwitcher.classicSwitcher;
+const Settings        = imports.ui.settings;
+const SignalManager   = imports.misc.signalManager;
+const Panel           = imports.ui.panel;
+const Main            = imports.ui.main;
+const Meta            = imports.gi.Meta;
+const Mainloop        = imports.mainloop;
+const AppletManager   = imports.ui.appletManager;
+const Lang            = imports.lang;
+const UPowerGlib      = imports.gi.UPowerGlib;
+const MessageTray     = imports.ui.messageTray;
+const Util            = imports.misc.util;
+const Tooltips        = imports.ui.tooltips;
+const WindowMenu      = imports.ui.windowMenu;
+const Cinnamon        = imports.gi.Cinnamon;
+const DeskletManager  = imports.ui.deskletManager;
 
 // For PopupMenu effects
-const Applet        = imports.ui.applet;
-const PopupMenu     = imports.ui.popupMenu;
+const Applet    = imports.ui.applet;
+const PopupMenu = imports.ui.popupMenu;
 
 const GaussianBlur = require("./gaussian_blur");
+const MonteCarloBlur = require("./monte_carlo_blur");
 const CornerEffect = require("./corner");
 
 const ANIMATION_TIME = 0.25;
@@ -63,6 +65,7 @@ let originalHideAppSwitcher3D;
 let originalSizeChangeWindowDone;
 
 let settings;
+let blurClassicSwitcher;
 let blurPanels;
 let blurPopupMenus;
 let blurDesktop;
@@ -75,6 +78,7 @@ let metaData;
 
 let cloneManager;
 
+var blurClassicSwitcherThis;
 var blurPanelsThis;
 var blurPopupMenusThis;
 var blurNotificationsThis;
@@ -86,7 +90,9 @@ const BlurType = {
    Simple: 1,
    Gaussian: 2,
    Transparent: 3,
-   DynamicBlur: 4
+   DynamicBlur: 4,    // Dynamic blur using Gaussian
+   MonteCarlo: 5,
+   DynamicMC: 6       // Dynamic blur using Monte-Carlo
 }
 
 const PanelLoc = {
@@ -118,6 +124,12 @@ function debugMsg(...params) {
    //log(...params);
 }
 
+function printStackTrace(header) {
+   log( header );
+   var err = new Error();
+   log( "Stack:\n"+err.stack );
+}
+
 function _animateVisibleOverview() {
    if (this.visible || this.animationInProgress)
       return;
@@ -138,8 +150,10 @@ function _animateVisibleOverview() {
       let fx;
       if (blurType === BlurType.Simple) {
          fx =  new Clutter.BlurEffect();
-      } else {
+      } else if (blurType === BlurType.Gaussian || blurType === BlurType.DynamicBlur) {
          fx = new GaussianBlur.GaussianBlurEffect( { radius: radius, brightness: 1, width: 0, height: 0 } );
+      } else { // Monte-Carlo
+         fx = new MonteCarloBlur.MonteCarloBlurEffect( { radius: radius, iterations: settings.montecarloIterations, prefer_closer_pixels: settings.montecarloPerferCloserPixels, use_base_pixel: settings.montecarloUseBasePixel, brightness: 1, width: 0, height: 0 } );
       }
       desktopBackground.add_effect_with_name( BLUR_EFFECT_NAME, fx );
    }
@@ -176,8 +190,10 @@ function _animateVisibleExpo() {
       let fx;
       if (blurType === BlurType.Simple) {
          fx =  new Clutter.BlurEffect();
-      } else {
+      } else if (blurType === BlurType.Gaussian || blurType === BlurType.DynamicBlur) {
          fx = new GaussianBlur.GaussianBlurEffect( {radius: radius, brightness: 1, width: 0, height: 0} );
+      } else { // Monte-Carlo
+         fx = new MonteCarloBlur.MonteCarloBlurEffect( { radius: radius, iterations: settings.montecarloIterations, prefer_closer_pixels: settings.montecarloPerferCloserPixels, use_base_pixel: settings.montecarloUseBasePixel, brightness: 1, width: 0, height: 0 } );
       }
       desktopBackground.add_effect_with_name( BLUR_EFFECT_NAME, fx );
    }
@@ -201,7 +217,7 @@ function _animateVisibleExpo() {
 function _initAppSwitcher3D(...params) {
    this._oldInit(...params);
 
-   if (this._background && this.actor) {
+   if (this._background && this.actor && settings.enableAppswitcherEffects && settings.appswitcherAllow3D) {
       let blurType = (settings.appswitcherOverride) ? settings.appswitcherBlurType : settings.blurType;
       let radius = (settings.appswitcherOverride) ? settings.appswitcherRadius : settings.radius;
       let blendColor = (settings.appswitcherOverride) ? settings.appswitcherBlendColor : settings.blendColor;
@@ -213,8 +229,10 @@ function _initAppSwitcher3D(...params) {
          let fx;
          if (blurType === BlurType.Simple) {
             fx =  new Clutter.BlurEffect();
-         } else {
+         } else if (blurType === BlurType.Gaussian || blurType === BlurType.DynamicBlur) {
             fx = new GaussianBlur.GaussianBlurEffect( {radius: radius, brightness: 1, width: 0, height: 0} );
+         } else { // Monte-Carlo
+            fx = new MonteCarloBlur.MonteCarloBlurEffect( { radius: radius, iterations: settings.montecarloIterations, prefer_closer_pixels: settings.montecarloPerferCloserPixels, use_base_pixel: settings.montecarloUseBasePixel, brightness: 1, width: 0, height: 0 } );
          }
          desktopBackground.add_effect_with_name( BLUR_EFFECT_NAME, fx );
          this._blurCinnamonBlurEffect = fx;
@@ -230,6 +248,15 @@ function _initAppSwitcher3D(...params) {
       color.alpha = opacity*2.55;
       this.actor.set_background_color(color);
    }
+
+   // Disable all panels
+   if (settings.appswitcherDisablePanels) {
+      let panels = Main.getPanels();
+      for ( let i=0 ; i < panels.length  ; i++ ) {
+         if (panels[i])
+            panels[i].disable();
+      }
+   }
 }
 
 function _hideAppSwitcher3D(...params) {
@@ -239,6 +266,18 @@ function _hideAppSwitcher3D(...params) {
    if (this._background && this._blurCinnamonDesatEffect) {
       this._background.remove_effect(this._blurCinnamonDesatEffect);
    }
+
+   // Enable all panels
+   if (settings.appswitcherDisablePanels) {
+      let panels = Main.getPanels();
+      for ( let i=0 ; i < panels.length  ; i++ ) {
+         if (panels[i]) {
+            // For some reason, if we enable the panels right now the panels applets don't reappear, doing this at idle seems to solve it.
+            Mainloop.idle_add( () => panels[i].enable() );
+         }
+      }
+   }
+
    this._oldHide(...params);
 }
 
@@ -266,6 +305,14 @@ function rectOverlap(aX, aY, aX2, aY2, bX, bY, bX2, bY2) {
    return false;
 }
 
+// Is metawindow a above b
+function isAbove(a, b) {
+   if (a===b) return false;
+   let windows = [a,b];
+   global.display.sort_windows_by_stacking(windows);
+   return windows[0] === b;
+}
+
 function getBackgroundClip(background) {
    let effect = background.get_effect(CORNER_EFFECT_NAME);
    let clip;
@@ -277,25 +324,53 @@ function getBackgroundClip(background) {
    return clip;
 }
 
-function createWindowClone(metaWindow, background) {
-   if (background.is_mapped() && background._blurCinnamonMetaWindowOwner !== metaWindow) {
+// Hack: To fix artifacts after painting a lower z-order clone, redraw the clone that is one higher in the z-order (the widow directly above).
+// This is only needed for application window backgrounds.
+function clonePainted(background, actor) {
+   let children = background._blurCinnamonGroup.get_children();
+   let idx = children.findIndex( (element) => element === actor );
+   if (idx != -1 && idx < children.length-1 && children[idx+1]._metaWindow) {
+      //log( `parint for ${actor._metaWindow.get_title()}, queuing redraw for ${children[idx+1]._metaWindow.get_title()}` );
+      children[idx+1].queue_redraw();
+   }
+}
+
+function createWindowClone(metaWindow, background, desktopOnly) {
+   if (background.is_mapped() && background._blurCinnamonMetaWindowOwner !== metaWindow && (!desktopOnly || metaWindow.get_window_type() === Meta.WindowType.DESKTOP) &&
+      (!background._blurCinnamonMetaWindowOwner || background._blurCinnamonMetaWindowOwner.get_window_type() !== Meta.WindowType.DESKTOP || metaWindow.get_window_type() === Meta.WindowType.DESKTOP) ) {
+      // Debugging check
+      if( background._blurCinnamonWinClones.find( (element) => element._metaWindow === metaWindow) ) {
+         log( `Warning! Tried to add a window clone to a background that already has a clone for that window.` );
+         return;
+      }
       let rect = metaWindow.get_buffer_rect();
       let compositor = metaWindow.get_compositor_private();
       let windowClone = new Clutter.Clone({source: compositor, reactive: false, x: rect.x, y: rect.y });
-      debugMsg( `Created clone ${windowClone} of ${metaWindow.get_title()} for background ${background._blurCinnamonName}` );
-      let dimmer = background._blurCinnamonDimmer;
-      let group = background._blurCinnamonGroup
-      group.insert_child_below(windowClone, dimmer);
+      debugMsg( `Created clone ${windowClone} of ${metaWindow.get_title()}/${metaWindow.get_id()} for background ${background._blurCinnamonName}` );
+      if (metaWindow.get_window_type() === Meta.WindowType.DESKTOP && background._blurCinnamonDeskletClone) {
+         background._blurCinnamonGroup.insert_child_below(windowClone, background._blurCinnamonDeskletClone);
+      } else {
+         background._blurCinnamonGroup.insert_child_below(windowClone, background._blurCinnamonDimmer);
+      }
       background._blurCinnamonWinClones.push(windowClone);
       windowClone._metaWindow = metaWindow;
+      if (settings.windowArtifactMitigation && background._blurCinnamonMetaWindowOwner) {
+         windowClone._paintEventId = windowClone.connect( "paint", (actor) => clonePainted(background, actor));
+      }
       return windowClone;
    } else {
-      debugMsg( "Not creating a clone. Background is not mapped or a self clone attempt." );
+      debugMsg( "Not creating an unnecessary clone." );
    }
 }
 
 function destroyWindowClone(windowClone, background) {
-   debugMsg( `Removing clone ${windowClone} of "${windowClone._metaWindow.get_title()}" from background ${background._blurCinnamonName} with ${background._blurCinnamonWinClones.length} clones` );
+   if (background._blurCinnamonMetaWindowOwner) {
+      debugMsg( `Removing clone ${windowClone} of "${windowClone._metaWindow.get_title()}"/${windowClone._metaWindow.get_id()} from background ${background._blurCinnamonName} / ${background._blurCinnamonMetaWindowOwner.get_title()} with ${background._blurCinnamonWinClones.length} clones` );
+   } else {
+      debugMsg( `Removing clone ${windowClone} of "${windowClone._metaWindow.get_title()}"/${windowClone._metaWindow.get_id()} from background ${background._blurCinnamonName} with ${background._blurCinnamonWinClones.length} clones` );
+   }
+   if (windowClone._paintEventId)
+      windowClone.disconnect( windowClone._paintEventId );
    background._blurCinnamonGroup.remove_child(windowClone);
    windowClone.destroy();
    let idx = background._blurCinnamonWinClones.indexOf(windowClone);
@@ -308,17 +383,73 @@ function destroyWindowClone(windowClone, background) {
 function destroyAllWindowsClones(background) {
    background._blurCinnamonWinClones.forEach( (windowClone) => {
       debugMsg( `Removing clone ${windowClone} of '${windowClone._metaWindow.get_title()}' from background ${background._blurCinnamonName}` );
-      windowClone.hide();
+      background._blurCinnamonGroup.remove_child(windowClone);
+      //windowClone.hide();
       windowClone.destroy();
    });
    background._blurCinnamonWinClones = [];
 }
 
+// Remove clones not in the new list of clones, add clones for windows not in the existing list of clones
+function applyNewCloneList(background, windowsToClone, desktopOnly) {
+   // Hide all clones that are no longer needed
+   let clones = background._blurCinnamonWinClones;
+   clones.forEach( (clone) => {
+      if (!windowsToClone.includes(clone._metaWindow)) {
+         clone.hide();
+      }
+   });
+   // Reorder and/or add any missing clones.
+   windowsToClone.forEach( (metaWindow) => {
+      if (background.is_mapped() && background._blurCinnamonMetaWindowOwner !== metaWindow && (!desktopOnly || metaWindow.get_window_type() === Meta.WindowType.DESKTOP)) {
+         let idx = clones.findIndex( (clone) => clone._metaWindow === metaWindow );
+         if (idx !==-1) {
+            if (metaWindow.get_window_type() === Meta.WindowType.DESKTOP && background._blurCinnamonDeskletClone) {
+               background._blurCinnamonGroup.insert_child_below(clones[idx], background._blurCinnamonDeskletClone);
+            } else {
+               background._blurCinnamonGroup.insert_child_below(clones[idx], background._blurCinnamonDimmer);
+            }
+         } else {
+            createWindowClone(metaWindow, background, desktopOnly);
+         }
+      }
+   });
+   // Remove all hidden clones on idle to avoid issues (do we really need to do it at idle??)
+   Mainloop.idle_add( () => background._blurCinnamonWinClones.forEach( (clone) => {
+      if (!clone.is_visible()) {
+         destroyWindowClone(clone, background);
+      }
+   }));
+}
+
+function destroyAllNonDesktopClones(background) {
+   for (let i=background._blurCinnamonWinClones.length-1 ; i >= 0 ; i--) {
+      let windowClone = background._blurCinnamonWinClones[i];
+      if (windowClone._metaWindow.get_window_type() !== Meta.WindowType.DESKTOP) {
+         debugMsg( `Removing clone ${windowClone} of '${windowClone._metaWindow.get_title()}' from background ${background._blurCinnamonName}` );
+         windowClone.hide();
+         windowClone.destroy();
+         background._blurCinnamonWinClones.splice(i, 1);
+      }
+   }
+}
+
+// This function just schedules an update to the background clones.
+// We don't do this work right away for a number of reasons:
+// 1. There are (what I believe to be) bugs in Clutter that causes hangs and weird behavior if done immediately
+// 2. The sort_windows_by_stacking() API will sort incorrectly when called from within the "notify::focus-window" event handler
+function cloneWindowsForBackground(background, showingDesktop, desktopOnly) {
+   //Promise.resolve().then( () => cloneWindowsForBackgroundNow(background, showingDesktop, desktopOnly) );
+   Mainloop.idle_add( () => cloneWindowsForBackgroundNow(background, showingDesktop, desktopOnly) );
+}
+
 // Find windows that need to be cloned for the background passed in.
 // metaWindowOwner is the window that owns the background and therefore
 // only windows with a z-order below that window should be included.
-// If metaWindowOwner is null, all overlapping windows will be cloned
-function cloneWindowsForBackground(background, showingDesktop) {
+// If metaWindowOwner is null, all overlapping windows will be cloned.
+// showingDesktop: bool, true when all windows are hidden (i.e Super+D)
+// desktopOnly: bool, true when the background should only show desktop clones
+function cloneWindowsForBackgroundNow(background, showingDesktop, desktopOnly) {
    let currentWs = global.workspace_manager.get_active_workspace_index();
    let [blurX, blurY, blurWidth, blurHeight] = getBackgroundClip(background);
    if (blurWidth===0 || blurHeight===0 || !background.is_mapped()) {
@@ -330,35 +461,42 @@ function cloneWindowsForBackground(background, showingDesktop) {
    let windowsToClone = [];
    let metaWindowOwner = background._blurCinnamonMetaWindowOwner;
 
-   if (!showingDesktop) {
-      // Find all windows that are visible and overlap with the passed in background
-      let windows = global.get_window_actors();
-      windows.forEach( (window) => {
-         let metaWindow = window.get_meta_window();
-         if (metaWindow && metaWindow.get_workspace() &&
-            (!metaWindowOwner || metaWindow.get_window_type() === Meta.WindowType.DESKTOP || metaWindowOwner.get_user_time() > metaWindow.get_user_time()) &&
-            (metaWindow.get_workspace().index() === currentWs || metaWindow.is_on_all_workspaces()) &&
-            !metaWindow.minimized && metaWindow.get_window_type() !== Meta.WindowType.OVERRIDE_OTHER)
-         {
-            let compositor = metaWindow.get_compositor_private();
-            let winRect = metaWindow.get_buffer_rect();
-            let winX = winRect.x;
-            let winY = winRect.y;
-            let winX2 = winRect.x + winRect.width;
-            let winY2 = winRect.y + winRect.height;
-            if (rectOverlap(winX, winY, winX2, winY2, blurX, blurY, blurX2, blurY2)) {
-               windowsToClone.push(metaWindow);
-            }
+   // Find all windows that are visible and overlap with the passed in background
+   let windows = global.get_window_actors();
+   windows.forEach( (window) => {
+      let metaWindow = window.get_meta_window();
+      if (metaWindow && metaWindow.get_workspace() &&
+         (!showingDesktop || metaWindow.get_window_type() === Meta.WindowType.DESKTOP) &&
+         (!desktopOnly || metaWindow.get_window_type() === Meta.WindowType.DESKTOP) &&
+         (metaWindow.get_workspace().index() === currentWs || metaWindow.is_on_all_workspaces()) &&
+         !metaWindow.minimized && metaWindow.get_window_type() !== Meta.WindowType.OVERRIDE_OTHER &&
+         metaWindow.get_wm_class() !== "Nemo-desktop")
+      {
+         let winRect = metaWindow.get_buffer_rect();
+         let winX = winRect.x;
+         let winY = winRect.y;
+         let winX2 = winRect.x + winRect.width;
+         let winY2 = winRect.y + winRect.height;
+         if (rectOverlap(winX, winY, winX2, winY2, blurX, blurY, blurX2, blurY2)) {
+            windowsToClone.push(metaWindow);
          }
-      });
-   }
+      }
+   });
 
-   let clones = background._blurCinnamonWinClones;
-
-   // Sort the windows by least recently interacted with
+   // Sort the windows bye the stacking order (lowest -> highest z-order)
    windowsToClone = global.display.sort_windows_by_stacking(windowsToClone);
 
+   // Remove owner window and all windows above it
+   if (metaWindowOwner) {
+      let idx = windowsToClone.findIndex( (element) => element === metaWindowOwner );
+      if (idx !== -1) {
+         debugMsg( `Removing windowsToClone (${windowsToClone.length}) before index ${idx}` );
+         windowsToClone.splice(idx, Infinity);
+      }
+   }
+
    // Deal with the existing clones
+   let clones = background._blurCinnamonWinClones;
    if (clones.length > 0) {
       // Check if we have any changes to worry about
       if (windowsToClone.length === clones.length) {
@@ -376,18 +514,13 @@ function cloneWindowsForBackground(background, showingDesktop) {
 
       // There are changes to the set of clones needed, so clear all existing clones
       destroyAllWindowsClones(background);
-      if (metaWindowOwner && windowsToClone.length > 0) {
-         // Adding clones immediately after removing all the clones causes bad things for windows
-         // so we do it after all the events are processed. This results an annoying flash when
-         // new windows are added to the clone list.
-         debugMsg( "Creating clones for Background after removing all clones" );
-         Mainloop.idle_add( () => windowsToClone.forEach( (window) => createWindowClone(window, background) ) );
-         return;
-      }
    }
    // Create all the needed clones
-   debugMsg( "Creating clones for Background" );
-   windowsToClone.forEach( (window) => createWindowClone(window, background) );
+   debugMsg( `Creating ${windowsToClone.length} clones for Background of ${background._blurCinnamonName}` );
+   if (metaWindowOwner) {
+      debugMsg( `Window: ${metaWindowOwner.get_title()}/${metaWindowOwner.get_id()}` );
+   }
+   windowsToClone.forEach( (window) => createWindowClone(window, background, desktopOnly) );
 
    return;
 }
@@ -420,32 +553,31 @@ class CloneManager {
    _onShowingDesktopChanged() {
       this.desktop_showing = !this.desktop_showing;
       if (this.desktop_showing) {
-         log( "Showing Desktop" );
-         this._backgrounds.forEach( (background) => destroyAllWindowsClones(background) );
+         this._backgrounds.forEach( (background) => destroyAllNonDesktopClones(background) );
       } else {
-         log( "Showing windows" );
-         this._backgrounds.forEach( (background) => cloneWindowsForBackground(background, this.desktop_showing) );
+         this._backgrounds.forEach( (background) => cloneWindowsForBackground(background, this.desktop_showing, background._blurCinnamonDesktopOnly) );
       }
    }
 
    _onWindowMinimized(metaWindow) {
-      this._onWindowDisappeared(metaWindow)
+      this._onWindowDisappeared(metaWindow);
    }
 
    _onWindowUnminimized(metaWindow) {
       // After unminimizing a window with a blurred background, if the window is dragged off a
       // dynamic blurred panel the window will not get drawn correctly after it's clone is deleted
-      //  from the panels dynamic blur group. This reapplyEffect call is a workaround for this issue.
+      // from the panels dynamic blur group. This reapplyEffect call is a workaround for this issue.
       if (blurApplications) {
          blurApplications.reapplyEffects(metaWindow);
       }
-      this._onWindowAppeared(metaWindow)
+      this._onWindowAppeared(metaWindow);
    }
 
    _uiScaleChanged() {
+      debugMsg( "UI Scale Changed" );
       this._backgrounds.forEach( (background) => destroyAllWindowsClones(background) );
       // Delay creating closes to avoid issues with an instance destroy/create sequence
-      Mainloop.idle_add( () => { this._backgrounds.forEach( (background) => cloneWindowsForBackground(background, this.desktop_showing) ); } );
+      this._backgrounds.forEach( (background) => cloneWindowsForBackground(background, this.desktop_showing, background._blurCinnamonDesktopOnly) );
    }
 
    getBackgroundCount() {
@@ -455,11 +587,26 @@ class CloneManager {
    backgroundClipChanged(background) {
       let idx = this._backgrounds.indexOf(background);
       if (idx!==-1) {
-         cloneWindowsForBackground(this._backgrounds[idx], this.desktop_showing);
+         cloneWindowsForBackground(background, this.desktop_showing, background._blurCinnamonDesktopOnly);
       }
    }
 
-   addBackground(background, metaWindowOwner) {
+   updateArtifactMitigation() {
+      debugMsg( "Update Artifact Mitigation" );
+      this._backgrounds.forEach( (background) => {
+         if (background._blurCinnamonMetaWindowOwner) {
+            background._blurCinnamonWinClones.forEach( (windowClone) => {
+               if (settings.windowArtifactMitigation && !windowClone._paintEventId) {
+                  windowClone._paintEventId = windowClone.connect( "paint", (actor) => clonePainted(background, windowClone));
+               } else if (!settings.windowArtifactMitigation && windowClone._paintEventId) {
+                  windowClone.disconnect( windowClone._paintEventId );
+               }
+            });
+         }
+      });
+   }
+
+   addBackground(background, owner, desktopOnly) {
       let idx = this._backgrounds.indexOf(background);
       if (idx !== -1) {
          debugMsg( `Not adding existing background "${background._blurCinnamonName}"` );
@@ -468,13 +615,20 @@ class CloneManager {
       if (background._blurCinnamonWinClones)
          debugMsg( `Already has clones... length ${background._blurCinnamonWinClones.length}` );
       debugMsg( `Adding background "${background}", children ${background._blurCinnamonGroup.get_n_children()}` );
-      this._backgrounds.push(background);
       background._blurCinnamonWinClones = [];
-      let deskletClone = new Clutter.Clone({source : Main.deskletContainer.actor});
-      background._blurCinnamonGroup.insert_child_below(deskletClone, background._blurCinnamonDimmer);
-      background._blurCinnamonDeskletClone = deskletClone;
-      background._blurCinnamonMetaWindowOwner = metaWindowOwner
-      cloneWindowsForBackground(background, this.desktop_showing);
+      this._backgrounds.push(background);
+      if (owner !== global.desklet_container && (!owner || owner.get_window_type() !== Meta.WindowType.DESKTOP)) {
+         let deskletClone = new Clutter.Clone({source : Main.deskletContainer.actor});
+         background._blurCinnamonGroup.insert_child_below(deskletClone, background._blurCinnamonDimmer);
+         background._blurCinnamonDeskletClone = deskletClone;
+      }
+      if (owner instanceof Meta.Window) {
+         background._blurCinnamonMetaWindowOwner = owner;
+      } else {
+         background._blurCinnamonMetaWindowOwner = null;
+      }
+      background._blurCinnamonDesktopOnly = desktopOnly;
+      cloneWindowsForBackgroundNow(background, this.desktop_showing, background._blurCinnamonDesktopOnly);
       this._signalManager.connect(background, "notify::mapped", () => this._onBackgroundMapped(background));
    }
 
@@ -491,6 +645,8 @@ class CloneManager {
          background._blurCinnamonDeskletClone.destroy();
          delete background._blurCinnamonDeskletClone;
       }
+      delete background._blurCinnamonMetaWindowOwner;
+      delete background._blurCinnamonDesktopOnly;
       this._backgrounds.splice(idx, 1);
       debugMsg( `Removed background for "${background}"/"${background._blurCinnamonName}", group children = ${background._blurCinnamonGroup.get_n_children()}` );
    }
@@ -500,12 +656,37 @@ class CloneManager {
       return (idx!==-1);
    }
 
+   raiseDeskletBackground(background) {
+      debugMsg( "Raising desklet background" );
+      // Hide the desklet container from all backgrounds to avoid an endless loop while painting
+      // The desklets are not under of any backgrounds anymore since it's been raised to the top
+      this._backgrounds.forEach( (background) => {
+         if (background._blurCinnamonDeskletClone) {
+            background._blurCinnamonDeskletClone.hide();
+         }
+      });
+      cloneWindowsForBackground(background, this.desktop_showing, false);
+   }
+
+   lowerDeskletBackground(background) {
+      debugMsg( "Lowering desklet background" );
+      // Show the desklet containter for all backgrounds since the desklets are now lowered again
+      this._backgrounds.forEach( (background) => {
+         if (background._blurCinnamonDeskletClone) {
+            background._blurCinnamonDeskletClone.show();
+         }
+      });
+      // We need to immediately remove clones of window for the desklet background to avoid SOF during painting
+      cloneWindowsForBackgroundNow(background, this.desktop_showing, background._blurCinnamonDesktopOnly);
+   }
+
    _onBackgroundMapped(background) {
       debugMsg( `Background ${(background.mapped)?"mapped":"unmapped"} for ${background._blurCinnamonName}` );
       if (background.mapped === true) {
-         cloneWindowsForBackground(background, this.desktop_showing);
+         cloneWindowsForBackground(background, this.desktop_showing, background._blurCinnamonDesktopOnly);
       } else {
-         destroyAllWindowsClones(background);
+         // An unmapped background can still be visible when a clone is shows (i.e Alt-Tab)
+         //destroyAllWindowsClones(background);
       }
    }
 
@@ -558,13 +739,13 @@ class CloneManager {
 
          debugMsg( `Checking if clones are needed for appeared window: "${metaWindow.get_title()}"` );
          this._backgrounds.forEach( (background) => {
-            if (!background._blurCinnamonMetaWindowOwner || background._blurCinnamonMetaWindowOwner.get_user_time() > metaWindow.get_user_time() ) {
+            if (!background._blurCinnamonMetaWindowOwner || metaWindow.get_window_type() === Meta.WindowType.DESKTOP || isAbove(background._blurCinnamonMetaWindowOwner, metaWindow)) {
                let [blurX, blurY, blurWidth, blurHeight] = getBackgroundClip(background);
                let blurX2 = blurX + blurWidth;
                let blurY2 = blurY + blurHeight;
                if ( rectOverlap(winX, winY, winX2, winY2, blurX, blurY, blurX2, blurY2) )
                {
-                  createWindowClone(metaWindow, background)
+                  createWindowClone(metaWindow, background, background._blurCinnamonDesktopOnly)
                }
             }
          });
@@ -584,10 +765,9 @@ class CloneManager {
       // Remove windowClones for this window from each background
       this._backgrounds.forEach( (background) => {
          if (background._blurCinnamonWinClones) {
-            let group = background._blurCinnamonGroup;
             for (let idx=background._blurCinnamonWinClones.length-1 ; idx >=0  ; idx-- ) {
                let windowClone = background._blurCinnamonWinClones[idx];
-               if (windowClone.get_source() === compositor) {
+               if (windowClone._metaWindow === metaWindow) {
                   debugMsg( `Removing clone for disappeared window` );
                   destroyWindowClone(windowClone, background);
                   break;
@@ -599,28 +779,32 @@ class CloneManager {
 
    _onFocusChanged() {
       let window = global.display.get_focus_window();
-      if (!window)
+      if (!window || window.get_window_type() === Meta.WindowType.DESKTOP)
          return;
-      let compositor = window.get_compositor_private();
       this._backgrounds.forEach( (background) => {
          if (background._blurCinnamonMetaWindowOwner === window) {
+            // This background is for the new focused window, we might need to create any number of clones for this background
             debugMsg( "Cloning windows because a blurred window has received the focus" );
-            cloneWindowsForBackground(background, this.desktop_showing);
-         }
-         if (background._blurCinnamonWinClones) {
-            let dimmer = background._blurCinnamonDimmer;
-            let group = background._blurCinnamonGroup;
-            for (let idx=background._blurCinnamonWinClones.length-1 ; idx >=0  ; idx-- ) {
-               let windowClone = background._blurCinnamonWinClones[idx];
-               if (windowClone.get_source() === compositor) {
-                  if (background._blurCinnamonMetaWindowOwner) {
-                     debugMsg( "Removing clone from a window background because it has the focus now" );
-                     destroyWindowClone(windowClone, background);
-                  } else {
-                     debugMsg( "Moving clone to top due to focus change" );
-                     group.set_child_below_sibling(windowClone, dimmer);
+            cloneWindowsForBackground(background, this.desktop_showing, background._blurCinnamonDesktopOnly);
+         } else {
+            if (background._blurCinnamonWinClones) {
+               let dimmer = background._blurCinnamonDimmer;
+               let group = background._blurCinnamonGroup;
+               for (let idx=background._blurCinnamonWinClones.length-1 ; idx >=0  ; idx-- ) {
+                  let windowClone = background._blurCinnamonWinClones[idx];
+                  if (windowClone._metaWindow === window) {
+                     if (background._blurCinnamonMetaWindowOwner) {
+                        // This background is for an application window, the focused window can't be in the background of any other window, so delete this clone
+                        debugMsg( "Removing clone from a window background because the clone's window has the focus now" );
+                        destroyWindowClone(windowClone, background);
+                     } else {
+                        // This background is for a non-window element (i.e panel, notification, tooltip etc), so this clone now needs to be on top of all other clones
+                        debugMsg( "Moving clone to top due to focus change" );
+                        group.set_child_below_sibling(windowClone, dimmer);
+                     }
+                     // There can only be one clone of a window in any given background, so we can break once we find a clone of the focused window
+                     break;
                   }
-                  break;
                }
             }
          }
@@ -634,14 +818,14 @@ class CloneManager {
          this._activeWorkspaceIdx = currentWs;
          // After switching workspace, if a window with a blurred background is dragged off a
          // dynamic blurred panel the window will not get drawn correctly after it's clone is deleted
-         //  from the panels dynamic blur group. This reapplyEffect call is a workaround for this issue.
+         // from the panels dynamic blur group. This reapplyEffect call is a workaround for this issue.
          if (blurApplications) {
             blurApplications.reapplyEffects();
          }
-         // Make sure we are listening for changes to windows on this (And only this) workspace
+         // Make sure we are listening for changes to windows on this (and only this) workspace
          this._setupWindowListeners();
          // Add new clones for windows on the new workspace
-         this._backgrounds.forEach( (background) => cloneWindowsForBackground(background, this.desktop_showing) );
+         this._backgrounds.forEach( (background) => cloneWindowsForBackground(background, this.desktop_showing, background._blurCinnamonDesktopOnly) );
       }
    }
 
@@ -650,17 +834,16 @@ class CloneManager {
    // the window overlap state of the new size/location of a window
    _allocationChanged(metaWindow) {
       let rect = metaWindow.get_buffer_rect();
-      let compositor = metaWindow.get_compositor_private();
       this._backgrounds.forEach( (background) => {
          let [blurX, blurY, blurWidth, blurHeight] = getBackgroundClip(background);
          let blurX2 = blurX + blurWidth;
          let blurY2 = blurY + blurHeight;
          let overlap = rectOverlap(rect.x, rect.y, rect.x+rect.width, rect.y+rect.height, blurX, blurY, blurX+blurWidth, blurY+blurHeight);
-         let underOwner = (!background._blurCinnamonMetaWindowOwner || background._blurCinnamonMetaWindowOwner.get_user_time() > metaWindow.get_user_time() );
+         let underOwner = (!background._blurCinnamonMetaWindowOwner || metaWindow.get_window_type() === Meta.WindowType.DESKTOP || isAbove(background._blurCinnamonMetaWindowOwner, metaWindow));
          let found = false;
          for (let idx=background._blurCinnamonWinClones.length-1 ; idx >= 0 ; idx-- ) {
             let windowClone = background._blurCinnamonWinClones[idx];
-            if (windowClone.get_source() === compositor ) {
+            if (windowClone._metaWindow === metaWindow) {
                found = true;
                if (!overlap || !underOwner) {
                   debugMsg( `Removing unneeded clone` );
@@ -674,7 +857,7 @@ class CloneManager {
          }
          if (!found && overlap && underOwner) {
             debugMsg( `Adding clone on allocation event` );
-            createWindowClone(metaWindow, background)
+            createWindowClone(metaWindow, background, background._blurCinnamonDesktopOnly)
          }
       });
    }
@@ -704,7 +887,7 @@ class BlurBase {
    }
 
    _getGenericSettings() {
-      if (!this._supportsDynamicBlur() && settings.blurType === BlurType.DynamicBlur)
+      if (!this._supportsDynamicBlur() && (settings.blurType === BlurType.DynamicBlur || settings.blurType === BlurType.DynamicMC))
          return [settings.opacity, settings.blendColor, BlurType.Gaussian, settings.radius, settings.saturation];
       return [settings.opacity, settings.blendColor, settings.blurType, settings.radius, settings.saturation];
    }
@@ -740,11 +923,11 @@ class BlurBase {
       return false;
    }
 
-   _createDynamicEffect(background, metaWindowOwner=null) {
+   _createDynamicEffect(background, owner=null, desktopOnly=false) {
       if (!cloneManager) {
          cloneManager = new CloneManager();
       }
-      cloneManager.addBackground(background, metaWindowOwner);
+      cloneManager.addBackground(background, owner, desktopOnly);
    }
 
    _destroyDynamicEffect(background) {
@@ -754,6 +937,18 @@ class BlurBase {
             cloneManager.destroy();
             cloneManager = null;
          }
+      }
+   }
+
+   _raiseDeskletDynamicBackground(background) {
+      if (cloneManager) {
+         cloneManager.raiseDeskletBackground(background);
+      }
+   }
+
+   _lowerDeskletDynamicBackground(background) {
+      if (cloneManager) {
+         cloneManager.lowerDeskletBackground(background);
       }
    }
 
@@ -768,6 +963,8 @@ class BlurBase {
          blurEffect =  new Clutter.BlurEffect();
       else if (blurType === BlurType.Gaussian || blurType === BlurType.DynamicBlur)
          blurEffect = new GaussianBlur.GaussianBlurEffect( {radius: radius, brightness: 1 , width: 0, height: 0} );
+      else // Monte-Carlo
+         blurEffect = new MonteCarloBlur.MonteCarloBlurEffect( { radius: radius, iterations: settings.montecarloIterations, prefer_closer_pixels: settings.montecarloPerferCloserPixels, use_base_pixel: settings.montecarloUseBasePixel, brightness: 1, width: 0, height: 0 } );
       if (saturation<100)
          desatEffect = new Clutter.DesaturateEffect({factor: (100-saturation)/100});
       if (cornerRadius>0)
@@ -782,7 +979,7 @@ class BlurBase {
 
       // Add a dimmer child to the background so we can change the colorization and dimming of the background
       let dimmerColor = this._getColor( blendColor, opacity );
-      let dimmer = new Clutter.Actor({x_expand: true, y_expand: true, width: background.width, height: background.height, background_color: dimmerColor});
+      let dimmer = new Clutter.Actor({width: background.width, height: background.height, background_color: dimmerColor});
       let group = new St.Group({clip_to_allocation: true});
       group.set_size( background.width, background.height);
 
@@ -790,7 +987,12 @@ class BlurBase {
       background.add_child(group);
 
       // If the screen resolution changes we need to change the dimmer actor size to match
-      background.connect("notify::size", () => {dimmer.set_width(background.width); dimmer.set_height(background.height);} );
+      background.connect("notify::size", () => {
+         group.set_width(background.width);
+         group.set_height(background.height);
+         dimmer.set_width(background.width);
+         dimmer.set_height(background.height);
+      });
       background._blurCinnamonDimmer = dimmer;
       background._blurCinnamonGroup = group;
 
@@ -832,7 +1034,6 @@ class BlurBase {
       let dynamicEffectActive = this._isDynamicEffectActive(background);
       // Remove any dynamic blurring if enabled
       if (dynamicEffectActive) {
-         log( "Removing dynamic effect on effects update" );
          this._destroyDynamicEffect(background);
       }
       // Create the background actor and attach the corner & desat effects
@@ -868,6 +1069,12 @@ class BlurBase {
          }
          let blurEffect = new GaussianBlur.GaussianBlurEffect( {radius: radius, brightness: 1, width: 0, height: 0} );
          background.add_effect_with_name( BLUR_EFFECT_NAME, blurEffect );
+      } else if ((blurType === BlurType.MonteCarlo || blurType === BlurType.DynamicMC) && !(curEffect instanceof MonteCarloBlur.MonteCarloBlurEffect)) {
+         if (curEffect) {
+            background.remove_effect(curEffect);
+         }
+         let blurEffect = new MonteCarloBlur.MonteCarloBlurEffect( { radius: radius, iterations: settings.montecarloIterations, prefer_closer_pixels: settings.montecarloPerferCloserPixels, use_base_pixel: settings.montecarloUseBasePixel, brightness: 1, width: 0, height: 0 } );
+         background.add_effect_with_name( BLUR_EFFECT_NAME, blurEffect );
       } else if (blurType === BlurType.Transparent && background instanceof Meta.X11BackgroundActor) {
          if (curEffect) {
             background.remove_effect(curEffect);
@@ -888,8 +1095,14 @@ class BlurBase {
          this.parent.add_actor(background);
       }
       // Adjust the blur effects
-      if (curEffect instanceof GaussianBlur.GaussianBlurEffect && curEffect.radius != radius) {
+      if ((curEffect instanceof GaussianBlur.GaussianBlurEffect || curEffect instanceof MonteCarloBlur.MonteCarloBlurEffect) && curEffect.radius != radius) {
          curEffect.radius = radius;
+      }
+      // If Monte Carlo, update it's settings
+      if (curEffect instanceof MonteCarloBlur.MonteCarloBlurEffect) {
+         curEffect.iterations = settings.montecarloIterations;
+         curEffect.use_base_pixel = settings.montecarloUseBasePixel;
+         curEffect.prefer_closer_pixels = settings.montecarloPerferCloserPixels;
       }
       // Setup/Adjust the desaturation effect
       curEffect = background.get_effect(DESAT_EFFECT_NAME);
@@ -932,7 +1145,9 @@ class BlurBase {
 
    destroy(background) {
       if (background._blurCinnamonDimmer) {
-         background.remove_child(background._blurCinnamonDimmer);
+         background._blurCinnamonGroup.remove_child(background._blurCinnamonDimmer);
+         background._blurCinnamonDimmer.destroy();
+         delete background._blurCinnamonDimmer;
       }
       let effect = this._getCornerEffect(background);
       if (effect)
@@ -954,6 +1169,95 @@ class BlurBase {
       log( `  Border:  ${themeNode.get_border_width(St.Side.LEFT)} ${themeNode.get_border_width(St.Side.RIGHT)} ${themeNode.get_border_width(St.Side.TOP)} ${themeNode.get_border_width(St.Side.BOTTOM)}` );
       log( `  Padding: ${themeNode.get_padding(St.Side.LEFT)} ${themeNode.get_padding(St.Side.RIGHT)} ${themeNode.get_padding(St.Side.TOP)} ${themeNode.get_padding(St.Side.BOTTOM)}` );
       log( `  Margin:  ${margins.left} ${margins.right} ${margins.top} ${margins.bottom}` );
+   }
+}
+
+class BlurClassicSwitcher extends BlurBase {
+   constructor() {
+      super();
+      this._signalManager = new SignalManager.SignalManager(null);
+      blurClassicSwitcherThis = this; // Make "this" available to monkey patched functions
+
+      this.original_show = ClassicSwitcher.ClassicSwitcher.prototype._show;
+      this.original_hide = ClassicSwitcher.ClassicSwitcher.prototype._hide;
+      ClassicSwitcher.ClassicSwitcher.prototype._show = this._show;
+      ClassicSwitcher.ClassicSwitcher.prototype._hide = this._hide;
+   }
+
+   _supportsDynamicBlur() {
+      return true;
+   }
+
+   _getUniqueSettings() {
+      return [settings.appswitcherOpacity, settings.appswitcherBlendColor, settings.appswitcherBlurType, settings.appswitcherRadius, settings.appswitcherSaturation];
+   }
+
+   // Monkey patch function. The 'this' will be for ClassicSwitcher
+   _show(...params) {
+      if (!this._previewEnabled)
+         blurClassicSwitcherThis._showBackground(this);
+      blurClassicSwitcherThis.original_show.call(this, ...params);
+      if (!this._previewEnabled)
+         blurClassicSwitcherThis._setClip(this._appList.actor)
+   }
+
+   _showBackground(switcher) {
+      let actor = switcher._appList.actor;
+      if (actor) {
+         actor.set_style( "background-gradient-direction: vertical; background-gradient-start: transparent; " +
+                          "background-gradient-end: transparent; background: transparent;" );
+
+         // Create the effects and the background actor to apply to effects to
+         let [opacity, blendColor, blurType, radius, saturation] = this._getSettings(settings.notificationOverride);
+         this._blurType = blurType
+         this._background = this._createBackgroundAndEffects(opacity, blendColor, blurType, radius, saturation, global.overlay_group, 10);
+         this._background._blurCinnamonName = "ClassicSwitcher";
+
+         // If Dynamic Blurring is enabled, create a workspace clone and add the clone to the background
+         if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) {
+            debugMsg( "Creating dynamic effect for classic app switcher" );
+            this._createDynamicEffect(this._background);
+         }
+         let themeNode = actor.get_theme_node();
+         if (themeNode) {
+            // We are assuming that all corners have the same radius, hope that is true.
+            let radius = themeNode.get_border_radius(St.Corner.TOPLEFT);
+            this._updateCornerRadius(this._background, (radius+6)/global.ui_scale);
+         }
+         this._signalManager.connect(actor, "notify::allocation", () => this._setClip(actor) );
+
+         this._background.show();
+         this._setClip(actor)
+      }
+   }
+
+   // Monkey patch function. The 'this' will be for ClassicSwitcher
+   _hide(...params) {
+      if (!this._previewEnabled) {
+         blurClassicSwitcherThis._hideBackground.call(blurClassicSwitcherThis);
+      }
+      blurClassicSwitcherThis.original_hide.call(this, ...params);
+   }
+
+   _hideBackground() {
+      if (this._blurType === BlurType.DynamicBlur || this._blurType === BlurType.DynamicMC) {
+         debugMsg( "Removing dynamic effect for classic app switcher" );
+         this._destroyDynamicEffect(this._background);
+      }
+
+      global.overlay_group.remove_actor(this._background);
+      super.destroy(this._background);
+      this._background.destroy();
+   }
+
+   destroy() {
+      ClassicSwitcher.ClassicSwitcher.prototype._show = this.original_show;
+      ClassicSwitcher.ClassicSwitcher.prototype._hide = this.original_hide;
+      if (this._background) {
+         global.overlay_group.remove_actor(this._background);
+         super.destroy(this._background);
+         this._background.destroy();
+      }
    }
 }
 
@@ -1275,7 +1579,7 @@ class BlurPanels extends BlurBase {
       blurredPanel.background = background;
       this._setClip(panel);
 
-      if (blurType === BlurType.DynamicBlur) {
+      if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) {
          this._createDynamicEffect(background);
       }
 
@@ -1371,6 +1675,8 @@ class BlurPanels extends BlurBase {
                global.overlay_group.remove_actor(blurredPanel.background);
                blurredPanel.background.destroy();
             }
+            if (blurredPanel.signalManager)
+               blurredPanel.signalManager.disconnectAllSignals()
             // Find the index of this panels this._blurredPanels entry then remove the entry
             for ( let i=0 ; i < this._blurredPanels.length ; i++ ) {
                if (this._blurredPanels[i].panel === panel) {
@@ -1428,7 +1734,7 @@ class BlurPanels extends BlurBase {
                } else {
                   this._blurPanel(panels[i]);
                }
-               if (blurType === BlurType.DynamicBlur && !this._isDynamicEffectActive(blurredPanel.background)) {
+               if ((blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) && !this._isDynamicEffectActive(blurredPanel.background)) {
                   this._createDynamicEffect(blurredPanel.background);
                }
             } else if (panels[i].__blurredPanel) {
@@ -1522,7 +1828,7 @@ class BlurPopupMenus extends BlurBase {
       this._cornerEffect = this._getCornerEffect(this._background);
 
       // Setup the popup menu accent color
-      let accentOpacity = (settings.popupOverride) ? settings.popupAccentOpacity : Math.min(opacity+10, 100);
+      let accentOpacity = settings.popupAccentOpacity;
       this._accentColor = this._getColor( blendColor, accentOpacity );
 
       this._changeCount = 0;
@@ -1664,7 +1970,7 @@ class BlurPopupMenus extends BlurBase {
          debugMsg( "Blurred actor is now visible" );
 
          // If Dynamic Blurring is enabled, create window clones and add them to the background
-         if (blurType === BlurType.DynamicBlur) {
+         if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) {
             this._createDynamicEffect(this._background);
          }
 
@@ -1828,7 +2134,7 @@ class BlurPopupMenus extends BlurBase {
       this._changeCount++;
 
       let [opacity, blendColor, blurType, radius, saturation] = this._getSettings(settings.popupOverride);
-      let accentOpacity = (settings.popupOverride) ? settings.popupAccentOpacity : Math.min(opacity+10, 100);
+      let accentOpacity = settings.popupAccentOpacity;
 
       this._background = this._updateEffects(this._background, opacity, blendColor, blurType, radius, saturation);
       //this._setClip(this._currentMenu);
@@ -1837,7 +2143,7 @@ class BlurPopupMenus extends BlurBase {
       // Update the accent dimming color
       this._accentColor = this._getColor( blendColor, accentOpacity );
 
-      if (blurType === BlurType.DynamicBlur && !this._isDynamicEffectActive(this._background)) {
+      if ((blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) && !this._isDynamicEffectActive(this._background)) {
          this._createDynamicEffect(this._background);
       }
 
@@ -1889,13 +2195,15 @@ class BlurDesktop extends BlurBase {
          this._blurEffect = new Clutter.BlurEffect();
       else if (blurType === BlurType.Gaussian)
          this._blurEffect = new GaussianBlur.GaussianBlurEffect( {radius: radius, brightness: 1, width: 0, height: 0} );
+      else if (blurType === BlurType.MonteCarlo)
+         this._blurEffect = new MonteCarloBlur.MonteCarloBlurEffect( { radius: radius, iterations: settings.montecarloIterations, prefer_closer_pixels: settings.montecarloPerferCloserPixels, use_base_pixel: settings.montecarloUseBasePixel, brightness: 1, width: 0, height: 0 } );
       this._desatEffect = new Clutter.DesaturateEffect({factor: (100-saturation)/100});
       if (this._blurEffect)
          global.background_actor.add_effect_with_name( BLUR_EFFECT_NAME, this._blurEffect );
       global.background_actor.add_effect_with_name( DESAT_EFFECT_NAME, this._desatEffect );
       // Add a dimmer child to the background so we can change the colorization and dimming of the background
       let dimmerColor = this._getColor( blendColor, opacity );
-      this._dimmer = new Clutter.Actor({x_expand: true, y_expand: true, width: global.background_actor.width, height: global.background_actor.height, background_color: dimmerColor});
+      this._dimmer = new Clutter.Actor({x_expand: true, y_expand: true, width: global.screen_width, height: global.screen_height, background_color: dimmerColor});
       global.background_actor.add_child(this._dimmer);
       this.updateEffects();
    }
@@ -1917,7 +2225,8 @@ class BlurDesktop extends BlurBase {
          this._signalManager.disconnectAllSignals();
          this._connected = false
       } else if(!this._connected && settings.desktopWithoutFocus) {
-         this._signalManager.connect(global.display, "notify::focus-window", this._onFocusChanged, this);
+         this._signalManager.connect(global.display, "notify::focus-window", () => this._onFocusChanged());
+         this._signalManager.connect(Main.layoutManager, "monitors-changed", () => this._monitorsChanged());
          this._connected = true;
       }
       let curEffect = global.background_actor.get_effect(BLUR_EFFECT_NAME);
@@ -1935,12 +2244,24 @@ class BlurDesktop extends BlurBase {
          }
          this._blurEffect = new GaussianBlur.GaussianBlurEffect( {radius: radius, brightness: 1, width: 0, height: 0} );
          global.background_actor.add_effect_with_name( BLUR_EFFECT_NAME, this._blurEffect );
+      } else if (blurType === BlurType.MonteCarlo && !(this._blurEffect instanceof MonteCarloBlur.MonteCarloBlurEffect)) {
+         if (curEffect) {
+            global.background_actor.remove_effect(curEffect);
+         }
+         this._blurEffect = new MonteCarloBlur.MonteCarloBlurEffect( { radius: radius, iterations: settings.montecarloIterations, prefer_closer_pixels: settings.montecarloPerferCloserPixels, use_base_pixel: settings.montecarloUseBasePixel, brightness: 1, width: 0, height: 0 } );
+         global.background_actor.add_effect_with_name( BLUR_EFFECT_NAME, this._blurEffect );
       } else if (blurType !== BlurType.None && curEffect === null) {
          global.background_actor.add_effect_with_name( BLUR_EFFECT_NAME, this._blurEffect );
       }
       // Adjust the effects
-      if (this._blurEffect instanceof GaussianBlur.GaussianBlurEffect && this._blurEffect.radius != radius) {
+      if ((this._blurEffect instanceof GaussianBlur.GaussianBlurEffect || this._blurEffect instanceof MonteCarloBlur.MonteCarloBlurEffect) && this._blurEffect.radius != radius) {
          this._blurEffect.radius = radius;
+      }
+      // If Monte Carlo, update it's settings
+      if (this._blurEffect instanceof MonteCarloBlur.MonteCarloBlurEffect) {
+         this._blurEffect.iterations = settings.montecarloIterations;
+         this._blurEffect.use_base_pixel = settings.montecarloUseBasePixel;
+         this._blurEffect.prefer_closer_pixels = settings.montecarloPerferCloserPixels;
       }
       if (this._desatEffect.factor !== (100-saturation)/100) {
          this._desatEffect.set_factor((100-saturation)/100);
@@ -1955,7 +2276,7 @@ class BlurDesktop extends BlurBase {
    _onFocusChanged(){
       let window = global.display.get_focus_window();
       if (!window || window.get_window_type() === Meta.WindowType.DESKTOP) {
-         if (this._blurEffect instanceof GaussianBlur.GaussianBlurEffect && this._blurEffect.radius != this._withFocusSettings.radius)
+         if ((this._blurEffect instanceof GaussianBlur.GaussianBlurEffect || this._blurEffect instanceof MonteCarloBlur.MonteCarloBlurEffect) && this._blurEffect.radius != this._withFocusSettings.radius)
             this._blurEffect.radius = this._withFocusSettings.radius;
          let dimmerColor = this._getColor( this._withFocusSettings.blendColor, this._withFocusSettings.opacity );
          this._dimmer.set_background_color(dimmerColor);
@@ -1965,7 +2286,7 @@ class BlurDesktop extends BlurBase {
          return;
       }
       if (this._currentlyWithFocus) {
-         if (this._blurEffect instanceof GaussianBlur.GaussianBlurEffect && this._blurEffect.radius != this._withoutFocusSettings.radius)
+         if ((this._blurEffect instanceof GaussianBlur.GaussianBlurEffect || this._blurEffect instanceof MonteCarloBlur.MonteCarloBlurEffect) && this._blurEffect.radius != this._withoutFocusSettings.radius)
             this._blurEffect.radius = this._withoutFocusSettings.radius;
          let dimmerColor = this._getColor( this._withoutFocusSettings.blendColor, this._withoutFocusSettings.opacity );
          this._dimmer.set_background_color(dimmerColor);
@@ -1973,6 +2294,12 @@ class BlurDesktop extends BlurBase {
             this._desatEffect.set_factor((100-this._withoutFocusSettings.saturation)/100);
          this._currentlyWithFocus = false;
       }
+   }
+
+   _monitorsChanged() {
+      debugMsg( `Monitor Changed: Scale ${global.ui_scale}, Width,Height ${global.screen_width},${global.screen_height}` );
+      this._dimmer.set_width(global.screen_width);
+      this._dimmer.set_height(global.screen_height);
    }
 
    destroy() {
@@ -2038,15 +2365,20 @@ class BlurNotifications extends BlurBase {
             let radius = themeNode.get_border_radius(St.Corner.TOPLEFT);
             this._updateCornerRadius(this._background, (radius+6)/global.ui_scale);
          }
-
-         actor.set_style( /*"border-radius: 0px;*/ "background-gradient-direction: vertical; background-gradient-start: transparent; " +
-                          "background-gradient-end: transparent; background: transparent;" );
-         button.set_style( /*"border-radius: 0px;*/ "background-gradient-direction: vertical; background-gradient-start: transparent; " +
-                          "background-gradient-end: transparent; background: transparent;" );
-         table.set_style( /*"border-radius: 0px;*/ "background-gradient-direction: vertical; background-gradient-start: transparent; " +
-                          "background-gradient-end: transparent; background: transparent;" );
+         if (settings.allowTransparentColorNotifications) {
+            actor.set_style( /*"border-radius: 0px;*/ "background-gradient-direction: vertical; background-gradient-start: transparent; " +
+                             "background-gradient-end: transparent; background: transparent;" );
+            button.set_style( /*"border-radius: 0px;*/ "background-gradient-direction: vertical; background-gradient-start: transparent; " +
+                             "background-gradient-end: transparent; background: transparent;" );
+            table.set_style( /*"border-radius: 0px;*/ "background-gradient-direction: vertical; background-gradient-start: transparent; " +
+                             "background-gradient-end: transparent; background: transparent;" );
+         } else {
+            actor.set_style( this._activeNotificationData.original_actor_style );
+            button.set_style( this._activeNotificationData.original_button_style );
+            table.set_style( this._activeNotificationData.original_table_style );
+         }
          this._setClip(actor, table);
-         if (this._blurType === BlurType.DynamicBlur && !this._isDynamicEffectActive(this._background)) {
+         if ((this._blurType === BlurType.DynamicBlur || this._blurType === BlurType.DynamicMC) && !this._isDynamicEffectActive(this._background)) {
             this._createDynamicEffect(this._background);
          }
       } else {
@@ -2075,17 +2407,16 @@ class BlurNotifications extends BlurBase {
 
 
       if (actor.visible) {
-         if (settings.allowTransparentColorPanels) {
+         let themeNode = table.get_theme_node();
+         if (themeNode) {
+            // We are assuming that all corners have the same radius, hope that is true.
+            let radius = themeNode.get_border_radius(St.Corner.TOPLEFT);
+            this._updateCornerRadius(this._background, (radius+6)/global.ui_scale);
+         }
+         if (settings.allowTransparentColorNotifications) {
             // Save the current settings so we can restore it if need be.
-            this._activeNotificationData = {actor: actor, original_table_color: table.get_background_color(), original_actor_style: actor.get_style(),
+            this._activeNotificationData = {actor: actor, original_actor_style: actor.get_style(),
                                             original_button_style: button.get_style(), original_table_style: table.get_style()};
-
-            let themeNode = table.get_theme_node();
-            if (themeNode) {
-               // We are assuming that all corners have the same radius, hope that is true.
-               let radius = themeNode.get_border_radius(St.Corner.TOPLEFT);
-               this._updateCornerRadius(this._background, (radius+6)/global.ui_scale);
-            }
 
             actor.set_style( /*"border-radius: 0px;*/ "background-gradient-direction: vertical; background-gradient-start: transparent; " +
                              "background-gradient-end: transparent; background: transparent;" );
@@ -2098,7 +2429,7 @@ class BlurNotifications extends BlurBase {
       // Resize the background to match the size of the notification window
       this._setClip(actor, table);
       // If Dynamic Blurring is enabled, create a workspace clone and add the clone to the background
-      if (this._blurType === BlurType.DynamicBlur) {
+      if (this._blurType === BlurType.DynamicBlur || this._blurType === BlurType.DynamicMC) {
          this._createDynamicEffect(this._background);
       }
       // The notification window size can change after being shown, so we need to adjust the background when that happens
@@ -2138,7 +2469,6 @@ class BlurNotifications extends BlurBase {
          let actor = this._activeNotificationData.actor;
          let button = actor.get_child();
          let table = button.get_child();
-         table.set_background_color( this._activeNotificationData.original_table_color );
          actor.set_style( this._activeNotificationData.original_actor_style );
          button.set_style( this._activeNotificationData.original_button_style );
          table.set_style( this._activeNotificationData.original_table_style );
@@ -2194,15 +2524,17 @@ class BlurTooltips extends BlurBase {
          this._updateCornerRadius(this._background, (radius+6)/global.ui_scale);
       }
 
-      actor.set_style(  "background-gradient-direction: vertical; background-gradient-start: transparent; " +
-                        "background-gradient-end: transparent;    background: transparent;"  );
+      if (settings.allowTransparentColorTooltips) {
+         actor.set_style(  "background-gradient-direction: vertical; background-gradient-start: transparent; " +
+                           "background-gradient-end: transparent;    background: transparent;"  );
+      }
       // Track the showing tooltip actor so we know which hide call to react to
       this._tooltipActor = actor;
       // Clip the background subtracting the actors margins since in some cases not doing so makes the background too large
       this._setClip(actor, actor);
       this._background.show();
       // If Dynamic Blurring is enabled, create a workspace clone and add the clone to the background
-      if (blurType === BlurType.DynamicBlur && !this._isDynamicEffectActive(this._background)) {
+      if ((blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) && !this._isDynamicEffectActive(this._background)) {
          this._createDynamicEffect(this._background);
       }
       // Adapt to any future tooltip size changes
@@ -2275,18 +2607,12 @@ class BlurApplications extends BlurBase {
       // Check existing windows to see if any need to be blurred
       let windows = global.display.list_windows(0);
       for (let i = 0; i < windows.length; i++) {
-         if (this._windowShouldBeBlurred(windows[i])) {
-            this._blurWindow(windows[i]);
-         }
+         this._blurWindow(windows[i]);
       }
    }
 
    _supportsDynamicBlur() {
-      // Since support for Dynamic blur for Application windows is "experimental", we return false here.
-      // It's used to choose between static and dynamic when the generic setting is set to dynamic
-      // so by returning false, the default will be Gaussian static when dynamic is selected.
-      // The only way to enable dynamic is to use custom settings for the specific window!
-      return false;
+      return true;
    }
 
    _onWindowGrabbed(display, screen, window, op) {
@@ -2314,66 +2640,51 @@ class BlurApplications extends BlurBase {
    }
 
    _windowAdded(workspace, metaWindow) {
-      if (this._windowShouldBeBlurred(metaWindow)) {
-         this._blurWindow(metaWindow);
-      }
-   }
-
-   _windowShouldBeBlurred(metaWindow) {
-      let winType = metaWindow.get_window_type();
-      if (winType !== Meta.WindowType.NORMAL && winType !== Meta.WindowType.DOCK && winType !== Meta.WindowType.DESKTOP)
-         return false;
-      let app = this._getAppForWindow(metaWindow);
-      let appId = app ? app.get_id() : null;
-      let wmclass = metaWindow.get_wm_class();
-      let winSettings = settings.windowInclusionList.find( (element) => {if (element.enabled && (element.application == appId || element.application == wmclass)) {return true;}} );
-      if (!winSettings) {
-         winSettings = settings.windowInclusionList.find( (element) => {if (element.application == _("Default window settings")) {return true;}} );
-      }
-      if (winSettings) {
-         return winSettings.enabled;
-      }
-      return false;
+      this._blurWindow(metaWindow);
    }
 
    _blurWindow(metaWindow) {
-      // A signal manager for this window
-      let signalManager = new SignalManager.SignalManager(null);
-
       // Get the windows compositor actor
       let compositor = metaWindow.get_compositor_private();
 
       // Get the effect setting that should apply to Application windows
       let [enabled, window_opacity, opacity, blendColor, blurType, radius, saturation, corner_radius, top, bottom] = this._getSettings(metaWindow);
+      if (enabled) {
+         // A signal manager for this window
+         let signalManager = new SignalManager.SignalManager(null);
 
-      // Setup the window opacity
-      if (!window_opacity || window_opacity < 10 || window_opacity > 100 )
-         window_opacity = 100;
-      metaWindow.set_opacity(window_opacity*2.55);
+         // Setup the window opacity
+         if (!window_opacity || window_opacity < 10 || window_opacity > 100 )
+            window_opacity = 100;
+         metaWindow.set_opacity(window_opacity*2.55);
 
-      // Create the effect and add it to the window
-      let background = this._createBackgroundAndEffects(opacity, blendColor, blurType, radius, saturation, null, corner_radius, top, bottom);
-      background._blurCinnamonName = "Window";
-      compositor.insert_child_at_index(background, 0);
+         // Create the effect and add it to the window
+         let background = this._createBackgroundAndEffects(opacity, blendColor, blurType, radius, saturation, null, corner_radius, top, bottom);
+         background._blurCinnamonName = "Window";
+         compositor.insert_child_at_index(background, 0);
 
-      // Add blur data to the compositor while blurring is in effect
-      compositor._blurCinnamonDataWindow = { effectThis: this, background: background, metaWindow: metaWindow, signalManager: signalManager };
+         // Add blur data to the compositor while blurring is in effect
+         compositor._blurCinnamonDataWindow = { effectThis: this, background: background, metaWindow: metaWindow, signalManager: signalManager };
 
-      // Add listeners for this window's compositor
-      //signalManager.connect(metaWindow, "notify::maximized-horizontally", () => this._maximized(metaWindow) );
-      //signalManager.connect(metaWindow, "notify::maximized-vertically ",  () => this._maximized(metaWindow) );
-      //signalManager.connect(metaWindow, "unmanaged"/*"unmanaging"*/, () => this._unblurWindow(compositor) );
-      signalManager.connect(compositor, "destroy", () => this._unblurWindow(compositor) );
-      signalManager.connect(compositor, "notify::allocation", () => this._setClip(compositor) );
-      //signalManager.connect(metaWindow, "notify::maximized-horizontally", () => this._setClip(compositor) );
-      //signalManager.connect(metaWindow, "notify::maximized-vertically", () => this._setClip(compositor) );
+         // Add listeners for this window's compositor
+         //signalManager.connect(metaWindow, "notify::maximized-horizontally", () => this._maximized(metaWindow) );
+         //signalManager.connect(metaWindow, "notify::maximized-vertically ",  () => this._maximized(metaWindow) );
+         //signalManager.connect(metaWindow, "unmanaged"/*"unmanaging"*/, () => this._unblurWindow(compositor) );
+         signalManager.connect(compositor, "destroy", () => this._unblurWindow(compositor) );
+         signalManager.connect(compositor, "notify::allocation", () => this._setClip(compositor) );
+         // Some windows are positioned after their first allocation, so keep the blur aligned
+         // when either the compositor actor or the MetaWindow reports a position update.
+         signalManager.connect(metaWindow, "position-changed", () => this._setClip(compositor) );
+         //signalManager.connect(metaWindow, "notify::maximized-horizontally", () => this._setClip(compositor) );
+         //signalManager.connect(metaWindow, "notify::maximized-vertically", () => this._setClip(compositor) );
 
-      // Resize / reposition the blurred actor
-      this._setClip(compositor);
-      // Make the background visible
-      background.show();
-      if (blurType === BlurType.DynamicBlur) {
-         this._createDynamicEffect(background, metaWindow);
+         // Resize / reposition the blurred actor
+         this._setClip(compositor);
+         // Make the background visible
+         background.show();
+         if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) {
+            this._createDynamicEffect(background, metaWindow);
+         }
       }
    }
 
@@ -2391,18 +2702,22 @@ class BlurApplications extends BlurBase {
 
    // Get the window specific effect settings, or a disabled set of value when no settings exist
    _getSettings(metaWindow) {
-      let app = this._getAppForWindow(metaWindow);
-      let appId = app ? app.get_id() : null;
       let wmclass = metaWindow.get_wm_class();
-      let element = settings.windowInclusionList.find( (element) => {if (element.application == appId || element.application == wmclass) {return true;}} );
-      if (!element) {
-         element = settings.windowInclusionList.find( (element) => {if (element.application == _("Default window settings")) {return true;}} );
-      }
-      if (element) {
-         if (element.override) {
-            return [element.enabled, element.window_opacity, element.opacity, element.color, element.blurtype, element.radius, element.saturation, element.corner_radius, element.corner_top, element.corner_bottom];
+      let winType = metaWindow.get_window_type();
+      // We want to allow blurring for normal window, docks (i.e Plank) and desktop windows (i.e Conky)
+      if ((winType === Meta.WindowType.NORMAL || winType === Meta.WindowType.DOCK || winType === Meta.WindowType.DESKTOP) && wmclass !== "Nemo-desktop") {
+         let app = this._getAppForWindow(metaWindow);
+         let appId = app ? app.get_id() : null;
+         let element = settings.windowInclusionList.find( (element) => {if (element.application == appId || element.application == wmclass) {return true;}} );
+         if (!element) {
+            element = settings.windowInclusionList.find( (element) => {if (element.application == _("Default window settings")) {return true;}} );
          }
-         return [element.enabled, element.window_opacity, ...super._getSettings(false), element.corner_radius, element.corner_top, element.corner_bottom ];
+         if (element) {
+            if (element.override) {
+               return [element.enabled, element.window_opacity, element.opacity, element.color, element.blurtype, element.radius, element.saturation, element.corner_radius, element.corner_top, element.corner_bottom];
+            }
+            return [element.enabled, element.window_opacity, ...super._getSettings(false), element.corner_radius, element.corner_top, element.corner_bottom ];
+         }
       }
       return [false, 100, 0, undefined, BlurType.None, 0, 100, 0, false, false]
    }
@@ -2424,9 +2739,14 @@ class BlurApplications extends BlurBase {
          //data.background.set_position( -rect.x+windowShadowSizeX, -rect.y+windowShadowSizeY );
 
          // Set the background position to the displays 0,0 based on it's transformed position and it's current position
-         let [rx,ry] = data.background.get_transformed_position();
-         let [x,y] = data.background.get_position();
-         data.background.set_position( x-rx, y-ry );
+         //let [rx,ry] = data.background.get_transformed_position();
+         //let [x,y] = data.background.get_position();
+         //data.background.set_position( x-rx, y-ry );
+         // The blur background lives inside the window compositor actor, so it must be
+         // offset by the compositor's transformed stage position, not by its own previous
+         // transformed position. Otherwise the blur and the real window can drift apart.
+         let [rx, ry] = compositor.get_transformed_position();
+         data.background.set_position(-rx, -ry);
 
          let cornerEffect = this._getCornerEffect(data.background);
          if (cornerEffect) {
@@ -2443,12 +2763,12 @@ class BlurApplications extends BlurBase {
       if (compositor._blurCinnamonDataWindow) {
          let data = compositor._blurCinnamonDataWindow;
          data.signalManager.disconnectAllSignals();
-         compositor.remove_child(data.background);
+         this._destroyDynamicEffect(data.background);
+         //compositor.remove_child(data.background);
          super.destroy(data.background);
          data.background.destroy();
          data.metaWindow.set_opacity(255);
          compositor._blurCinnamonDataWindow = undefined;
-         this._destroyDynamicEffect(data.background);
       }
    }
 
@@ -2461,7 +2781,7 @@ class BlurApplications extends BlurBase {
          if (data) {
             debugMsg( "Reapplying effects to window" );
             this._unblurWindow(compositor);
-            Mainloop.idle_add( () =>  this._blurWindow(metaWindow) );
+            Mainloop.idle_add( () => this._blurWindow(metaWindow) );
          }
       } else {
          // Go through all windows and remove then reapply effects
@@ -2482,9 +2802,6 @@ class BlurApplications extends BlurBase {
       // Go through all windows and update/apply/remove effects
       let windows = global.display.list_windows(0);
       for (let i = 0; i < windows.length; i++) {
-         let winType = windows[i].get_window_type();
-         if (winType !== Meta.WindowType.NORMAL && winType !== Meta.WindowType.DOCK && winType !== Meta.WindowType.DESKTOP)
-            continue;
          let compositor = windows[i].get_compositor_private();
          let data = compositor._blurCinnamonDataWindow;
          let [enabled, window_opacity, opacity, blendColor, blurType, radius, saturation, corner_radius, top, bottom] = this._getSettings(windows[i]);
@@ -2502,7 +2819,7 @@ class BlurApplications extends BlurBase {
                if (!window_opacity || window_opacity < 10 || window_opacity > 100 )
                   window_opacity = 100;
                windows[i].set_opacity(window_opacity*2.55);
-               if (blurType === BlurType.DynamicBlur && !this._isDynamicEffectActive(data.background)) {
+               if ((blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) && !this._isDynamicEffectActive(data.background)) {
                   this._createDynamicEffect(data.background, data.metaWindow);
                }
             }
@@ -2616,6 +2933,7 @@ class BlurFocusEffect extends BlurBase {
       this._focusedCompositor = window.get_compositor_private();
       this._focusedCompositor.insert_child_at_index(this._background, 0);
       this._signalManager.connect(this._focusedCompositor, "notify::allocation", () => this._setClip() );
+      this._signalManager.connect(window, "position-changed", () => this._setClip() );
       this._signalManager.connect(window, "unmanaging", () => this._removeEffect() );
       this._focusedCompositor._blurCinnamonDataFocusEffect = { effectThis: this };
       this._setClip();
@@ -2626,6 +2944,7 @@ class BlurFocusEffect extends BlurBase {
       this._background.hide();
       if (this._focusedCompositor) {
          this._signalManager.disconnect("notify::allocation", this._focusedCompositor );
+         this._signalManager.disconnect("position-changed", this._focusedWindow );
          this._signalManager.disconnect("unmanaging", this._focusedWindow );
          this._focusedCompositor.remove_child(this._background);
          this._focusedCompositor._blurCinnamonDataFocusEffect = undefined;
@@ -2652,9 +2971,12 @@ class BlurFocusEffect extends BlurBase {
          //data.background.set_position( -rect.x+windowShadowSizeX, -rect.y+windowShadowSizeY );
 
          // Set the background position to the displays 0,0 based on it's transformed position and it's current position
-         let [rx,ry] = this._background.get_transformed_position();
-         let [x,y] = this._background.get_position();
-         this._background.set_position( x-rx, y-ry );
+         //let [rx,ry] = this._background.get_transformed_position();
+         //let [x,y] = this._background.get_position();
+         //this._background.set_position( x-rx, y-ry );
+         // Keep the focus background aligned with the compositor actor in stage coordinates.
+         let [rx, ry] = this._focusedCompositor.get_transformed_position();
+         this._background.set_position(-rx, -ry);
 
          if (this._cornerEffect)
             this._cornerEffect.clip = [rect.x+2, rect.y+2, rect.width-3, rect.height-3];
@@ -2692,6 +3014,11 @@ class BlurDesklets extends BlurBase {
       this.original_unloadDesklet = DeskletManager._unloadDesklet;
       DeskletManager._unloadDesklet = this._unloadDesklet;
 
+      this.origianl_raise = DeskletManager.DeskletContainer.prototype.raise;
+      DeskletManager.DeskletContainer.prototype.raise = this._raise;
+      this.origianl_lower = DeskletManager.DeskletContainer.prototype.lower;
+      DeskletManager.DeskletContainer.prototype.lower = this._lower;
+
       // Make sure all the Desklets are defined in the deskletList
       let desklets = DeskletManager.getDefinitions();
       for (let i=0 ; i<desklets.length ; i++) {
@@ -2699,7 +3026,6 @@ class BlurDesklets extends BlurBase {
          let desklet = desklets[i].desklet;
          if (desklet && uuid) {
             this._addDeskletToList(desklet);
-            this._blurDesklet(desklet);
          }
       }
 
@@ -2710,8 +3036,63 @@ class BlurDesklets extends BlurBase {
             deskletList.splice(i, 1);
          }
       }
+
       // Save desklets-list just in case we removed anything
       settings.settings.setValue("desklets-list", deskletList);
+
+      // See if any desklets need to be blurred now that we have the desklets-list all setup right
+      desklets = DeskletManager.getDefinitions();
+      for (let i=0 ; i<desklets.length ; i++) {
+         let {uuid, desklet_id} = desklets[i];
+         let desklet = desklets[i].desklet;
+         if (desklet && uuid) {
+            this._blurDesklet(desklet);
+         }
+      }
+   }
+
+   _supportsDynamicBlur() {
+      return true;
+   }
+
+   // Monkey patched function to raise the desklets
+   _raise() {
+      blurDeskletsThis.origianl_raise.call(this);
+      blurDeskletsThis._deskletsRaised.call(blurDeskletsThis);
+   }
+
+   _deskletsRaised() {
+      let desklets = DeskletManager.getDefinitions();
+      for (let i=0 ; i<desklets.length ; i++) {
+         let {uuid, desklet_id} = desklets[i];
+         let desklet = desklets[i].desklet;
+         if (desklet._blurCinnamonBackground) {
+            let blurSettings = desklet._blurCinnamonBackground._blurCinnamonSettings;
+            if(blurSettings[3] === BlurType.DynamicBlur || blurSettings[3] === BlurType.DynamicMC) {
+               this._raiseDeskletDynamicBackground(desklet._blurCinnamonBackground);
+            }
+         }
+      }
+   }
+
+   // Monkey patched function to lower the deskelts
+   _lower() {
+      blurDeskletsThis.origianl_lower.call(this);
+      blurDeskletsThis._deskletsLowered.call(blurDeskletsThis);
+   }
+
+   _deskletsLowered() {
+      let desklets = DeskletManager.getDefinitions();
+      for (let i=0 ; i<desklets.length ; i++) {
+         let {uuid, desklet_id} = desklets[i];
+         let desklet = desklets[i].desklet;
+         if (desklet._blurCinnamonBackground) {
+            let blurSettings = desklet._blurCinnamonBackground._blurCinnamonSettings;
+            if(blurSettings[3] === BlurType.DynamicBlur || blurSettings[3] === BlurType.DynamicMC) {
+               this._lowerDeskletDynamicBackground(desklet._blurCinnamonBackground);
+            }
+         }
+      }
    }
 
    _blurDesklet(desklet) {
@@ -2729,17 +3110,22 @@ class BlurDesklets extends BlurBase {
          bottomRadius = themeNode.get_border_radius(St.Corner.BOTTOMLEFT);
          cornerRadius = Math.max(topRadius, bottomRadius);
       }
-      let [enabled, opacity, blendColor, blurType, radius, saturation] = this._getDeskletSettings(desklet);
+      let deskletSettings = this._getDeskletSettings(desklet);
+      let [enabled, opacity, blendColor, blurType, radius, saturation] = deskletSettings;
       if (enabled) {
          let background = this._createBackgroundAndEffects(opacity, blendColor, blurType, radius, saturation, null, cornerRadius, topRadius!==0, bottomRadius!==0);
          global.desklet_container.insert_child_at_index(background, 0);
          background._blurCinnamonName = "Desklet";
          desklet._blurCinnamonBackground = background;
+         background._blurCinnamonSettings = deskletSettings;
          this._setClip(desklet);
          background.show();
          desklet._blurCinnamonSignalManager = new SignalManager.SignalManager(null);
          desklet._blurCinnamonSignalManager.connect(desklet.actor, "notify::allocation", () => this._setClip(desklet) );
          //desklet._blurCinnamonSignalManager.connect(desklet, "destroy", () => this._deskletRemoved(desklet) );
+         if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) {
+            this._createDynamicEffect(background, global.desklet_container, true);
+         }
       }
    }
 
@@ -2804,15 +3190,24 @@ class BlurDesklets extends BlurBase {
          let desklet =  DeskletManager.get_object_for_instance(element.instance);
          if (desklet) {
             //log( `Updating ${desklet.metadata.name} / ${desklet._uuid} / ${desklet.instance_id} / ${(desklet._blurCinnamonBackground!==undefined)}` );
-            let [enabled, opacity, blendColor, blurType, radius, saturation] = this._getDeskletSettings(desklet);
-            if (desklet._blurCinnamonBackground) {
-               if (enabled) {
-                  this._updateEffects( desklet._blurCinnamonBackground, opacity, blendColor, blurType, radius, saturation );
-               } else {
-                  this._deskletDestroy(desklet);
+            let deskletSettings = this._getDeskletSettings(desklet);
+            // If desklet was never blurred in the past, or any of the desklets blur settings have changed
+            if (!desklet._blurCinnamonBackground || !deskletSettings.every( (e, i) => e == desklet._blurCinnamonBackground._blurCinnamonSettings[i] )) {
+               let [enabled, opacity, blendColor, blurType, radius, saturation] = deskletSettings;
+               if (desklet._blurCinnamonBackground) {
+                  if (enabled) {
+                     this._updateEffects( desklet._blurCinnamonBackground, opacity, blendColor, blurType, radius, saturation );
+                     desklet._blurCinnamonBackground._blurCinnamonSettings = deskletSettings;
+                     if ((blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) && !this._isDynamicEffectActive(desklet._blurCinnamonBackground)) {
+                        this._createDynamicEffect(desklet._blurCinnamonBackground, global.desklet_container, true);
+                     }
+                  } else {
+                     this._deskletDestroy(desklet);
+                  }
+               } else if (enabled) {
+                  this._blurDesklet(desklet)
+                  desklet._blurCinnamonBackground._blurCinnamonSettings = deskletSettings;
                }
-            } else if (enabled) {
-               this._blurDesklet(desklet)
             }
          }
       });
@@ -2847,6 +3242,7 @@ class BlurDesklets extends BlurBase {
          delete desklet._blurCinnamonSignalManager;
       }
       if (desklet._blurCinnamonBackground) {
+         this._destroyDynamicEffect(desklet._blurCinnamonBackground);
          desklet._blurCinnamonBackground.hide();
          global.bottom_window_group.remove_actor(desklet._blurCinnamonBackground);
          desklet._blurCinnamonBackground.destroy();
@@ -2870,6 +3266,9 @@ class BlurDesklets extends BlurBase {
       }
       DeskletManager._createDesklets = this.original_createDesklets;
       DeskletManager._unloadDesklet = this.original_unloadDesklet;
+
+      DeskletManager.DeskletContainer.prototype.raise = this.origianl_raise;
+      DeskletManager.DeskletContainer.prototype.lower = this.origianl_lower;
    }
 }
 
@@ -2882,6 +3281,10 @@ class BlurSettings {
       this.bind('radius',     'radius',     blurChanged);
       this.bind('blendColor', 'blendColor', colorChanged);
       this.bind('saturation', 'saturation', saturationChanged);
+
+      this.bind('monte-carlo-iterations', 'montecarloIterations', blurChanged);
+      this.bind('monte-carlo-use-base-pixel', 'montecarloUseBasePixel', blurChanged);
+      this.bind('monte-carlo-prefer-closer-pixels', 'montecarloPerferCloserPixels', blurChanged);
 
       this.bind('overview-opacity',    'overviewOpacity');
       this.bind('overview-blurType',   'overviewBlurType');
@@ -2927,18 +3330,23 @@ class BlurSettings {
       this.bind('notification-radius',     'notificationRadius',     updateNotificationEffects);
       this.bind('notification-blendColor', 'notificationBlendColor', updateNotificationEffects);
       this.bind('notification-saturation', 'notificationSaturation', updateNotificationEffects);
+      this.bind('allow-transparent-color-notifications', 'allowTransparentColorNotifications', updateNotificationEffects);
 
       this.bind('appswitcher-opacity',    'appswitcherOpacity');
       this.bind('appswitcher-blurType',   'appswitcherBlurType');
       this.bind('appswitcher-radius',     'appswitcherRadius');
       this.bind('appswitcher-blendColor', 'appswitcherBlendColor');
       this.bind('appswitcher-saturation', 'appswitcherSaturation');
+      this.bind('appswitcher-disable-3d-panels', 'appswitcherDisablePanels');
+      this.bind('appswitcher-allow-classic',     'appswitcherAllowClassic', enableClassicSwitcherChecked);
+      this.bind('appswitcher-allow-3d',          'appswitcherAllow3D');
 
       this.bind('tooltips-opacity',    'tooltipOpacity');
       this.bind('tooltips-blurType',   'tooltipBlurType');
       this.bind('tooltips-radius',     'tooltipRadius');
       this.bind('tooltips-blendColor', 'tooltipBlendColor');
       this.bind('tooltips-saturation', 'tooltipSaturation');
+      this.bind('allow-transparent-color-tooltips', 'allowTransparentColorTooltips');
 
       this.bind('desklets-opacity',    'deskletsOpacity',    updateDeskletEffects);
       this.bind('desklets-blurType',   'deskletsBlurType',   updateDeskletEffects);
@@ -2952,6 +3360,7 @@ class BlurSettings {
       this.bind('enable-desklets-unique-settings', 'enableDeskletsUniqueSettings', updateDeskletEffects);
 
       this.bind('windows-inclusion-list', 'windowInclusionList', updateWindowEffects);
+      this.bind('windows-atrifact-mitigation', 'windowArtifactMitigation', updateArtifactMitigation);
 
       this.bind('focused-window-backlight', 'focusedWindowEffect', updateFocusedWindowEffect);
 
@@ -2963,7 +3372,7 @@ class BlurSettings {
       this.bind('enable-notification-override', 'notificationOverride', updateNotificationEffects);
       this.bind('enable-appswitcher-override',  'appswitcherOverride');
       this.bind('enable-tooltips-override',     'tooltipsOverride');
-      this.bind('enable-desklets-override',     'deskletsOverride');
+      this.bind('enable-desklets-override',     'deskletsOverride', updateDeskletEffects);
 
       this.bind('enable-overview-effects',      'enableOverviewEffects', enableOverviewChanged);
       this.bind('enable-expo-effects',          'enableExpoEffects',     enableExpoChanged);
@@ -2971,7 +3380,7 @@ class BlurSettings {
       this.bind('enable-popup-effects',         'enablePopupEffects',    enablePopupChanged);
       this.bind('enable-desktop-effects',       'enableDesktopEffects',  enableDesktopChanged);
       this.bind('enable-notification-effects',  'enableNotificationEffects', enableNotificationChanged);
-      this.bind('enable-appswitcher-effects',   'enableAppswitcherEffects', enableAppswitcherChanged);
+      this.bind('enable-appswitcher-effects',   'enableAppswitcherEffects');
       this.bind('enable-tooltips-effects',      'enableTooltipEffects',  enableTooltipsChanged);
       this.bind('enable-window-effects',        'enableWindowEffects',  enableWindowChanged);
       this.bind('enable-desklet-effects',       'enableDeskletEffects',  enableDeskletChanged);
@@ -3000,7 +3409,7 @@ class BlurSettings {
    }
 
    destroy() {
-      this._signalManager .disconnectAllSignals();
+      this._signalManager.disconnectAllSignals();
       this.settings.finalize();
    }
 }
@@ -3035,6 +3444,12 @@ function updateDeskletEffects() {
 function updateWindowEffects() {
    if (blurApplications && settings.enableWindowEffects) {
       blurApplications.updateEffects();
+   }
+}
+
+function updateArtifactMitigation() {
+   if (cloneManager) {
+      cloneManager.updateArtifactMitigation();
    }
 }
 
@@ -3129,7 +3544,7 @@ function enableOverviewChanged() {
    if (settings.enableOverviewEffects) {
       Overview.Overview.prototype._animateVisible = _animateVisibleOverview;
       Overview.Overview.prototype._oldAnimateVisible = originalAnimateOverview;
-   } else {
+   } else if (Overview.Overview.prototype._oldAnimateVisible) {
       delete Overview.Overview.prototype._oldAnimateVisible;
       Overview.Overview.prototype._animateVisible = originalAnimateOverview;
    }
@@ -3139,23 +3554,20 @@ function enableExpoChanged() {
    if (settings.enableExpoEffects) {
       Expo.Expo.prototype._animateVisible = _animateVisibleExpo;
       Expo.Expo.prototype._oldAnimateVisible = originalAnimateExpo;
-   } else {
+   } else if (Expo.Expo.prototype._oldAnimateVisibleExpo) {
       delete Expo.Expo.prototype._oldAnimateVisibleExpo;
       Expo.Expo.prototype._animateVisible = originalAnimateExpo;
    }
 }
 
-function enableAppswitcherChanged() {
-   if (settings.enableAppswitcherEffects) {
-      AppSwitcher3D.AppSwitcher3D.prototype._init = _initAppSwitcher3D;
-      AppSwitcher3D.AppSwitcher3D.prototype._oldInit = originalInitAppSwitcher3D;
-      AppSwitcher3D.AppSwitcher3D.prototype._hide = _hideAppSwitcher3D;
-      AppSwitcher3D.AppSwitcher3D.prototype._oldHide = originalHideAppSwitcher3D;
+function enableClassicSwitcherChecked() {
+   if (settings.appswitcherAllowClassic) {
+      blurClassicSwitcher = new BlurClassicSwitcher();
    } else {
-      delete AppSwitcher3D.AppSwitcher3D.prototype._oldInit;
-      AppSwitcher3D.AppSwitcher3D.prototype._init = originalInitAppSwitcher3D;
-      delete AppSwitcher3D.AppSwitcher3D.prototype._oldHide;
-      AppSwitcher3D.AppSwitcher3D.prototype._hide = originalHideAppSwitcher3D;
+      if (blurClassicSwitcher) {
+         blurClassicSwitcher.destroy();
+         blurClassicSwitcher = null;
+      }
    }
 }
 
@@ -3224,11 +3636,7 @@ function enableDeskletChanged() {
 }
 
 function init(extensionMeta) {
-   settings = new BlurSettings(extensionMeta.uuid);
    metaData = extensionMeta;
-
-   // Save the version number to the settings so that the About page can read it (is there a better way?)
-   settings.settings.setValue("ext-version", extensionMeta.version);
 
    // Store the original functions for monkey patched functions
    originalAnimateOverview = Overview.Overview.prototype._animateVisible;
@@ -3239,6 +3647,11 @@ function init(extensionMeta) {
 }
 
 function enable() {
+   settings = new BlurSettings(metaData.uuid);
+
+   // Save the version number to the settings so that the About page can read it (is there a better way?)
+   settings.settings.setValue("ext-version", metaData.version);
+
    // Monkey patch to enable Overview effects
    if (settings.enableOverviewEffects) {
       Overview.Overview.prototype._animateVisible = this._animateVisibleOverview;
@@ -3252,16 +3665,18 @@ function enable() {
    }
 
    // Monkey patch to enable 3D AppSwitcher effects
-   if (settings.enableAppswitcherEffects) {
-      AppSwitcher3D.AppSwitcher3D.prototype._init = this._initAppSwitcher3D;
-      AppSwitcher3D.AppSwitcher3D.prototype._oldInit = originalInitAppSwitcher3D;
-      AppSwitcher3D.AppSwitcher3D.prototype._hide = this._hideAppSwitcher3D;
-      AppSwitcher3D.AppSwitcher3D.prototype._oldHide = originalHideAppSwitcher3D;
-   }
+   AppSwitcher3D.AppSwitcher3D.prototype._init = this._initAppSwitcher3D;
+   AppSwitcher3D.AppSwitcher3D.prototype._oldInit = originalInitAppSwitcher3D;
+   AppSwitcher3D.AppSwitcher3D.prototype._hide = this._hideAppSwitcher3D;
+   AppSwitcher3D.AppSwitcher3D.prototype._oldHide = originalHideAppSwitcher3D;
 
    // Unconditionally monkey patch _sizeChangeWindowDone since it's needed for two effects
    Main.wm._sizeChangeWindowDone = _sizeChangeWindowDoneWindowManager;
 
+   // Create a Classic Switcher Effects class instance, the constructor will kick things off
+   if (settings.enableAppswitcherEffects && settings.appswitcherAllowClassic) {
+      blurClassicSwitcher = new BlurClassicSwitcher();
+   }
    // Create a Panel Effects class instance, the constructor will kick things off
    if (settings.enablePanelsEffects) {
       blurPanels = new BlurPanels();
@@ -3294,12 +3709,12 @@ function enable() {
    if (settings.enableDeskletEffects > 0) {
       blurDesklets = new BlurDesklets();
    }
-   // If this is the first time running Blur Cinnamon, sent a welcome notification message
+   // If this is the first time running Blur Cinnamon, send a welcome notification message
    if (settings.newInstall) {
       settings.settings.setValue( "new-install", 0 );
       let source = new MessageTray.Source(metaData.name);
       let notification = new MessageTray.Notification(source, _("Welcome to Blur Cinnamon"),
-         _("Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/Timeline effects.\n\nOpen the Blur Cinnamon Settings to enable additional effects on several other desktop elements like menus, notifications and windows, or disable effects on components that were enabled by default. You can also make changes to the effect properties like blur intensity, color saturation and dimming."),
+         _("Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n\nOpen the Blur Cinnamon Settings to enable additional effects on several other desktop elements like menus, notifications and windows, or disable effects on components that were enabled by default. You can also make changes to the effect properties like blur intensity, color saturation and dimming."),
          {icon: new St.Icon({icon_name: "blur-cinnamon", icon_type: St.IconType.FULLCOLOR, icon_size: source.ICON_SIZE })}
          );
       Main.messageTray.add(source);
@@ -3312,24 +3727,27 @@ function enable() {
 }
 
 function disable() {
-   if (settings.enableOverviewEffects) {
+   if (Overview.Overview.prototype._oldAnimateVisible) {
       delete Overview.Overview.prototype._oldAnimateVisible;
       Overview.Overview.prototype._animateVisible = originalAnimateOverview;
    }
 
-   if (settings.enableExpoEffects) {
+   if (Expo.Expo.prototype._oldAnimateVisibleExpo) {
       delete Expo.Expo.prototype._oldAnimateVisibleExpo;
       Expo.Expo.prototype._animateVisible = originalAnimateExpo;
    }
 
-   if (settings.enableAppswitcherEffects) {
-      delete AppSwitcher3D.AppSwitcher3D.prototype._oldInit;
-      AppSwitcher3D.AppSwitcher3D.prototype._init = originalInitAppSwitcher3D;
-      delete AppSwitcher3D.AppSwitcher3D.prototype._oldHide;
-      AppSwitcher3D.AppSwitcher3D.prototype._hide = originalHideAppSwitcher3D;
-   }
+   delete AppSwitcher3D.AppSwitcher3D.prototype._oldInit;
+   AppSwitcher3D.AppSwitcher3D.prototype._init = originalInitAppSwitcher3D;
+   delete AppSwitcher3D.AppSwitcher3D.prototype._oldHide;
+   AppSwitcher3D.AppSwitcher3D.prototype._hide = originalHideAppSwitcher3D;
 
    Main.wm._sizeChangeWindowDone = originalSizeChangeWindowDone;
+
+   if (blurClassicSwitcher) {
+      blurClassicSwitcher.destroy();
+      blurClassicSwitcher = null;
+   }
 
    if (blurPanels) {
       blurPanels.destroy();

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/monte_carlo_blur.glsl
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/monte_carlo_blur.glsl
@@ -1,0 +1,52 @@
+uniform sampler2D tex;
+uniform float radius;
+uniform int iterations;
+uniform float brightness;
+uniform float width;
+uniform float height;
+uniform bool use_base_pixel;
+uniform bool prefer_closer_pixels;
+
+float srand(vec2 a) {
+    return sin(dot(a, vec2(1233.224, 1743.335)));
+}
+
+float rand(inout float r) {
+    r = fract(3712.65 * r + 0.61432);
+    return (r - 0.5) * 2.0;
+}
+
+void main() {
+    vec2 uv = cogl_tex_coord0_in.st;
+    vec2 p = 16 * radius / vec2(width, height);
+    float r = srand(uv);
+
+    vec2 rv;
+    vec2 dir;
+    vec2 new_uv;
+    int strength;
+
+    int count = 0;
+    vec4 c = vec4(0.);
+
+    for (int i = 0; i < iterations; i++) {
+        rv.x = rand(r);
+        rv.y = rand(r) * 3.141592;
+        dir = vec2(cos(rv.y), sin(rv.y));
+        new_uv = uv + rv.x * dir * p;
+        if (new_uv.x > 2. / width && new_uv.y > 2. / height && new_uv.x < 1. - 3. / width && new_uv.y < 1. - 3. / height) {
+            strength = prefer_closer_pixels ? ((iterations - i) * (iterations - i)) : 1;
+            c += strength * texture2D(tex, new_uv);
+            count += strength;
+        }
+    }
+
+    if (count == 0 || use_base_pixel) {
+        strength = prefer_closer_pixels ? ((iterations + 1) * (iterations + 1)) : 1;
+        c += strength * texture2D(tex, uv);
+        count += strength;
+    }
+
+    c.xyz *= brightness;
+    cogl_color_out = c / count;
+}

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/monte_carlo_blur.js
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/monte_carlo_blur.js
@@ -9,16 +9,17 @@ const GLib = imports.gi.GLib;
 
 const UUID = "BlurCinnamon@klangman";
 
-const SHADER_FILENAME = 'gaussian_blur.glsl';
+const SHADER_FILENAME = 'monte_carlo_blur.glsl';
 const DEFAULT_PARAMS = {
-    radius: 30, brightness: .6,
-    width: 0, height: 0, direction: 0, chained_effect: null
+    radius: 2., iterations: 5, brightness: .6,
+    width: 0, height: 0, use_base_pixel: true,
+    prefer_closer_pixels: true
 };
 
 
-const GaussianBlurEffect =
+const MonteCarloBlurEffect =
     new GObject.registerClass({
-        GTypeName: `GaussianBlurEffect_${Math.floor(Math.random() * 100000) + 1}`,
+        GTypeName: `MonteCarloBlurEffect_${Math.floor(Math.random() * 100000) + 1}`,
         Properties: {
             'radius': GObject.ParamSpec.double(
                 `radius`,
@@ -26,7 +27,15 @@ const GaussianBlurEffect =
                 `Blur radius`,
                 GObject.ParamFlags.READWRITE,
                 0.0, 2000.0,
-                30.0,
+                2.0,
+            ),
+            'iterations': GObject.ParamSpec.int(
+                `iterations`,
+                `Iterations`,
+                `Blur iterations`,
+                GObject.ParamFlags.READWRITE,
+                0, 64,
+                5,
             ),
             'brightness': GObject.ParamSpec.double(
                 `brightness`,
@@ -52,55 +61,59 @@ const GaussianBlurEffect =
                 0.0, Number.MAX_SAFE_INTEGER,
                 0.0,
             ),
-            'direction': GObject.ParamSpec.int(
-                `direction`,
-                `Direction`,
-                `Direction`,
+            'use_base_pixel': GObject.ParamSpec.boolean(
+                `use_base_pixel`,
+                `Use base pixel`,
+                `Use base pixel`,
                 GObject.ParamFlags.READWRITE,
-                0, 1,
-                0,
+                true,
             ),
-            'chained_effect': GObject.ParamSpec.object(
-                `chained_effect`,
-                `Chained Effect`,
-                `Chained Effect`,
+            'prefer_closer_pixels': GObject.ParamSpec.boolean(
+                `prefer_closer_pixels`,
+                `Prefer closer pixels`,
+                `Prefer closer pixels`,
                 GObject.ParamFlags.READWRITE,
-                GObject.Object,
+                true,
             ),
         }
-    }, class GaussianBlurEffect extends Clutter.ShaderEffect {
+    }, class MonteCarloBlurEffect extends Clutter.ShaderEffect {
         constructor(params) {
             super(params);
 
             if (params && params.radius != undefined )
                this.radius = params.radius;
             else
-               this.radius = 30;
+               this.radius = 2.0;
 
-            if (params && params.brightness !== undefined)
+            if (params && params.iterations != undefined )
+               this.iterations = params.iterations;
+            else
+               this.iterations = 5;
+
+            if (params && params.brightness != undefined )
                this.brightness = params.brightness;
             else
                this.brightness = 0.6;
 
-            if (params && params.width)
+            if (params && params.width != undefined )
                this.width = params.width;
             else
                this.width = 0;
 
-            if (params && params.height)
+            if (params && params.height != undefined )
                this.height = params.height;
             else
                this.height = 0;
 
-            if (params && params.direction)
-               this.direction = params.direction;
+            if (params && params.use_base_pixel != undefined )
+               this.use_base_pixel = params.use_base_pixel;
             else
-               this.direction = 0;
+               this.use_base_pixel = true;
 
-            if (params && params.chained_effect)
-               this.chained_effect = params.chained_effect;
+            if (params && params.prefer_closer_pixels != undefined )
+               this.prefer_closer_pixels = params.prefer_closer_pixels;
             else
-               this.chained_effect = null;
+               this.prefer_closer_pixels = true;
 
             // set shader source
             this._source = this.get_shader_source(SHADER_FILENAME);
@@ -109,9 +122,10 @@ const GaussianBlurEffect =
 
             const theme_context = St.ThemeContext.get_for_stage(global.stage);
             theme_context.connect(
-                'notify::scale-factor', () => {
-                this.set_uniform_value('sigma', parseFloat(this.radius * theme_context.scale_factor / 2 - 1e-6) );
-                }
+                'notify::scale-factor',
+                _ => this.set_uniform_value('radius',
+                    parseFloat(this._radius * theme_context.scale_factor - 1e-6)
+                )
             );
         }
 
@@ -126,21 +140,30 @@ const GaussianBlurEffect =
         }
 
         get radius() {
-            return this._radius;
+            return this._radius*10;
         }
 
         set radius(value) {
-            if (this._radius !== value) {
-                this._radius = value;
+            if (this._radius !== value/10) {
+                this._radius = value/10;
 
                 const scale_factor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
 
-                // like Clutter, we use the assumption radius = 2*sigma
-                this.set_uniform_value('sigma', parseFloat(this._radius * scale_factor / 2 - 1e-6));
-                this.set_enabled(this.radius > 0.);
+                this.set_uniform_value('radius', parseFloat(this._radius * scale_factor - 1e-6));
+                this.set_enabled(this.radius > 0. && this.iterations > 0);
+            }
+        }
 
-                if (this.chained_effect)
-                    this.chained_effect.radius = value;
+        get iterations() {
+            return this._iterations;
+        }
+
+        set iterations(value) {
+            if (this._iterations !== value) {
+                this._iterations = value;
+
+                this.set_uniform_value('iterations', this._iterations);
+                this.set_enabled(this.radius > 0. && this.iterations > 0);
             }
         }
 
@@ -153,9 +176,6 @@ const GaussianBlurEffect =
                 this._brightness = value;
 
                 this.set_uniform_value('brightness', parseFloat(this._brightness - 1e-6));
-
-                if (this.chained_effect)
-                    this.chained_effect.brightness = value;
             }
         }
 
@@ -168,9 +188,6 @@ const GaussianBlurEffect =
                 this._width = value;
 
                 this.set_uniform_value('width', parseFloat(this._width + 3.0 - 1e-6));
-
-                if (this.chained_effect)
-                    this.chained_effect.width = value;
             }
         }
 
@@ -183,27 +200,31 @@ const GaussianBlurEffect =
                 this._height = value;
 
                 this.set_uniform_value('height', parseFloat(this._height + 3.0 - 1e-6));
-
-                if (this.chained_effect)
-                    this.chained_effect.height = value;
             }
         }
 
-        get direction() {
-            return this._direction;
+        get use_base_pixel() {
+            return this._use_base_pixel;
         }
 
-        set direction(value) {
-            if (this._direction !== value)
-                this._direction = value;
+        set use_base_pixel(value) {
+            if (this._use_base_pixel !== value) {
+                this._use_base_pixel = value;
+
+                this.set_uniform_value('use_base_pixel', this._use_base_pixel ? 1 : 0);
+            }
         }
 
-        get chained_effect() {
-            return this._chained_effect;
+        get prefer_closer_pixels() {
+            return this._prefer_closer_pixels;
         }
 
-        set chained_effect(value) {
-            this._chained_effect = value;
+        set prefer_closer_pixels(value) {
+            if (this._prefer_closer_pixels !== value) {
+                this._prefer_closer_pixels = value;
+
+                this.set_uniform_value('prefer_closer_pixels', this._prefer_closer_pixels ? 1 : 0);
+            }
         }
 
         vfunc_set_actor(actor) {
@@ -223,26 +244,5 @@ const GaussianBlurEffect =
                 this._actor_connection_size_id = null;
 
             super.vfunc_set_actor(actor);
-
-            if (this.direction == 0) {
-                if (this.chained_effect)
-                    this.chained_effect.get_actor()?.remove_effect(this.chained_effect);
-                else
-                    this.chained_effect = new GaussianBlurEffect({
-                        radius: this.radius,
-                        brightness: this.brightness,
-                        width: this.width,
-                        height: this.height,
-                        direction: 1
-                    });
-                if (actor !== null)
-                    actor.add_effect(this.chained_effect);
-            }
-        }
-
-        vfunc_paint_target(...params) {
-            this.set_uniform_value("dir", this.direction);
-
-            super.vfunc_paint_target(...params);
         }
     });

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/settings-schema.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/settings-schema.json
@@ -11,7 +11,7 @@
       "generic-settings-page" : {
          "type" : "page",
          "title" : "Generic effect settings",
-         "sections" : ["generic-effect-settings"]
+         "sections" : ["generic-effect-settings", "monte-carlo-settings"]
       },
       "component-setting-page" : {
          "type" : "page",
@@ -36,6 +36,12 @@
          "keys" : ["opacity", "blendColor", "blurType", "radius", "saturation"]
       },
 
+      "monte-carlo-settings" : {
+         "type" : "section",
+         "title" : "Monte Carlo specific settings",
+         "keys" : ["monte-carlo-iterations", "monte-carlo-use-base-pixel", "monte-carlo-prefer-closer-pixels", "monte-carlo-label"]
+      },
+
       "component-selector-section" : {
          "type" : "section",
          "title" : "Component Selector",
@@ -50,10 +56,10 @@
                     "panel-warning", "enable-panels-override", "allow-transparent-color-panels", "no-panel-effects-maximized", "hover-brighten-panels", "enable-panel-unique-settings", "panels-opacity", "panels-blendColor", "panels-blurType", "panels-radius", "panels-saturation", "panel-unique-settings",
                     "popup-warning", "enable-popup-override", "popup-applet-menu-effects", "popup-panel-menu-effects", "popup-title-menu-effects", "allow-transparent-color-popup", "popup-opacity", "popup-accent-opacity", "popup-blendColor", "popup-blurType", "popup-radius", "popup-saturation",
                     "desktop-warning", "enable-desktop-override", "desktop-without-focus", "desktop-with-focus", "desktop-opacity", "desktop-blendColor", "desktop-blurType", "desktop-radius", "desktop-saturation",
-                    "notification-warning", "enable-notification-override", "notification-opacity", "notification-blendColor", "notification-blurType", "notification-radius", "notification-saturation", "notification-test-button",
-                    "appswitcher-warning", "enable-appswitcher-override", "appswitcher-info", "window-settings-button", "appswitcher-opacity", "appswitcher-blendColor", "appswitcher-blurType", "appswitcher-radius", "appswitcher-saturation",
-                    "tooltips-warning", "enable-tooltips-override", "tooltips-opacity", "tooltips-blendColor", "tooltips-blurType", "tooltips-radius", "tooltips-saturation",
-                    "windows-warning", "windows-inclusion-list", "windows-label", "windows-add-button", "windows-compiz-mitigation",
+                    "notification-warning", "enable-notification-override", "allow-transparent-color-notifications", "notification-opacity", "notification-blendColor", "notification-blurType", "notification-radius", "notification-saturation", "notification-test-button",
+                    "appswitcher-warning", "enable-appswitcher-override", "appswitcher-disable-3d-panels", "appswitcher-allow-classic", "appswitcher-allow-3d", "window-settings-button", "appswitcher-opacity", "appswitcher-blendColor", "appswitcher-blurType", "appswitcher-radius", "appswitcher-saturation",
+                    "tooltips-warning", "enable-tooltips-override", "allow-transparent-color-tooltips", "tooltips-opacity", "tooltips-blendColor", "tooltips-blurType", "tooltips-radius", "tooltips-saturation",
+                    "windows-warning", "windows-inclusion-list", "windows-label", "windows-add-button", "windows-atrifact-mitigation", "windows-compiz-mitigation",
                     "desklets-warning", "enable-desklets-override", "enable-desklets-unique-settings", "desklets-opacity", "desklets-blendColor", "desklets-blurType", "desklets-radius", "desklets-saturation", "desklets-list", "desklets-auto", "desklets-label",
                     "info-label"
                   ]
@@ -162,7 +168,7 @@
       "type" : "custom",
       "file" : "CustomWidgets.py",
       "widget" : "About",
-      "description" : "\n<b>Bringing your style into focus</b>\nVersion: ext-version\n\nDeveloped by: Kevin Langman\n<a href=\"https://github.com/klangman/BlurCinnamon\">Github</a> / <a href=\"https://github.com/klangman/BlurCinnamon/issues/new\">Report an issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/104\">Website</a>\n\nThe rounded corners and Gaussian effects are based on code by aunetx (Blur-my-shell)\n<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n\nThe Overview effect is partially based on the BlurOverview extension by nailfarmer",
+      "description" : "\n<b>Bringing your style into focus</b>\nVersion: ext-version\n\nDeveloped by: Kevin Langman\n<a href=\"https://github.com/klangman/BlurCinnamon\">Github</a> / <a href=\"https://github.com/klangman/BlurCinnamon/issues/new\">Report an issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/104\">Website</a>\n\nThe rounded corners, Gaussian and Monte Carlo effects\nare based on code by aunetx (Blur-my-shell)\n<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n\nThe Overview effect is partially based on the BlurOverview extension by nailfarmer",
       "icon" : "/icon.png"
    },
 
@@ -204,8 +210,8 @@
    },
    "enable-appswitcher-effects" : {
       "type": "switch",
-      "description": "Alt-Tab application switcher (Coverflow & Timeline only)",
-      "tooltip": "Apply effects to the Alt-Tab application switcher background when setup to use the Coverflow or Timeline styles",
+      "description": "Alt-Tab application switcher",
+      "tooltip": "Apply effects to the Alt-Tab application switcher background",
       "default": true
    },
    "enable-tooltips-effects" : {
@@ -253,59 +259,82 @@
         "default": true,
         "dependency" : "enable-popup-effects & component-selector=4"
     },
+    "allow-transparent-color-notifications" : {
+        "type": "switch",
+        "description": "Override some of the notification theme settings (recommended)",
+        "tooltip": "Allow this extension to modify the notification transparency and background color settings. If this is disabled the extension will only apply a blur background under the notifications. This setting should only be disabled when the theme already uses transparent notifications and you want the themes setting to apply.",
+        "default": true,
+        "dependency" : "enable-notification-effects & component-selector=5"
+    },
+    "allow-transparent-color-tooltips" : {
+        "type": "switch",
+        "description": "Override some of the tooltip theme settings (recommended)",
+        "tooltip": "Allow this extension to modify the tooltip transparency and background color settings. If this is disabled the extension will only apply a blur background under the tooltips. This setting should only be disabled when the theme already uses transparent tooltips and you want the themes setting to apply.",
+        "default": true,
+        "dependency" : "enable-tooltips-effects & component-selector=8"
+    },
 
     "enable-overview-override" : {
         "type": "switch",
-        "description": "Use unique effect settings for the Overview",
+        "description": "Override the generic effect settings for the Overview",
         "dependency" : "enable-overview-effects & component-selector=6",
+        "tooltip": "Override the settings found on the \"Generic effect settings\" tab with unique settings for this cinnamon component.",
         "default": false
     },
     "enable-expo-override" : {
         "type": "switch",
-        "description": "Use unique effect settings for the Expo",
+        "description": "Override the generic effect settings for the Expo",
         "dependency" : "enable-expo-effects & component-selector=3",
+        "tooltip": "Override the settings found on the \"Generic effect settings\" tab with unique settings for this cinnamon component.",
         "default": false
     },
     "enable-panels-override" : {
         "type": "switch",
-        "description": "Use unique effect settings for the Panels",
+        "description": "Override the generic effect settings for the Panels",
         "dependency" : "enable-panels-effects & component-selector=7",
+        "tooltip": "Override the settings found on the \"Generic effect settings\" tab with unique settings for this cinnamon component.",
         "default": false
     },
     "enable-popup-override" : {
         "type": "switch",
-        "description": "Use unique effect settings for the popup menus",
+        "description": "Override the generic effect settings for popup menus",
         "dependency" : "enable-popup-effects & component-selector=4",
+        "tooltip": "Override the settings found on the \"Generic effect settings\" tab with unique settings for this cinnamon component.",
         "default": false
     },
     "enable-desktop-override" : {
         "type": "switch",
-        "description": "Use unique effect settings for the desktop background",
+        "description": "Override the generic effect settings for the desktop background",
         "dependency" : "enable-desktop-effects & component-selector=2",
+        "tooltip": "Override the settings found on the \"Generic effect settings\" tab with unique settings for this cinnamon component.",
         "default": false
     },
     "enable-notification-override" : {
         "type": "switch",
-        "description": "Use unique effect settings for the notification popups",
+        "description": "Override the generic effect settings for notification popups",
         "dependency" : "enable-notification-effects & component-selector=5",
+        "tooltip": "Override the settings found on the \"Generic effect settings\" tab with unique settings for this cinnamon component.",
         "default": false
     },
     "enable-appswitcher-override" : {
         "type": "switch",
-        "description": "Use unique effect settings for the Alt-Tab app switcher",
+        "description": "Override the generic effect settings for the Alt-Tab app switcher",
         "dependency" : "enable-appswitcher-effects & component-selector=0",
+        "tooltip": "Override the settings found on the \"Generic effect settings\" tab with unique settings for this cinnamon component.",
         "default": false
     },
     "enable-tooltips-override" : {
         "type": "switch",
-        "description": "Use unique effect settings for the panel tooltips",
+        "description": "Override the generic effect settings for panel tooltips",
         "dependency" : "enable-tooltips-effects & component-selector=8",
+        "tooltip": "Override the settings found on the \"Generic effect settings\" tab with unique settings for this cinnamon component.",
         "default": false
     },
     "enable-desklets-override" : {
         "type": "switch",
-        "description": "Use unique effect settings for the Desklets",
+        "description": "Override the generic effect settings for Desklets",
         "dependency" : "enable-desklet-effects & component-selector=1",
+        "tooltip": "Override the settings found on the \"Generic effect settings\" tab with unique settings for this cinnamon component.",
         "default": false
     },
 
@@ -343,7 +372,7 @@
             {"id": "override",  "title": "Custom",    "type": "boolean", "default": true},
             {"id": "opacity",   "title": "Dim",       "type": "integer", "default": 40,  "min": 0, "max": 100},
             {"id": "color",     "title": "Color",     "type": "string",  "default": "rgb(0,0,0)"},
-            {"id": "blurtype",  "title": "Background","type": "integer", "default": 4, "options": { "Transparent": 3, "Transparent to wallpaper": 0, "Simple static blur": 1, "Gaussian static blur": 2, "Gaussian dynamic blur": 4 } },
+            {"id": "blurtype",  "title": "Background","type": "integer", "default": 4, "options": { "Transparent": 3, "Transparent to wallpaper": 0, "Simple static blur": 1, "Gaussian static blur": 2, "Gaussian dynamic blur": 4, "Monte Carlo static blur": 5, "Monte Carlo dynamic blur": 6 } },
             {"id": "radius",    "title": "Intensity", "type": "integer", "default": 10,  "min": 0, "max": 100},
             {"id": "saturation","title": "Saturation","type": "integer", "default": 100, "min": 0, "max": 100},
             {"id": "customCSS", "title": "Custom CSS","type": "string",  "default": ""}
@@ -398,7 +427,9 @@
             "None / Transparent to wallpaper": 0,
             "Simple static blur": 1,
             "Gaussian static blur": 2,
-            "Gaussian dynamic blur (if applicable)": 4
+            "Gaussian dynamic blur (if applicable)": 4,
+            "Monte Carlo static blur": 5,
+            "Monte Carlo dynamic blur (if applicable)": 6
         },
         "description": "Type of blur effect",
         "tooltip": "What type of blur algorithm should be used to blur the background"
@@ -408,11 +439,11 @@
         "type" : "custom",
         "file" : "CustomWidgets.py",
         "widget" : "CompactScale",
-        "description" : "Gaussian blur intensity",
+        "description" : "Blur intensity",
         "min" : 0.0,
         "max" : 100,
         "step" : 0.1,
-        "dependency" : "blurType=2 | blurType=4",
+        "dependency" : "blurType>1",
         "tooltip": "Adjusts the intensity of the blur effect by changing the radius use by the effect.",
         "default": 9
     },
@@ -427,6 +458,40 @@
         "step" : 0.1,
         "tooltip": "Adjusts the color saturation of the background image from gray-scale to full color.",
         "default": 100
+    },
+
+    "monte-carlo-iterations": {
+        "type" : "custom",
+        "file" : "CustomWidgets.py",
+        "widget" : "CompactScale",
+        "description": "Iterations",
+        "min": 0,
+        "max": 64,
+        "default": 5,
+        "step": 1,
+        "tooltip": "Increasing number of iterations will make the blur appear smoother at the cost of some CPU power."
+    },
+
+    "monte-carlo-use-base-pixel": {
+        "type": "switch",
+        "description": "Use base pixel",
+        "tooltip": "Whether or not the original pixel is counted for the blur. If it is, the image will be more legible.",
+        "default": true
+    },
+
+    "monte-carlo-prefer-closer-pixels": {
+        "type": "switch",
+        "description": "Prefer closer pixels",
+        "tooltip": "Whether or not the pixels that are closer to the original pixel will have more weight.",
+        "default": true
+    },
+
+    "monte-carlo-label": {
+        "type" : "custom",
+        "file" : "CustomWidgets.py",
+        "widget" : "LabelWithTooltip",
+        "description" : "<b>Note:</b> These Monte Carlo settings are used globally for all components",
+        "tooltip": "The above Monte Carlo settings are used globally for all components that are configured to use the Monte Carlo blur algorithm, these settings can not be configured separately for each component"
     },
 
     "overview-opacity": {
@@ -455,7 +520,8 @@
         "options": {
             "None": 0,
             "Simple": 1,
-            "Gaussian": 2
+            "Gaussian": 2,
+            "Monte Carlo": 5
         },
         "description": "Type of blur effect",
         "dependency" : "enable-overview-effects & component-selector=6 & enable-overview-override",
@@ -466,11 +532,11 @@
         "type" : "custom",
         "file" : "CustomWidgets.py",
         "widget" : "CompactScale",
-        "description" : "Gaussian blur intensity",
+        "description" : "Blur intensity",
         "min" : 0.0,
         "max" : 100,
         "step" : 0.1,
-        "dependency" : "enable-overview-effects & component-selector=6 & overview-blurType=2 & enable-overview-override",
+        "dependency" : "enable-overview-effects & component-selector=6 & overview-blurType>1 & enable-overview-override",
         "tooltip": "Adjusts the intensity of the blur effect by changing the radius use by the effect.",
         "default": 9
     },
@@ -515,7 +581,8 @@
         "options": {
             "None": 0,
             "Simple": 1,
-            "Gaussian": 2
+            "Gaussian": 2,
+            "Monte Carlo": 5
         },
         "description": "Type of blur effect",
         "dependency" : "enable-expo-effects & component-selector=3 & enable-expo-override",
@@ -526,13 +593,13 @@
         "type" : "custom",
         "file" : "CustomWidgets.py",
         "widget" : "CompactScale",
-        "description" : "Gaussian blur intensity",
+        "description" : "Blur intensity",
         "min" : 0.0,
         "max" : 100,
         "step" : 0.1,
         "tooltip": "Adjusts the intensity of the blur effect by changing the radius use by the effect.",
         "default": 9,
-        "dependency" : "enable-expo-effects & component-selector=3 & expo-blurType=2 & enable-expo-override"
+        "dependency" : "enable-expo-effects & component-selector=3 & expo-blurType>1 & enable-expo-override"
     },
 
     "expo-saturation": {
@@ -577,7 +644,9 @@
             "Transparent to wallpaper": 0,
             "Simple static blur": 1,
             "Gaussian static blur": 2,
-            "Gaussian dynamic blur": 4
+            "Gaussian dynamic blur": 4,
+            "Monte Carlo static blur": 5,
+            "Monte Carlo dynamic blur": 6
         },
         "description": "Type of background effect",
         "tooltip": "What type of background effect should be applied",
@@ -588,7 +657,7 @@
         "type" : "custom",
         "file" : "CustomWidgets.py",
         "widget" : "CompactScale",
-        "description" : "Gaussian blur intensity",
+        "description" : "Blur intensity",
         "min" : 0.0,
         "max" : 100,
         "step" : 0.1,
@@ -653,7 +722,7 @@
         "max": 100,
         "default": 50,
         "step": 1,
-        "dependency" : "enable-popup-effects & component-selector=4 & enable-popup-override",
+        "dependency" : "enable-popup-effects & component-selector=4",
         "tooltip": "Defines the additional dimming applied to the popup menu accent elements (i.e. the main menu favorites box and entry boxes) which allow these elements to stand out from the other popup menu areas"
     },
 
@@ -673,7 +742,9 @@
             "Transparent to wallpaper": 0,
             "Simple static blur": 1,
             "Gaussian static blur": 2,
-            "Gaussian dynamic blur": 4
+            "Gaussian dynamic blur": 4,
+            "Monte Carlo static blur": 5,
+            "Monte Carlo dynamic blur": 6
         },
         "description": "Type of background effect",
         "tooltip": "What type of background effect should be applied",
@@ -684,7 +755,7 @@
         "type" : "custom",
         "file" : "CustomWidgets.py",
         "widget" : "CompactScale",
-        "description" : "Gaussian blur intensity",
+        "description" : "Blur intensity",
         "min" : 0.0,
         "max" : 100,
         "step" : 0.1,
@@ -749,7 +820,8 @@
         "options": {
             "None": 0,
             "Simple": 1,
-            "Gaussian": 2
+            "Gaussian": 2,
+            "Monte Carlo": 5
         },
         "description": "Type of blur effect",
         "tooltip": "What type of blur algorithm should be used to blur the background",
@@ -760,13 +832,13 @@
         "type" : "custom",
         "file" : "CustomWidgets.py",
         "widget" : "CompactScale",
-        "description" : "Gaussian blur intensity",
+        "description" : "Blur intensity",
         "min" : 0.0,
         "max" : 100,
         "step" : 0.1,
         "tooltip": "Adjusts the intensity of the blur effect by changing the radius use by the effect.",
         "default": 20,
-        "dependency" : "enable-desktop-effects & component-selector=2 & desktop-blurType=2 & enable-desktop-override"
+        "dependency" : "enable-desktop-effects & component-selector=2 & desktop-blurType>1 & enable-desktop-override"
     },
 
     "desktop-saturation": {
@@ -811,7 +883,9 @@
             "Transparent to wallpaper": 0,
             "Simple static blur": 1,
             "Gaussian static blur": 2,
-            "Gaussian dynamic blur": 4
+            "Gaussian dynamic blur": 4,
+            "Monte Carlo static blur": 5,
+            "Monte Carlo dynamic blur": 6
         },
         "description": "Type of background effect",
         "dependency" : "enable-notification-effects & component-selector=5 & enable-notification-override",
@@ -822,7 +896,7 @@
         "type" : "custom",
         "file" : "CustomWidgets.py",
         "widget" : "CompactScale",
-        "description" : "Gaussian blur intensity",
+        "description" : "Blur intensity",
         "min" : 0.0,
         "max" : 100,
         "step" : 0.1,
@@ -852,10 +926,28 @@
       "tooltip" : "This button will cause a notification message to appear so you can see how your notification setting behave."
     },
 
-    "appswitcher-info" : {
-        "type" : "label",
-        "description" : "Note: Alt-Tab effects only apply to the Coverflow and Timeline 3D Alt-Tab configurations",
-        "dependency" : "enable-appswitcher-effects & component-selector=0"
+    "appswitcher-disable-3d-panels" : {
+        "type": "switch",
+        "description": "Hide panels while using the Coverflow/Timeline 3D Alt-Tab switchers",
+        "tooltip": "Make the panels invisible when using the Coverflow or the Timeline 3D Alt-Tab switchers",
+        "dependency" : "enable-appswitcher-effects & component-selector=0",
+        "default": true
+    },
+
+    "appswitcher-allow-classic" : {
+        "type": "switch",
+        "description": "Apply effects to the standard Alt-Tab switcher",
+        "tooltip": "Allow applying effects to the standard Alt-Tab switcher. Only the switcher options without \"previews\" are supported. The standard Alt-Tab switcher can use static or dynamic blur, but dynamic is recommended.",
+        "dependency" : "enable-appswitcher-effects & component-selector=0",
+        "default": true
+    },
+
+    "appswitcher-allow-3d" : {
+        "type": "switch",
+        "description": "Apply effects to the 3D Alt-Tab switchers",
+        "tooltip": "Allow applying effects to the Coverflow and Timeline 3D Alt-Tab switchers. The 3D Alt-Tab switchers will use static blurring even when dynamic blurring is selected since they don't benifit from dynamic blurring.",
+        "dependency" : "enable-appswitcher-effects & component-selector=0",
+        "default": true
     },
 
     "appswitcher-opacity" : {
@@ -880,28 +972,31 @@
 
     "appswitcher-blurType": {
         "type": "combobox",
-        "default": 2,
+        "default": 4,
         "options": {
             "None": 0,
-            "Simple": 1,
-            "Gaussian": 2
+            "Simple static blur": 1,
+            "Gaussian static blur": 2,
+            "Gaussian dynamic blur": 4,
+            "Monte Carlo static blur": 5,
+            "Monte Carlo dynamic blur": 6
         },
         "description": "Type of blur effect",
         "dependency" : "enable-appswitcher-effects & component-selector=0 & enable-appswitcher-override",
-        "tooltip": "What type of blur algorithm should be used to blur the background"
+        "tooltip": "What type of blur algorithm should be used to blur the background. A dynamic blur type can be used for the standard switcher but static blurring is always used for the 3D switchers as they do not benefit from dynamic effects."
     },
 
     "appswitcher-radius": {
         "type" : "custom",
         "file" : "CustomWidgets.py",
         "widget" : "CompactScale",
-        "description" : "Gaussian blur intensity",
+        "description" : "Blur intensity",
         "min" : 0.0,
         "max" : 100,
         "step" : 0.1,
         "tooltip": "Adjusts the intensity of the blur effect by changing the radius use by the effect.",
         "default": 9,
-        "dependency" : "enable-appswitcher-effects & component-selector=0 & appswitcher-blurType=2 & enable-appswitcher-override"
+        "dependency" : "enable-appswitcher-effects & component-selector=0 & appswitcher-blurType>1 & enable-appswitcher-override"
     },
 
     "appswitcher-saturation": {
@@ -945,7 +1040,9 @@
             "Transparent to wallpaper": 0,
             "Simple static blur": 1,
             "Gaussian static blur": 2,
-            "Gaussian dynamic blur": 4
+            "Gaussian dynamic blur": 4,
+            "Monte Carlo static blur": 5,
+            "Monte Carlo dynamic blur": 6
         },
         "description": "Type of background effect",
         "dependency" : "enable-tooltips-effects & component-selector=8 & enable-tooltips-override",
@@ -956,7 +1053,7 @@
         "type" : "custom",
         "file" : "CustomWidgets.py",
         "widget" : "CompactScale",
-        "description" : "Gaussian blur intensity",
+        "description" : "Blur intensity",
         "min" : 0.0,
         "max" : 100,
         "step" : 0.1,
@@ -1004,8 +1101,11 @@
         "default": 2,
         "options": {
             "None": 0,
-            "Simple": 1,
-            "Gaussian": 2
+            "Simple static blur": 1,
+            "Gaussian static blur": 2,
+            "Gaussian dynamic blur": 4,
+            "Monte Carlo static blur": 5,
+            "Monte Carlo dynamic blur": 6
         },
         "description": "Type of blur effect",
         "tooltip": "What type of blur algorithm should be used to blur the background",
@@ -1016,13 +1116,13 @@
         "type" : "custom",
         "file" : "CustomWidgets.py",
         "widget" : "CompactScale",
-        "description" : "Gaussian blur intensity",
+        "description" : "Blur intensity",
         "min" : 0.0,
         "max" : 100,
         "step" : 0.1,
         "tooltip": "Adjusts the intensity of the blur effect by changing the radius use by the effect.",
         "default": 20,
-        "dependency" : "enable-desklet-effects & component-selector=1 & !enable-desklets-unique-settings & desklets-blurType=2 & enable-desklets-override"
+        "dependency" : "enable-desklet-effects & component-selector=1 & !enable-desklets-unique-settings & desklets-blurType>1 & enable-desklets-override"
     },
 
     "desklets-saturation": {
@@ -1050,7 +1150,7 @@
             {"id": "override",      "title": "Custom",       "type": "boolean", "default": true},
             {"id": "opacity",       "title": "Dim",          "type": "integer", "default": 0,  "min": 0, "max": 100},
             {"id": "color",         "title": "Color",        "type": "string",  "default": "rgb(0,0,0)"},
-            {"id": "blurtype",      "title": "Background",   "type": "integer", "default": 2, "options": {"Transparent to wallpaper": 0, "Simple static blur": 1, "Gaussian static blur": 2, "Gaussian dynamic blur (experimental)": 4} },
+            {"id": "blurtype",      "title": "Background",   "type": "integer", "default": 2, "options": {"Transparent to wallpaper": 0, "Simple static blur": 1, "Gaussian static blur": 2, "Gaussian dynamic blur": 4, "Monte Carlo static blur": 5, "Monte Carlo dynamic blur": 6 } },
             {"id": "radius",        "title": "Intensity",    "type": "integer", "default": 10,  "min": 0, "max": 100},
             {"id": "saturation",    "title": "Saturation",   "type": "integer", "default": 100, "min": 0, "max": 100},
             {"id": "corner_radius", "title": "Corner Radius","type": "integer", "default": 10, "min": 0, "max": 25},
@@ -1085,6 +1185,14 @@
         "tooltip": "When enabled, the window moving effect created by the \"Compiz windows effect\" extension will be disabled for windows with Blur Cinnamon effects applied. This option will have no effect unless the \"Compiz window effect\" extension is installed and active."
     },
 
+    "windows-atrifact-mitigation": {
+        "type": "switch",
+        "default": true,
+        "description": "Use artifact mitigation techniques",
+        "dependency" : "enable-window-effects & component-selector=9",
+        "tooltip": "When enabled, steps will be taken to eliminate background graphical artifacts for windows that use dynamic blur effects. The mitigation steps will have some minor persistent CPU costs when a dynamic blurred window is on top of two or more other windows. This option is recommended unless you are using video wallpaper like Hidamari"
+    },
+
     "desklets-auto": {
         "type": "switch",
         "default": true,
@@ -1106,7 +1214,7 @@
             {"id": "override",   "title": "Custom",     "type": "boolean", "default": true},
             {"id": "opacity",    "title": "Dim",        "type": "integer", "default": 0,  "min": 0, "max": 100},
             {"id": "color",      "title": "Color",      "type": "string",  "default": "rgb(0,0,0)"},
-            {"id": "blurtype",   "title": "Blur",       "type": "integer", "default": 2, "options": { "None": 0, "Simple": 1, "Gaussian": 2 } },
+            {"id": "blurtype",   "title": "Blur",       "type": "integer", "default": 2, "options": { "None": 0, "Simple static blur": 1, "Gaussian static blur": 2, "Gaussian dynamic blur": 4, "Monte Carlo static blur": 5, "Monte Carlo dynamic blur": 6 } },
             {"id": "radius",     "title": "Intensity",  "type": "integer", "default": 10,  "min": 0, "max": 100},
             {"id": "saturation", "title": "Saturation", "type": "integer", "default": 100, "min": 0, "max": 100}
         ],

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
@@ -1,7 +1,7 @@
 {
     "uuid": "BlurCinnamon@klangman",
     "name": "Blur Cinnamon",
-    "version": "2.0.1",
+    "version": "2.5.0",
     "description": "Allows you to blur, colorize, desaturate and adjust the dimming of several Cinnamon Desktop components",
     "url": "https://github.com/klangman/BlurCinnamon",
     "cinnamon-version": [

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: BlurCinnamon@klangman 2.0.1\n"
+"Project-Id-Version: BlurCinnamon@klangman 2.5.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-06 00:29-0500\n"
+"POT-Creation-Date: 2026-06-06 17:40-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,30 +17,28 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
-#. 6.0/extension.js:2399
+#. 6.0/extension.js:2600 6.0/extension.js:2603 6.0/extension.js:2713
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:2544
+#. 6.0/extension.js:2861
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:2545
+#. 6.0/extension.js:2862
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3301
+#. 6.0/extension.js:3716
 msgid "Welcome to Blur Cinnamon"
 msgstr ""
 
-#. 6.0/extension.js:3302
+#. 6.0/extension.js:3717
 msgid ""
-"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
-"Timeline effects.\n"
+"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
 "Open the Blur Cinnamon Settings to enable additional effects on several "
 "other desktop elements like menus, notifications and windows, or disable "
@@ -49,15 +47,15 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:3306
+#. 6.0/extension.js:3721
 msgid "Open Blur Cinnamon Settings"
 msgstr ""
 
-#. 6.0/extension.js:3388
+#. 6.0/extension.js:3806
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:3389
+#. 6.0/extension.js:3807
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -95,6 +93,10 @@ msgstr ""
 
 #. 6.0->settings-schema.json->general-settings->title
 msgid "Cinnamon desktop components where effects will be applied"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-settings->title
+msgid "Monte Carlo specific settings"
 msgstr ""
 
 #. 6.0->settings-schema.json->component-selector-section->title
@@ -258,8 +260,8 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners and Gaussian effects are based on code by aunetx (Blur-"
-"my-shell)\n"
+"The rounded corners, Gaussian and Monte Carlo effects\n"
+"are based on code by aunetx (Blur-my-shell)\n"
 "<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
 "href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
 "\n"
@@ -330,13 +332,11 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->description
-msgid "Alt-Tab application switcher (Coverflow & Timeline only)"
+msgid "Alt-Tab application switcher"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->tooltip
-msgid ""
-"Apply effects to the Alt-Tab application switcher background when setup to "
-"use the Coverflow or Timeline styles"
+msgid "Apply effects to the Alt-Tab application switcher background"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-tooltips-effects->description
@@ -409,40 +409,81 @@ msgid ""
 "setting to apply."
 msgstr ""
 
+#. 6.0->settings-schema.json->allow-transparent-color-
+#. notifications->description
+msgid "Override some of the notification theme settings (recommended)"
+msgstr ""
+
+#. 6.0->settings-schema.json->allow-transparent-color-notifications->tooltip
+msgid ""
+"Allow this extension to modify the notification transparency and background "
+"color settings. If this is disabled the extension will only apply a blur "
+"background under the notifications. This setting should only be disabled "
+"when the theme already uses transparent notifications and you want the "
+"themes setting to apply."
+msgstr ""
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->description
+msgid "Override some of the tooltip theme settings (recommended)"
+msgstr ""
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->tooltip
+msgid ""
+"Allow this extension to modify the tooltip transparency and background color "
+"settings. If this is disabled the extension will only apply a blur "
+"background under the tooltips. This setting should only be disabled when the "
+"theme already uses transparent tooltips and you want the themes setting to "
+"apply."
+msgstr ""
+
 #. 6.0->settings-schema.json->enable-overview-override->description
-msgid "Use unique effect settings for the Overview"
+msgid "Override the generic effect settings for the Overview"
+msgstr ""
+
+#. 6.0->settings-schema.json->enable-overview-override->tooltip
+#. 6.0->settings-schema.json->enable-expo-override->tooltip
+#. 6.0->settings-schema.json->enable-panels-override->tooltip
+#. 6.0->settings-schema.json->enable-popup-override->tooltip
+#. 6.0->settings-schema.json->enable-desktop-override->tooltip
+#. 6.0->settings-schema.json->enable-notification-override->tooltip
+#. 6.0->settings-schema.json->enable-appswitcher-override->tooltip
+#. 6.0->settings-schema.json->enable-tooltips-override->tooltip
+#. 6.0->settings-schema.json->enable-desklets-override->tooltip
+msgid ""
+"Override the settings found on the \"Generic effect settings\" tab with "
+"unique settings for this cinnamon component."
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-expo-override->description
-msgid "Use unique effect settings for the Expo"
+msgid "Override the generic effect settings for the Expo"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-panels-override->description
-msgid "Use unique effect settings for the Panels"
+msgid "Override the generic effect settings for the Panels"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-popup-override->description
-msgid "Use unique effect settings for the popup menus"
+msgid "Override the generic effect settings for popup menus"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-desktop-override->description
-msgid "Use unique effect settings for the desktop background"
+msgid "Override the generic effect settings for the desktop background"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-notification-override->description
-msgid "Use unique effect settings for the notification popups"
+msgid "Override the generic effect settings for notification popups"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-appswitcher-override->description
-msgid "Use unique effect settings for the Alt-Tab app switcher"
+msgid "Override the generic effect settings for the Alt-Tab app switcher"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-tooltips-override->description
-msgid "Use unique effect settings for the panel tooltips"
+msgid "Override the generic effect settings for panel tooltips"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-desklets-override->description
-msgid "Use unique effect settings for the Desklets"
+msgid "Override the generic effect settings for Desklets"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-desklets-unique-settings->description
@@ -610,7 +651,9 @@ msgstr ""
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple static blur"
 msgstr ""
 
@@ -618,12 +661,28 @@ msgstr ""
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian static blur"
 msgstr ""
 
 #. 6.0->settings-schema.json->blurType->options
 msgid "Gaussian dynamic blur (if applicable)"
+msgstr ""
+
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+msgid "Monte Carlo static blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->blurType->options
+msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr ""
 
 #. 6.0->settings-schema.json->blurType->description
@@ -639,7 +698,6 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr ""
@@ -654,7 +712,7 @@ msgstr ""
 #. 6.0->settings-schema.json->appswitcher-radius->description
 #. 6.0->settings-schema.json->tooltips-radius->description
 #. 6.0->settings-schema.json->desklets-radius->description
-msgid "Gaussian blur intensity"
+msgid "Blur intensity"
 msgstr ""
 
 #. 6.0->settings-schema.json->radius->tooltip
@@ -699,6 +757,48 @@ msgid ""
 "color."
 msgstr ""
 
+#. 6.0->settings-schema.json->monte-carlo-iterations->description
+msgid "Iterations"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
+msgid ""
+"Increasing number of iterations will make the blur appear smoother at the "
+"cost of some CPU power."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
+msgid "Use base pixel"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->tooltip
+msgid ""
+"Whether or not the original pixel is counted for the blur. If it is, the "
+"image will be more legible."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->description
+msgid "Prefer closer pixels"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->tooltip
+msgid ""
+"Whether or not the pixels that are closer to the original pixel will have "
+"more weight."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->description
+msgid ""
+"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->tooltip
+msgid ""
+"The above Monte Carlo settings are used globally for all components that are "
+"configured to use the Monte Carlo blur algorithm, these settings can not be "
+"configured separately for each component"
+msgstr ""
+
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
@@ -710,17 +810,19 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr ""
 
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
+msgstr ""
+
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Monte Carlo"
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->options
@@ -740,8 +842,19 @@ msgstr ""
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian dynamic blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+msgid "Monte Carlo dynamic blur"
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -821,10 +934,43 @@ msgid ""
 "your notification setting behave."
 msgstr ""
 
-#. 6.0->settings-schema.json->appswitcher-info->description
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->description
+msgid "Hide panels while using the Coverflow/Timeline 3D Alt-Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->tooltip
 msgid ""
-"Note: Alt-Tab effects only apply to the Coverflow and Timeline 3D Alt-Tab "
-"configurations"
+"Make the panels invisible when using the Coverflow or the Timeline 3D Alt-"
+"Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->description
+msgid "Apply effects to the standard Alt-Tab switcher"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->tooltip
+msgid ""
+"Allow applying effects to the standard Alt-Tab switcher. Only the switcher "
+"options without \"previews\" are supported. The standard Alt-Tab switcher "
+"can use static or dynamic blur, but dynamic is recommended."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->description
+msgid "Apply effects to the 3D Alt-Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->tooltip
+msgid ""
+"Allow applying effects to the Coverflow and Timeline 3D Alt-Tab switchers. "
+"The 3D Alt-Tab switchers will use static blurring even when dynamic blurring "
+"is selected since they don't benifit from dynamic blurring."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
+msgid ""
+"What type of blur algorithm should be used to blur the background. A dynamic "
+"blur type can be used for the standard switcher but static blurring is "
+"always used for the 3D switchers as they do not benefit from dynamic effects."
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->description
@@ -879,6 +1025,19 @@ msgid ""
 "effect\" extension will be disabled for windows with Blur Cinnamon effects "
 "applied. This option will have no effect unless the \"Compiz window effect\" "
 "extension is installed and active."
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->description
+msgid "Use artifact mitigation techniques"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->tooltip
+msgid ""
+"When enabled, steps will be taken to eliminate background graphical "
+"artifacts for windows that use dynamic blur effects. The mitigation steps "
+"will have some minor persistent CPU costs when a dynamic blurred window is "
+"on top of two or more other windows. This option is recommended unless you "
+"are using video wallpaper like Hidamari"
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-06 00:29-0500\n"
+"POT-Creation-Date: 2026-06-06 17:40-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,32 +18,30 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.6\n"
 
-#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
-#. 6.0/extension.js:2399
+#. 6.0/extension.js:2600 6.0/extension.js:2603 6.0/extension.js:2713
 #, fuzzy
 msgid "Default window settings"
 msgstr "Obrir la configuració d'Alt-Tab de Cinnamon"
 
-#. 6.0/extension.js:2544
+#. 6.0/extension.js:2861
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:2545
+#. 6.0/extension.js:2862
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3301
+#. 6.0/extension.js:3716
 msgid "Welcome to Blur Cinnamon"
 msgstr "Benvingut al Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:3302
+#. 6.0/extension.js:3717
 #, fuzzy
 msgid ""
-"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
-"Timeline effects.\n"
+"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
 "Open the Blur Cinnamon Settings to enable additional effects on several "
 "other desktop elements like menus, notifications and windows, or disable "
@@ -60,15 +58,15 @@ msgstr ""
 "per defecte. També podeu realitzar canvis a les propietats dels efectes, com "
 "ara la intensitat del desenfoc, la saturació del color i l'enfoscament."
 
-#. 6.0/extension.js:3306
+#. 6.0/extension.js:3721
 msgid "Open Blur Cinnamon Settings"
 msgstr "Obre la configuració del Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:3388
+#. 6.0/extension.js:3806
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Provant els efectes del Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:3389
+#. 6.0/extension.js:3807
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -117,6 +115,11 @@ msgstr ""
 #, fuzzy
 msgid "Cinnamon desktop components where effects will be applied"
 msgstr "Components de Cinnamon als quals s'aplicaran els efectes"
+
+#. 6.0->settings-schema.json->monte-carlo-settings->title
+#, fuzzy
+msgid "Monte Carlo specific settings"
+msgstr "Configuració exclusiva del Tauler"
 
 #. 6.0->settings-schema.json->component-selector-section->title
 msgid "Component Selector"
@@ -303,8 +306,8 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners and Gaussian effects are based on code by aunetx (Blur-"
-"my-shell)\n"
+"The rounded corners, Gaussian and Monte Carlo effects\n"
+"are based on code by aunetx (Blur-my-shell)\n"
 "<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
 "href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
 "\n"
@@ -405,13 +408,13 @@ msgstr ""
 "escampi per les vores."
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->description
-msgid "Alt-Tab application switcher (Coverflow & Timeline only)"
+#, fuzzy
+msgid "Alt-Tab application switcher"
 msgstr "Canvi d'aplicació via Alt-Tab (només Animació i línia temporal)"
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->tooltip
-msgid ""
-"Apply effects to the Alt-Tab application switcher background when setup to "
-"use the Coverflow or Timeline styles"
+#, fuzzy
+msgid "Apply effects to the Alt-Tab application switcher background"
 msgstr ""
 "Aplica efectes al canvi d'aplicacions via Alt-Tab o quan s'utilitzen els "
 "estils de Cobertura o Línia temporal"
@@ -512,43 +515,106 @@ msgstr ""
 "només hauria d'estar desactivada quan el tema ja faci ús de taulers "
 "transparents per defecte i voleu que les opcions del mateix s'apliquin."
 
+#. 6.0->settings-schema.json->allow-transparent-color-
+#. notifications->description
+#, fuzzy
+msgid "Override some of the notification theme settings (recommended)"
+msgstr "Sobreescriu algunes de les opcions dels temes als taulers (recomanat)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-notifications->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the notification transparency and background "
+"color settings. If this is disabled the extension will only apply a blur "
+"background under the notifications. This setting should only be disabled "
+"when the theme already uses transparent notifications and you want the "
+"themes setting to apply."
+msgstr ""
+"Permet a aquesta extensió modificar la configuració de transparència i el "
+"color de fons. Si està desactivat, l'extensió només aplicarà difuminació a "
+"sota dels taulers. Aquesta opció només hauria d'estar desactivada quan el "
+"tema ja faci ús de taulers transparents per defecte i voleu que les opcions "
+"del mateix s'apliquin."
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->description
+#, fuzzy
+msgid "Override some of the tooltip theme settings (recommended)"
+msgstr "Sobreescriu algunes de les opcions dels temes als taulers (recomanat)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the tooltip transparency and background color "
+"settings. If this is disabled the extension will only apply a blur "
+"background under the tooltips. This setting should only be disabled when the "
+"theme already uses transparent tooltips and you want the themes setting to "
+"apply."
+msgstr ""
+"Permet a aquesta extensió modificar la configuració de transparència i el "
+"color de fons. Si està desactivat, l'extensió només aplicarà difuminació a "
+"sota dels taulers. Aquesta opció només hauria d'estar desactivada quan el "
+"tema ja faci ús de taulers transparents per defecte i voleu que les opcions "
+"del mateix s'apliquin."
+
 #. 6.0->settings-schema.json->enable-overview-override->description
-msgid "Use unique effect settings for the Overview"
+#, fuzzy
+msgid "Override the generic effect settings for the Overview"
 msgstr "Utilitza ajusts d'efectes exclusius per a la Vista General"
 
+#. 6.0->settings-schema.json->enable-overview-override->tooltip
+#. 6.0->settings-schema.json->enable-expo-override->tooltip
+#. 6.0->settings-schema.json->enable-panels-override->tooltip
+#. 6.0->settings-schema.json->enable-popup-override->tooltip
+#. 6.0->settings-schema.json->enable-desktop-override->tooltip
+#. 6.0->settings-schema.json->enable-notification-override->tooltip
+#. 6.0->settings-schema.json->enable-appswitcher-override->tooltip
+#. 6.0->settings-schema.json->enable-tooltips-override->tooltip
+#. 6.0->settings-schema.json->enable-desklets-override->tooltip
+msgid ""
+"Override the settings found on the \"Generic effect settings\" tab with "
+"unique settings for this cinnamon component."
+msgstr ""
+
 #. 6.0->settings-schema.json->enable-expo-override->description
-msgid "Use unique effect settings for the Expo"
+#, fuzzy
+msgid "Override the generic effect settings for the Expo"
 msgstr "Utilitza ajusts d'efectes exclusius per a l'Exposició"
 
 #. 6.0->settings-schema.json->enable-panels-override->description
-msgid "Use unique effect settings for the Panels"
+#, fuzzy
+msgid "Override the generic effect settings for the Panels"
 msgstr "Utilitza ajusts d'efectes exclusius pels Taulers"
 
 #. 6.0->settings-schema.json->enable-popup-override->description
-msgid "Use unique effect settings for the popup menus"
+#, fuzzy
+msgid "Override the generic effect settings for popup menus"
 msgstr "Utilitza ajusts d'efectes exclusius pels menús emergents"
 
 #. 6.0->settings-schema.json->enable-desktop-override->description
-msgid "Use unique effect settings for the desktop background"
+#, fuzzy
+msgid "Override the generic effect settings for the desktop background"
 msgstr "Utilitza ajusts d'efectes exclusius pel fons d'escriptori"
 
 #. 6.0->settings-schema.json->enable-notification-override->description
-msgid "Use unique effect settings for the notification popups"
+#, fuzzy
+msgid "Override the generic effect settings for notification popups"
 msgstr "Utilitza ajusts d'efectes exclusius per a les notificacions emergents"
 
 #. 6.0->settings-schema.json->enable-appswitcher-override->description
-msgid "Use unique effect settings for the Alt-Tab app switcher"
+#, fuzzy
+msgid "Override the generic effect settings for the Alt-Tab app switcher"
 msgstr ""
 "Utilitza ajusts d'efectes exclusius pel canvi d'aplicacions via Alt-Tab"
 
 #. 6.0->settings-schema.json->enable-tooltips-override->description
-msgid "Use unique effect settings for the panel tooltips"
+#, fuzzy
+msgid "Override the generic effect settings for panel tooltips"
 msgstr ""
 "Utilitza ajusts d'efectes exclusius per a la informació emergent als taulers"
 
 #. 6.0->settings-schema.json->enable-desklets-override->description
 #, fuzzy
-msgid "Use unique effect settings for the Desklets"
+msgid "Override the generic effect settings for Desklets"
 msgstr "Utilitza ajusts d'efectes exclusius pels Taulers"
 
 #. 6.0->settings-schema.json->enable-desklets-unique-settings->description
@@ -735,7 +801,9 @@ msgstr "Fons d'escriptori"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple static blur"
 msgstr ""
 
@@ -743,13 +811,30 @@ msgstr ""
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 #, fuzzy
 msgid "Gaussian static blur"
 msgstr "Intensitat del difuminat Gaussià"
 
 #. 6.0->settings-schema.json->blurType->options
 msgid "Gaussian dynamic blur (if applicable)"
+msgstr ""
+
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo static blur"
+msgstr "Intensitat del difuminat Gaussià"
+
+#. 6.0->settings-schema.json->blurType->options
+msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr ""
 
 #. 6.0->settings-schema.json->blurType->description
@@ -765,7 +850,6 @@ msgstr "Tipus d'efecte de difuminat"
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Tipus d'algorisme de difuminat que s'utilitzarà pel fons"
@@ -780,7 +864,8 @@ msgstr "Tipus d'algorisme de difuminat que s'utilitzarà pel fons"
 #. 6.0->settings-schema.json->appswitcher-radius->description
 #. 6.0->settings-schema.json->tooltips-radius->description
 #. 6.0->settings-schema.json->desklets-radius->description
-msgid "Gaussian blur intensity"
+#, fuzzy
+msgid "Blur intensity"
 msgstr "Intensitat del difuminat Gaussià"
 
 #. 6.0->settings-schema.json->radius->tooltip
@@ -828,6 +913,49 @@ msgid ""
 "color."
 msgstr "Ajusta la saturació de color de la imatge de fons."
 
+#. 6.0->settings-schema.json->monte-carlo-iterations->description
+#, fuzzy
+msgid "Iterations"
+msgstr "Saturació"
+
+#. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
+msgid ""
+"Increasing number of iterations will make the blur appear smoother at the "
+"cost of some CPU power."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
+msgid "Use base pixel"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->tooltip
+msgid ""
+"Whether or not the original pixel is counted for the blur. If it is, the "
+"image will be more legible."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->description
+msgid "Prefer closer pixels"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->tooltip
+msgid ""
+"Whether or not the pixels that are closer to the original pixel will have "
+"more weight."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->description
+msgid ""
+"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->tooltip
+msgid ""
+"The above Monte Carlo settings are used globally for all components that are "
+"configured to use the Monte Carlo blur algorithm, these settings can not be "
+"configured separately for each component"
+msgstr ""
+
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
@@ -839,18 +967,20 @@ msgstr "Cap"
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Simple"
 
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gaussià"
+
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Monte Carlo"
+msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
@@ -870,9 +1000,21 @@ msgstr "Fons d'escriptori"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 #, fuzzy
 msgid "Gaussian dynamic blur"
+msgstr "Intensitat del difuminat Gaussià"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo dynamic blur"
 msgstr "Intensitat del difuminat Gaussià"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -968,10 +1110,47 @@ msgstr ""
 "Aquest botó causarà l'enviament d'una notificació de prova per tal que "
 "pugueu visualitzar com es comporta."
 
-#. 6.0->settings-schema.json->appswitcher-info->description
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->description
+msgid "Hide panels while using the Coverflow/Timeline 3D Alt-Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->tooltip
 msgid ""
-"Note: Alt-Tab effects only apply to the Coverflow and Timeline 3D Alt-Tab "
-"configurations"
+"Make the panels invisible when using the Coverflow or the Timeline 3D Alt-"
+"Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->description
+#, fuzzy
+msgid "Apply effects to the standard Alt-Tab switcher"
+msgstr ""
+"Utilitza ajusts d'efectes exclusius pel canvi d'aplicacions via Alt-Tab"
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->tooltip
+msgid ""
+"Allow applying effects to the standard Alt-Tab switcher. Only the switcher "
+"options without \"previews\" are supported. The standard Alt-Tab switcher "
+"can use static or dynamic blur, but dynamic is recommended."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->description
+#, fuzzy
+msgid "Apply effects to the 3D Alt-Tab switchers"
+msgstr ""
+"Utilitza ajusts d'efectes exclusius pel canvi d'aplicacions via Alt-Tab"
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->tooltip
+msgid ""
+"Allow applying effects to the Coverflow and Timeline 3D Alt-Tab switchers. "
+"The 3D Alt-Tab switchers will use static blurring even when dynamic blurring "
+"is selected since they don't benifit from dynamic blurring."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
+msgid ""
+"What type of blur algorithm should be used to blur the background. A dynamic "
+"blur type can be used for the standard switcher but static blurring is "
+"always used for the 3D switchers as they do not benefit from dynamic effects."
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->description
@@ -1026,6 +1205,19 @@ msgid ""
 "effect\" extension will be disabled for windows with Blur Cinnamon effects "
 "applied. This option will have no effect unless the \"Compiz window effect\" "
 "extension is installed and active."
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->description
+msgid "Use artifact mitigation techniques"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->tooltip
+msgid ""
+"When enabled, steps will be taken to eliminate background graphical "
+"artifacts for windows that use dynamic blur effects. The mitigation steps "
+"will have some minor persistent CPU costs when a dynamic blurred window is "
+"on top of two or more other windows. This option is recommended unless you "
+"are using video wallpaper like Hidamari"
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/da.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.5.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-06 00:29-0500\n"
+"POT-Creation-Date: 2026-06-06 17:40-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Alan Mortensen <over.tackiness223@passinbox.com>\n"
 "Language-Team: \n"
@@ -18,16 +18,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
-#. 6.0/extension.js:2399
+#. 6.0/extension.js:2600 6.0/extension.js:2603 6.0/extension.js:2713
 msgid "Default window settings"
 msgstr "Standardvinduesindstillinger"
 
-#. 6.0/extension.js:2544
+#. 6.0/extension.js:2861
 msgid "Error"
 msgstr "Fejl"
 
-#. 6.0/extension.js:2545
+#. 6.0/extension.js:2862
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
@@ -37,14 +36,14 @@ msgstr ""
 "vindue, der tidligere var i fokus, tilhører, og derfor kan Blur Cinnamon-"
 "effekterne ikke anvendes på dette vindue"
 
-#. 6.0/extension.js:3301
+#. 6.0/extension.js:3716
 msgid "Welcome to Blur Cinnamon"
 msgstr "Velkommen til Sløret Cinnamon"
 
-#. 6.0/extension.js:3302
+#. 6.0/extension.js:3717
+#, fuzzy
 msgid ""
-"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
-"Timeline effects.\n"
+"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
 "Open the Blur Cinnamon Settings to enable additional effects on several "
 "other desktop elements like menus, notifications and windows, or disable "
@@ -61,15 +60,15 @@ msgstr ""
 "kan også foretage ændringer i effektens egenskaber, såsom sløringens "
 "intensitet, farvemætning og dæmpning."
 
-#. 6.0/extension.js:3306
+#. 6.0/extension.js:3721
 msgid "Open Blur Cinnamon Settings"
 msgstr "Åbn Sløret Cinnamon-indstillinger"
 
-#. 6.0/extension.js:3388
+#. 6.0/extension.js:3806
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Tester Sløret Cinnamons underretningseffekter"
 
-#. 6.0/extension.js:3389
+#. 6.0/extension.js:3807
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -112,6 +111,11 @@ msgstr "Om"
 #. 6.0->settings-schema.json->general-settings->title
 msgid "Cinnamon desktop components where effects will be applied"
 msgstr "Cinnamon-skrivebordskomponenter som vil blive påvirket af effekter"
+
+#. 6.0->settings-schema.json->monte-carlo-settings->title
+#, fuzzy
+msgid "Monte Carlo specific settings"
+msgstr "Panelspecifikke indstillinger"
 
 #. 6.0->settings-schema.json->component-selector-section->title
 msgid "Component Selector"
@@ -299,6 +303,7 @@ msgid "Show settings for component:"
 msgstr "Vis indstillinger for komponent:"
 
 #. 6.0->settings-schema.json->about-text->description
+#, fuzzy
 msgid ""
 "\n"
 "<b>Bringing your style into focus</b>\n"
@@ -307,11 +312,11 @@ msgid ""
 "Developed by: Kevin Langman\n"
 "<a href=\"https://github.com/klangman/BlurCinnamon\">Github</a> / <a "
 "href=\"https://github.com/klangman/BlurCinnamon/issues/new\">Report an "
-"issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/"
-"view/104\">Website</a>\n"
+"issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
+"104\">Website</a>\n"
 "\n"
-"The rounded corners and Gaussian effects are based on code by aunetx (Blur-"
-"my-shell)\n"
+"The rounded corners, Gaussian and Monte Carlo effects\n"
+"are based on code by aunetx (Blur-my-shell)\n"
 "<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
 "href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
 "\n"
@@ -421,13 +426,13 @@ msgstr ""
 "er synlig."
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->description
-msgid "Alt-Tab application switcher (Coverflow & Timeline only)"
+#, fuzzy
+msgid "Alt-Tab application switcher"
 msgstr "Alt-Tab-programskifter (kun Coverflow og Tidslinje)"
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->tooltip
-msgid ""
-"Apply effects to the Alt-Tab application switcher background when setup to "
-"use the Coverflow or Timeline styles"
+#, fuzzy
+msgid "Apply effects to the Alt-Tab application switcher background"
 msgstr ""
 "Anvend effekter på Alt-Tab-programskifterens baggrund, når den er indstillet "
 "til at bruge Coverflow- eller Tidslinje-stilene"
@@ -532,40 +537,104 @@ msgstr ""
 "deaktiveres, hvis temaet allerede bruger gennemsigtige pop op-menuer, og du "
 "ønsker, at temaets indstillinger skal anvendes."
 
+#. 6.0->settings-schema.json->allow-transparent-color-
+#. notifications->description
+#, fuzzy
+msgid "Override some of the notification theme settings (recommended)"
+msgstr "Tilsidesæt nogle af panelets temaindstillinger (anbefalet)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-notifications->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the notification transparency and background "
+"color settings. If this is disabled the extension will only apply a blur "
+"background under the notifications. This setting should only be disabled "
+"when the theme already uses transparent notifications and you want the "
+"themes setting to apply."
+msgstr ""
+"Tillad denne udvidelse at ændre panelernes gennemsigtighed og "
+"baggrundsfarveindstillinger. Hvis dette er deaktiveret, vil udvidelsen kun "
+"anvende en sløret baggrund under panelerne. Denne indstilling bør kun "
+"deaktiveres, hvis temaet allerede bruger gennemsigtige paneler, og du "
+"ønsker, at temaets indstillinger skal anvendes."
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->description
+#, fuzzy
+msgid "Override some of the tooltip theme settings (recommended)"
+msgstr "Tilsidesæt nogle af panelets temaindstillinger (anbefalet)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the tooltip transparency and background color "
+"settings. If this is disabled the extension will only apply a blur "
+"background under the tooltips. This setting should only be disabled when the "
+"theme already uses transparent tooltips and you want the themes setting to "
+"apply."
+msgstr ""
+"Tillad denne udvidelse at ændre panelernes gennemsigtighed og "
+"baggrundsfarveindstillinger. Hvis dette er deaktiveret, vil udvidelsen kun "
+"anvende en sløret baggrund under panelerne. Denne indstilling bør kun "
+"deaktiveres, hvis temaet allerede bruger gennemsigtige paneler, og du "
+"ønsker, at temaets indstillinger skal anvendes."
+
 #. 6.0->settings-schema.json->enable-overview-override->description
-msgid "Use unique effect settings for the Overview"
+#, fuzzy
+msgid "Override the generic effect settings for the Overview"
 msgstr "Brug unikke effektindstillinger til Oversigten"
 
+#. 6.0->settings-schema.json->enable-overview-override->tooltip
+#. 6.0->settings-schema.json->enable-expo-override->tooltip
+#. 6.0->settings-schema.json->enable-panels-override->tooltip
+#. 6.0->settings-schema.json->enable-popup-override->tooltip
+#. 6.0->settings-schema.json->enable-desktop-override->tooltip
+#. 6.0->settings-schema.json->enable-notification-override->tooltip
+#. 6.0->settings-schema.json->enable-appswitcher-override->tooltip
+#. 6.0->settings-schema.json->enable-tooltips-override->tooltip
+#. 6.0->settings-schema.json->enable-desklets-override->tooltip
+msgid ""
+"Override the settings found on the \"Generic effect settings\" tab with "
+"unique settings for this cinnamon component."
+msgstr ""
+
 #. 6.0->settings-schema.json->enable-expo-override->description
-msgid "Use unique effect settings for the Expo"
+#, fuzzy
+msgid "Override the generic effect settings for the Expo"
 msgstr "Brug unikke effektindstillinger til Vis arbejdsområder"
 
 #. 6.0->settings-schema.json->enable-panels-override->description
-msgid "Use unique effect settings for the Panels"
+#, fuzzy
+msgid "Override the generic effect settings for the Panels"
 msgstr "Brug unikke effektindstillinger til paneler"
 
 #. 6.0->settings-schema.json->enable-popup-override->description
-msgid "Use unique effect settings for the popup menus"
+#, fuzzy
+msgid "Override the generic effect settings for popup menus"
 msgstr "Brug unikke effektindstillinger til pop op-menuer"
 
 #. 6.0->settings-schema.json->enable-desktop-override->description
-msgid "Use unique effect settings for the desktop background"
+#, fuzzy
+msgid "Override the generic effect settings for the desktop background"
 msgstr "Brug unikke effektindstillinger til skrivebordsbaggrunden"
 
 #. 6.0->settings-schema.json->enable-notification-override->description
-msgid "Use unique effect settings for the notification popups"
+#, fuzzy
+msgid "Override the generic effect settings for notification popups"
 msgstr "Brug unikke effektindstillinger til pop op-vinduer til underretninger"
 
 #. 6.0->settings-schema.json->enable-appswitcher-override->description
-msgid "Use unique effect settings for the Alt-Tab app switcher"
+#, fuzzy
+msgid "Override the generic effect settings for the Alt-Tab app switcher"
 msgstr "Brug unikke effektindstillinger til Alt-Tab-programskifteren"
 
 #. 6.0->settings-schema.json->enable-tooltips-override->description
-msgid "Use unique effect settings for the panel tooltips"
+#, fuzzy
+msgid "Override the generic effect settings for panel tooltips"
 msgstr "Brug unikke effektindstillinger til panelværktøjstip"
 
 #. 6.0->settings-schema.json->enable-desklets-override->description
-msgid "Use unique effect settings for the Desklets"
+#, fuzzy
+msgid "Override the generic effect settings for Desklets"
 msgstr "Brug unikke effektindstillinger til skrivebordsprogrammer"
 
 #. 6.0->settings-schema.json->enable-desklets-unique-settings->description
@@ -762,7 +831,9 @@ msgstr "Ingen / gennemsigtig til baggrunden"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple static blur"
 msgstr "Enkel statisk sløring"
 
@@ -770,12 +841,30 @@ msgstr "Enkel statisk sløring"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian static blur"
 msgstr "Gaussisk statisk sløring"
 
 #. 6.0->settings-schema.json->blurType->options
 msgid "Gaussian dynamic blur (if applicable)"
+msgstr "Gaussisk dynamisk sløring (hvis tilgængelig)"
+
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo static blur"
+msgstr "Enkel statisk sløring"
+
+#. 6.0->settings-schema.json->blurType->options
+#, fuzzy
+msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr "Gaussisk dynamisk sløring (hvis tilgængelig)"
 
 #. 6.0->settings-schema.json->blurType->description
@@ -791,7 +880,6 @@ msgstr "Type af sløringseffekt"
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Hvilken type sløringsalgoritme skal bruges til at sløre baggrunden."
@@ -806,7 +894,8 @@ msgstr "Hvilken type sløringsalgoritme skal bruges til at sløre baggrunden."
 #. 6.0->settings-schema.json->appswitcher-radius->description
 #. 6.0->settings-schema.json->tooltips-radius->description
 #. 6.0->settings-schema.json->desklets-radius->description
-msgid "Gaussian blur intensity"
+#, fuzzy
+msgid "Blur intensity"
 msgstr "Gaussisk sløringsintensitet"
 
 #. 6.0->settings-schema.json->radius->tooltip
@@ -853,6 +942,49 @@ msgid ""
 "color."
 msgstr "Justerer baggrundsbilledets farvemætning fra gråskala til fuld farve."
 
+#. 6.0->settings-schema.json->monte-carlo-iterations->description
+#, fuzzy
+msgid "Iterations"
+msgstr "Mætning"
+
+#. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
+msgid ""
+"Increasing number of iterations will make the blur appear smoother at the "
+"cost of some CPU power."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
+msgid "Use base pixel"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->tooltip
+msgid ""
+"Whether or not the original pixel is counted for the blur. If it is, the "
+"image will be more legible."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->description
+msgid "Prefer closer pixels"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->tooltip
+msgid ""
+"Whether or not the pixels that are closer to the original pixel will have "
+"more weight."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->description
+msgid ""
+"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->tooltip
+msgid ""
+"The above Monte Carlo settings are used globally for all components that are "
+"configured to use the Monte Carlo blur algorithm, these settings can not be "
+"configured separately for each component"
+msgstr ""
+
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
@@ -864,18 +996,20 @@ msgstr "Ingen"
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Simpel"
 
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gaussisk"
+
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Monte Carlo"
+msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
@@ -894,8 +1028,20 @@ msgstr "Gennemsigtig til baggrund"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian dynamic blur"
+msgstr "Gaussisk dynamisk sløring"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo dynamic blur"
 msgstr "Gaussisk dynamisk sløring"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -930,9 +1076,9 @@ msgstr "Yderligere dæmpning af fremhævede pop op-menuelementer (%)"
 
 #. 6.0->settings-schema.json->popup-accent-opacity->tooltip
 msgid ""
-"Defines the additional dimming applied to the popup menu accent elements (i."
-"e. the main menu favorites box and entry boxes) which allow these elements "
-"to stand out from the other popup menu areas"
+"Defines the additional dimming applied to the popup menu accent elements "
+"(i.e. the main menu favorites box and entry boxes) which allow these "
+"elements to stand out from the other popup menu areas"
 msgstr ""
 "Definerer den ekstra dæmpning, der anvendes på pop op-menuenes fremhævede "
 "elementer (dvs. hovedmenuenes favoritfelt og indtastningsfelter), som gør "
@@ -986,13 +1132,46 @@ msgstr ""
 "Denne knap frembringer en underretningsmeddelelse, så du kan se, hvordan "
 "dine underretningssindstillinger fungerer."
 
-#. 6.0->settings-schema.json->appswitcher-info->description
-msgid ""
-"Note: Alt-Tab effects only apply to the Coverflow and Timeline 3D Alt-Tab "
-"configurations"
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->description
+msgid "Hide panels while using the Coverflow/Timeline 3D Alt-Tab switchers"
 msgstr ""
-"Bemærk: Alt-Tab-effekterne gælder kun for Alt-Tab-konfigurationerne for "
-"Coverflow og Timeline 3D"
+
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->tooltip
+msgid ""
+"Make the panels invisible when using the Coverflow or the Timeline 3D Alt-"
+"Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->description
+#, fuzzy
+msgid "Apply effects to the standard Alt-Tab switcher"
+msgstr "Brug unikke effektindstillinger til Alt-Tab-programskifteren"
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->tooltip
+msgid ""
+"Allow applying effects to the standard Alt-Tab switcher. Only the switcher "
+"options without \"previews\" are supported. The standard Alt-Tab switcher "
+"can use static or dynamic blur, but dynamic is recommended."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->description
+#, fuzzy
+msgid "Apply effects to the 3D Alt-Tab switchers"
+msgstr "Brug unikke effektindstillinger til Alt-Tab-programskifteren"
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->tooltip
+msgid ""
+"Allow applying effects to the Coverflow and Timeline 3D Alt-Tab switchers. "
+"The 3D Alt-Tab switchers will use static blurring even when dynamic blurring "
+"is selected since they don't benifit from dynamic blurring."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
+msgid ""
+"What type of blur algorithm should be used to blur the background. A dynamic "
+"blur type can be used for the standard switcher but static blurring is "
+"always used for the 3D switchers as they do not benefit from dynamic effects."
+msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->description
 msgid "Application window inclusion list"
@@ -1058,6 +1237,19 @@ msgstr ""
 "der skabes af udvidelsen “Compiz-vindueseffekt”, for vinduer, hvor der er "
 "anvendt Sløret Cinnamon-effekter. Denne indstilling har ingen virkning, "
 "medmindre udvidelsen “Compiz-vindueseffekt” er installeret og aktiveret."
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->description
+msgid "Use artifact mitigation techniques"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->tooltip
+msgid ""
+"When enabled, steps will be taken to eliminate background graphical "
+"artifacts for windows that use dynamic blur effects. The mitigation steps "
+"will have some minor persistent CPU costs when a dynamic blurred window is "
+"on top of two or more other windows. This option is recommended unless you "
+"are using video wallpaper like Hidamari"
+msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description
 msgid "Automatically enable effects for newly added Desklets"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-06 00:29-0500\n"
+"POT-Creation-Date: 2026-06-06 17:40-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,16 +17,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.8\n"
 
-#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
-#. 6.0/extension.js:2399
+#. 6.0/extension.js:2600 6.0/extension.js:2603 6.0/extension.js:2713
 msgid "Default window settings"
 msgstr "Configuración predeterminada de la ventana"
 
-#. 6.0/extension.js:2544
+#. 6.0/extension.js:2861
 msgid "Error"
 msgstr "Error"
 
-#. 6.0/extension.js:2545
+#. 6.0/extension.js:2862
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
@@ -36,14 +35,14 @@ msgstr ""
 "tenía el foco anteriormente, por lo que no se pueden aplicar los efectos de "
 "Desenfoque Cinnamon a esa ventana"
 
-#. 6.0/extension.js:3301
+#. 6.0/extension.js:3716
 msgid "Welcome to Blur Cinnamon"
 msgstr "Bienvenido a Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:3302
+#. 6.0/extension.js:3717
+#, fuzzy
 msgid ""
-"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
-"Timeline effects.\n"
+"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
 "Open the Blur Cinnamon Settings to enable additional effects on several "
 "other desktop elements like menus, notifications and windows, or disable "
@@ -60,15 +59,15 @@ msgstr ""
 "También puedes realizar cambios en las propiedades de los efectos, como la "
 "intensidad del desenfoque, la saturación del color y el oscurecimiento."
 
-#. 6.0/extension.js:3306
+#. 6.0/extension.js:3721
 msgid "Open Blur Cinnamon Settings"
 msgstr "Abrir configuración de Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:3388
+#. 6.0/extension.js:3806
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Probando los efectos de notificación de Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:3389
+#. 6.0/extension.js:3807
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -117,6 +116,11 @@ msgstr "Acerca de"
 #. 6.0->settings-schema.json->general-settings->title
 msgid "Cinnamon desktop components where effects will be applied"
 msgstr "Componentes del escritorio Cinnamon a los que se aplicarán los efectos"
+
+#. 6.0->settings-schema.json->monte-carlo-settings->title
+#, fuzzy
+msgid "Monte Carlo specific settings"
+msgstr "Configuraciones específicas del panel"
 
 #. 6.0->settings-schema.json->component-selector-section->title
 msgid "Component Selector"
@@ -305,6 +309,7 @@ msgid "Show settings for component:"
 msgstr "Mostrar configuración del componente:"
 
 #. 6.0->settings-schema.json->about-text->description
+#, fuzzy
 msgid ""
 "\n"
 "<b>Bringing your style into focus</b>\n"
@@ -316,8 +321,8 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners and Gaussian effects are based on code by aunetx (Blur-"
-"my-shell)\n"
+"The rounded corners, Gaussian and Monte Carlo effects\n"
+"are based on code by aunetx (Blur-my-shell)\n"
 "<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
 "href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
 "\n"
@@ -430,13 +435,13 @@ msgstr ""
 "modo que se vea el fondo difuminado."
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->description
-msgid "Alt-Tab application switcher (Coverflow & Timeline only)"
+#, fuzzy
+msgid "Alt-Tab application switcher"
 msgstr "Selector de aplicaciones Alt-Tab (solo Coverflow y Línea de tiempo)"
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->tooltip
-msgid ""
-"Apply effects to the Alt-Tab application switcher background when setup to "
-"use the Coverflow or Timeline styles"
+#, fuzzy
+msgid "Apply effects to the Alt-Tab application switcher background"
 msgstr ""
 "Aplicar efectos al fondo del selector de aplicaciones Alt-Tab cuando se "
 "configura para usar los estilos Coverflow o Línea de tiempo"
@@ -543,46 +548,110 @@ msgstr ""
 "configuración solo debe desactivarse cuando el tema ya utilice menús "
 "emergentes transparentes y se desee aplicar la configuración del tema."
 
+#. 6.0->settings-schema.json->allow-transparent-color-
+#. notifications->description
+#, fuzzy
+msgid "Override some of the notification theme settings (recommended)"
+msgstr "Anular algunos ajustes del tema de los paneles (recomendado)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-notifications->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the notification transparency and background "
+"color settings. If this is disabled the extension will only apply a blur "
+"background under the notifications. This setting should only be disabled "
+"when the theme already uses transparent notifications and you want the "
+"themes setting to apply."
+msgstr ""
+"Permite que esta extensión modifique la configuración de transparencia y "
+"color de fondo de los paneles. Si se desactiva, la extensión solo aplicará "
+"un fondo difuminado debajo de los paneles. Esta configuración solo debe "
+"desactivarse cuando el tema ya utilice paneles transparentes y se desee "
+"aplicar la configuración del tema."
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->description
+#, fuzzy
+msgid "Override some of the tooltip theme settings (recommended)"
+msgstr "Anular algunos ajustes del tema de los paneles (recomendado)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the tooltip transparency and background color "
+"settings. If this is disabled the extension will only apply a blur "
+"background under the tooltips. This setting should only be disabled when the "
+"theme already uses transparent tooltips and you want the themes setting to "
+"apply."
+msgstr ""
+"Permite que esta extensión modifique la configuración de transparencia y "
+"color de fondo de los paneles. Si se desactiva, la extensión solo aplicará "
+"un fondo difuminado debajo de los paneles. Esta configuración solo debe "
+"desactivarse cuando el tema ya utilice paneles transparentes y se desee "
+"aplicar la configuración del tema."
+
 #. 6.0->settings-schema.json->enable-overview-override->description
-msgid "Use unique effect settings for the Overview"
+#, fuzzy
+msgid "Override the generic effect settings for the Overview"
 msgstr "Usar ajustes de efectos exclusivos para la Vista general"
 
+#. 6.0->settings-schema.json->enable-overview-override->tooltip
+#. 6.0->settings-schema.json->enable-expo-override->tooltip
+#. 6.0->settings-schema.json->enable-panels-override->tooltip
+#. 6.0->settings-schema.json->enable-popup-override->tooltip
+#. 6.0->settings-schema.json->enable-desktop-override->tooltip
+#. 6.0->settings-schema.json->enable-notification-override->tooltip
+#. 6.0->settings-schema.json->enable-appswitcher-override->tooltip
+#. 6.0->settings-schema.json->enable-tooltips-override->tooltip
+#. 6.0->settings-schema.json->enable-desklets-override->tooltip
+msgid ""
+"Override the settings found on the \"Generic effect settings\" tab with "
+"unique settings for this cinnamon component."
+msgstr ""
+
 #. 6.0->settings-schema.json->enable-expo-override->description
-msgid "Use unique effect settings for the Expo"
+#, fuzzy
+msgid "Override the generic effect settings for the Expo"
 msgstr "Usar ajustes de efectos exclusivos para el efecto Exposición"
 
 #. 6.0->settings-schema.json->enable-panels-override->description
-msgid "Use unique effect settings for the Panels"
+#, fuzzy
+msgid "Override the generic effect settings for the Panels"
 msgstr "Usar ajustes de efectos exclusivos para los Paneles"
 
 #. 6.0->settings-schema.json->enable-popup-override->description
-msgid "Use unique effect settings for the popup menus"
+#, fuzzy
+msgid "Override the generic effect settings for popup menus"
 msgstr "Usar ajustes de efectos exclusivos para los menús emergentes"
 
 #. 6.0->settings-schema.json->enable-desktop-override->description
-msgid "Use unique effect settings for the desktop background"
+#, fuzzy
+msgid "Override the generic effect settings for the desktop background"
 msgstr ""
 "Utiliza una configuración de efectos exclusivos para el fondo de escritorio"
 
 #. 6.0->settings-schema.json->enable-notification-override->description
-msgid "Use unique effect settings for the notification popups"
+#, fuzzy
+msgid "Override the generic effect settings for notification popups"
 msgstr ""
 "Usar ajustes de efectos exclusivos para las ventanas emergentes de "
 "notificación"
 
 #. 6.0->settings-schema.json->enable-appswitcher-override->description
-msgid "Use unique effect settings for the Alt-Tab app switcher"
+#, fuzzy
+msgid "Override the generic effect settings for the Alt-Tab app switcher"
 msgstr ""
 "Usar ajustes de efectos exclusivos para el selector de aplicaciones Alt-Tab"
 
 #. 6.0->settings-schema.json->enable-tooltips-override->description
-msgid "Use unique effect settings for the panel tooltips"
+#, fuzzy
+msgid "Override the generic effect settings for panel tooltips"
 msgstr ""
 "Usar ajustes de efectos exclusivos para las descripciones emergentes del "
 "panel"
 
 #. 6.0->settings-schema.json->enable-desklets-override->description
-msgid "Use unique effect settings for the Desklets"
+#, fuzzy
+msgid "Override the generic effect settings for Desklets"
 msgstr "Utiliza ajustes de efectos únicos para los Desklets"
 
 #. 6.0->settings-schema.json->enable-desklets-unique-settings->description
@@ -778,7 +847,9 @@ msgstr "Ninguno / Transparente para el fondo de pantalla"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple static blur"
 msgstr "Desenfoque estático simple"
 
@@ -786,12 +857,30 @@ msgstr "Desenfoque estático simple"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian static blur"
 msgstr "Desenfoque gaussiano estático"
 
 #. 6.0->settings-schema.json->blurType->options
 msgid "Gaussian dynamic blur (if applicable)"
+msgstr "Desenfoque dinámico gaussiano (si procede)"
+
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo static blur"
+msgstr "Desenfoque estático simple"
+
+#. 6.0->settings-schema.json->blurType->options
+#, fuzzy
+msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr "Desenfoque dinámico gaussiano (si procede)"
 
 #. 6.0->settings-schema.json->blurType->description
@@ -807,7 +896,6 @@ msgstr "Tipo de efecto de desenfoque"
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr ""
@@ -823,7 +911,8 @@ msgstr ""
 #. 6.0->settings-schema.json->appswitcher-radius->description
 #. 6.0->settings-schema.json->tooltips-radius->description
 #. 6.0->settings-schema.json->desklets-radius->description
-msgid "Gaussian blur intensity"
+#, fuzzy
+msgid "Blur intensity"
 msgstr "Intensidad del desenfoque gaussiano"
 
 #. 6.0->settings-schema.json->radius->tooltip
@@ -872,6 +961,49 @@ msgstr ""
 "Ajusta la saturación del color de la imagen de fondo, desde escala de grises "
 "hasta color completo."
 
+#. 6.0->settings-schema.json->monte-carlo-iterations->description
+#, fuzzy
+msgid "Iterations"
+msgstr "Saturación"
+
+#. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
+msgid ""
+"Increasing number of iterations will make the blur appear smoother at the "
+"cost of some CPU power."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
+msgid "Use base pixel"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->tooltip
+msgid ""
+"Whether or not the original pixel is counted for the blur. If it is, the "
+"image will be more legible."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->description
+msgid "Prefer closer pixels"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->tooltip
+msgid ""
+"Whether or not the pixels that are closer to the original pixel will have "
+"more weight."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->description
+msgid ""
+"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->tooltip
+msgid ""
+"The above Monte Carlo settings are used globally for all components that are "
+"configured to use the Monte Carlo blur algorithm, these settings can not be "
+"configured separately for each component"
+msgstr ""
+
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
@@ -883,18 +1015,20 @@ msgstr "Ninguno"
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Sencillo"
 
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gaussiano"
+
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Monte Carlo"
+msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
@@ -913,8 +1047,20 @@ msgstr "Transparente al fondo de pantalla"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian dynamic blur"
+msgstr "Desenfoque dinámico gaussiano"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo dynamic blur"
 msgstr "Desenfoque dinámico gaussiano"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -1009,13 +1155,48 @@ msgstr ""
 "Este botón hará que aparezca un mensaje de notificación para que puedas ver "
 "cómo funciona su configuración de notificaciones."
 
-#. 6.0->settings-schema.json->appswitcher-info->description
-msgid ""
-"Note: Alt-Tab effects only apply to the Coverflow and Timeline 3D Alt-Tab "
-"configurations"
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->description
+msgid "Hide panels while using the Coverflow/Timeline 3D Alt-Tab switchers"
 msgstr ""
-"Nota: Los efectos Alt-Tab solo se aplican a las configuraciones Alt-Tab de "
-"Coverflow y Timeline 3D"
+
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->tooltip
+msgid ""
+"Make the panels invisible when using the Coverflow or the Timeline 3D Alt-"
+"Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->description
+#, fuzzy
+msgid "Apply effects to the standard Alt-Tab switcher"
+msgstr ""
+"Usar ajustes de efectos exclusivos para el selector de aplicaciones Alt-Tab"
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->tooltip
+msgid ""
+"Allow applying effects to the standard Alt-Tab switcher. Only the switcher "
+"options without \"previews\" are supported. The standard Alt-Tab switcher "
+"can use static or dynamic blur, but dynamic is recommended."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->description
+#, fuzzy
+msgid "Apply effects to the 3D Alt-Tab switchers"
+msgstr ""
+"Usar ajustes de efectos exclusivos para el selector de aplicaciones Alt-Tab"
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->tooltip
+msgid ""
+"Allow applying effects to the Coverflow and Timeline 3D Alt-Tab switchers. "
+"The 3D Alt-Tab switchers will use static blurring even when dynamic blurring "
+"is selected since they don't benifit from dynamic blurring."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
+msgid ""
+"What type of blur algorithm should be used to blur the background. A dynamic "
+"blur type can be used for the standard switcher but static blurring is "
+"always used for the 3D switchers as they do not benefit from dynamic effects."
+msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->description
 msgid "Application window inclusion list"
@@ -1085,6 +1266,19 @@ msgstr ""
 "efectos de Desenfoque de Cinnamon aplicados. Esta opción no tendrá ningún "
 "efecto a menos que la extensión \"Efecto de ventanas Compiz\" esté instalada "
 "y activa."
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->description
+msgid "Use artifact mitigation techniques"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->tooltip
+msgid ""
+"When enabled, steps will be taken to eliminate background graphical "
+"artifacts for windows that use dynamic blur effects. The mitigation steps "
+"will have some minor persistent CPU costs when a dynamic blurred window is "
+"on top of two or more other windows. This option is recommended unless you "
+"are using video wallpaper like Hidamari"
+msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description
 msgid "Automatically enable effects for newly added Desklets"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fi.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-06 00:29-0500\n"
+"POT-Creation-Date: 2026-06-06 17:40-0400\n"
 "PO-Revision-Date: 2025-03-30 10:53+0300\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -18,31 +18,29 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
-#. 6.0/extension.js:2399
+#. 6.0/extension.js:2600 6.0/extension.js:2603 6.0/extension.js:2713
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:2544
+#. 6.0/extension.js:2861
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:2545
+#. 6.0/extension.js:2862
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3301
+#. 6.0/extension.js:3716
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Blur Cinnamon"
 
-#. 6.0/extension.js:3302
+#. 6.0/extension.js:3717
 msgid ""
-"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
-"Timeline effects.\n"
+"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
 "Open the Blur Cinnamon Settings to enable additional effects on several "
 "other desktop elements like menus, notifications and windows, or disable "
@@ -51,16 +49,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:3306
+#. 6.0/extension.js:3721
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Blur Cinnamon"
 
-#. 6.0/extension.js:3388
+#. 6.0/extension.js:3806
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:3389
+#. 6.0/extension.js:3807
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -106,6 +104,11 @@ msgstr ""
 #, fuzzy
 msgid "Cinnamon desktop components where effects will be applied"
 msgstr "Cinnamon komponentit. Valitse mihin tehoste lisätään"
+
+#. 6.0->settings-schema.json->monte-carlo-settings->title
+#, fuzzy
+msgid "Monte Carlo specific settings"
+msgstr "Paneelikohtaiset asetukset"
 
 #. 6.0->settings-schema.json->component-selector-section->title
 msgid "Component Selector"
@@ -288,8 +291,8 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners and Gaussian effects are based on code by aunetx (Blur-"
-"my-shell)\n"
+"The rounded corners, Gaussian and Monte Carlo effects\n"
+"are based on code by aunetx (Blur-my-shell)\n"
 "<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
 "href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
 "\n"
@@ -387,14 +390,13 @@ msgstr ""
 "pyöristetyt kulmat, jotta epäselvä tausta ei valu pyöristetyille reunoille."
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->description
-msgid "Alt-Tab application switcher (Coverflow & Timeline only)"
+msgid "Alt-Tab application switcher"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->tooltip
-msgid ""
-"Apply effects to the Alt-Tab application switcher background when setup to "
-"use the Coverflow or Timeline styles"
-msgstr ""
+#, fuzzy
+msgid "Apply effects to the Alt-Tab application switcher background"
+msgstr "Käytä tehosteita ponnahdusikkunoissa"
 
 #. 6.0->settings-schema.json->enable-tooltips-effects->description
 #, fuzzy
@@ -496,44 +498,104 @@ msgstr ""
 "tulee poistaa käytöstä vain, jos teema käyttää jo läpinäkyvää "
 "ponnahdusvalikkoa ja haluat käyttää omaa teema-asetusta."
 
+#. 6.0->settings-schema.json->allow-transparent-color-
+#. notifications->description
+#, fuzzy
+msgid "Override some of the notification theme settings (recommended)"
+msgstr "Ohita jotkin paneelin teema-asetukset (suositus)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-notifications->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the notification transparency and background "
+"color settings. If this is disabled the extension will only apply a blur "
+"background under the notifications. This setting should only be disabled "
+"when the theme already uses transparent notifications and you want the "
+"themes setting to apply."
+msgstr ""
+"Salli tämän laajennuksen muokata paneelien läpinäkyvyyttä ja taustavärin "
+"asetuksia. Jos tämä ei ole käytössä, laajennus lisää vain sumennetun "
+"peittokuvan paneelin alle. Tämä asetus poistetaan käytöstä vain, jos "
+"teemassa on jo käytössä läpinäkyvä paneeli tai haluat käyttää teeman omia "
+"asetuksia."
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->description
+#, fuzzy
+msgid "Override some of the tooltip theme settings (recommended)"
+msgstr "Ohita jotkin paneelin teema-asetukset (suositus)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the tooltip transparency and background color "
+"settings. If this is disabled the extension will only apply a blur "
+"background under the tooltips. This setting should only be disabled when the "
+"theme already uses transparent tooltips and you want the themes setting to "
+"apply."
+msgstr ""
+"Salli tämän laajennuksen muokata paneelien läpinäkyvyyttä ja taustavärin "
+"asetuksia. Jos tämä ei ole käytössä, laajennus lisää vain sumennetun "
+"peittokuvan paneelin alle. Tämä asetus poistetaan käytöstä vain, jos "
+"teemassa on jo käytössä läpinäkyvä paneeli tai haluat käyttää teeman omia "
+"asetuksia."
+
 #. 6.0->settings-schema.json->enable-overview-override->description
-msgid "Use unique effect settings for the Overview"
+#, fuzzy
+msgid "Override the generic effect settings for the Overview"
 msgstr "Käytä tehosteita ohjelmat näkymässä"
 
+#. 6.0->settings-schema.json->enable-overview-override->tooltip
+#. 6.0->settings-schema.json->enable-expo-override->tooltip
+#. 6.0->settings-schema.json->enable-panels-override->tooltip
+#. 6.0->settings-schema.json->enable-popup-override->tooltip
+#. 6.0->settings-schema.json->enable-desktop-override->tooltip
+#. 6.0->settings-schema.json->enable-notification-override->tooltip
+#. 6.0->settings-schema.json->enable-appswitcher-override->tooltip
+#. 6.0->settings-schema.json->enable-tooltips-override->tooltip
+#. 6.0->settings-schema.json->enable-desklets-override->tooltip
+msgid ""
+"Override the settings found on the \"Generic effect settings\" tab with "
+"unique settings for this cinnamon component."
+msgstr ""
+
 #. 6.0->settings-schema.json->enable-expo-override->description
-msgid "Use unique effect settings for the Expo"
+#, fuzzy
+msgid "Override the generic effect settings for the Expo"
 msgstr "Käytä tehosteita työtilan näkymässä"
 
 #. 6.0->settings-schema.json->enable-panels-override->description
-msgid "Use unique effect settings for the Panels"
+#, fuzzy
+msgid "Override the generic effect settings for the Panels"
 msgstr "Käytä tehosteita paneelissa"
 
 #. 6.0->settings-schema.json->enable-popup-override->description
-msgid "Use unique effect settings for the popup menus"
+#, fuzzy
+msgid "Override the generic effect settings for popup menus"
 msgstr "Käytä tehosteita ponnahdusikkunoissa"
 
 #. 6.0->settings-schema.json->enable-desktop-override->description
-msgid "Use unique effect settings for the desktop background"
+#, fuzzy
+msgid "Override the generic effect settings for the desktop background"
 msgstr "Käytä tehosteita taustakuvassa"
 
 #. 6.0->settings-schema.json->enable-notification-override->description
 #, fuzzy
-msgid "Use unique effect settings for the notification popups"
+msgid "Override the generic effect settings for notification popups"
 msgstr "Käytä tehosteita ponnahdusikkunoissa"
 
 #. 6.0->settings-schema.json->enable-appswitcher-override->description
 #, fuzzy
-msgid "Use unique effect settings for the Alt-Tab app switcher"
+msgid "Override the generic effect settings for the Alt-Tab app switcher"
 msgstr "Käytä tehosteita ponnahdusikkunoissa"
 
 #. 6.0->settings-schema.json->enable-tooltips-override->description
 #, fuzzy
-msgid "Use unique effect settings for the panel tooltips"
+msgid "Override the generic effect settings for panel tooltips"
 msgstr "Käytä tehosteita paneelissa"
 
 #. 6.0->settings-schema.json->enable-desklets-override->description
 #, fuzzy
-msgid "Use unique effect settings for the Desklets"
+msgid "Override the generic effect settings for Desklets"
 msgstr "Käytä tehosteita paneelissa"
 
 #. 6.0->settings-schema.json->enable-desklets-unique-settings->description
@@ -714,7 +776,9 @@ msgstr "Taustakuva"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple static blur"
 msgstr ""
 
@@ -722,13 +786,30 @@ msgstr ""
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 #, fuzzy
 msgid "Gaussian static blur"
 msgstr "Sumennuksen voimakkuus"
 
 #. 6.0->settings-schema.json->blurType->options
 msgid "Gaussian dynamic blur (if applicable)"
+msgstr ""
+
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo static blur"
+msgstr "Sumennuksen voimakkuus"
+
+#. 6.0->settings-schema.json->blurType->options
+msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr ""
 
 #. 6.0->settings-schema.json->blurType->description
@@ -744,7 +825,6 @@ msgstr "Sumeustehoste"
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Mitä sumennusalgoritmia tulisi käyttää taustan sumentamiseen"
@@ -759,7 +839,8 @@ msgstr "Mitä sumennusalgoritmia tulisi käyttää taustan sumentamiseen"
 #. 6.0->settings-schema.json->appswitcher-radius->description
 #. 6.0->settings-schema.json->tooltips-radius->description
 #. 6.0->settings-schema.json->desklets-radius->description
-msgid "Gaussian blur intensity"
+#, fuzzy
+msgid "Blur intensity"
 msgstr "Sumennuksen voimakkuus"
 
 #. 6.0->settings-schema.json->radius->tooltip
@@ -805,6 +886,49 @@ msgid ""
 "color."
 msgstr "Säätää taustakuvan värikylläisyyttä."
 
+#. 6.0->settings-schema.json->monte-carlo-iterations->description
+#, fuzzy
+msgid "Iterations"
+msgstr "Kylläisyys"
+
+#. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
+msgid ""
+"Increasing number of iterations will make the blur appear smoother at the "
+"cost of some CPU power."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
+msgid "Use base pixel"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->tooltip
+msgid ""
+"Whether or not the original pixel is counted for the blur. If it is, the "
+"image will be more legible."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->description
+msgid "Prefer closer pixels"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->tooltip
+msgid ""
+"Whether or not the pixels that are closer to the original pixel will have "
+"more weight."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->description
+msgid ""
+"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->tooltip
+msgid ""
+"The above Monte Carlo settings are used globally for all components that are "
+"configured to use the Monte Carlo blur algorithm, these settings can not be "
+"configured separately for each component"
+msgstr ""
+
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
@@ -816,18 +940,20 @@ msgstr "Ei mitään"
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Vakio"
 
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gaussian"
+
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Monte Carlo"
+msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
@@ -847,9 +973,21 @@ msgstr "Taustakuva"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 #, fuzzy
 msgid "Gaussian dynamic blur"
+msgstr "Sumennuksen voimakkuus"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo dynamic blur"
 msgstr "Sumennuksen voimakkuus"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -940,10 +1078,45 @@ msgid ""
 "your notification setting behave."
 msgstr ""
 
-#. 6.0->settings-schema.json->appswitcher-info->description
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->description
+msgid "Hide panels while using the Coverflow/Timeline 3D Alt-Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->tooltip
 msgid ""
-"Note: Alt-Tab effects only apply to the Coverflow and Timeline 3D Alt-Tab "
-"configurations"
+"Make the panels invisible when using the Coverflow or the Timeline 3D Alt-"
+"Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->description
+#, fuzzy
+msgid "Apply effects to the standard Alt-Tab switcher"
+msgstr "Käytä tehosteita ponnahdusikkunoissa"
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->tooltip
+msgid ""
+"Allow applying effects to the standard Alt-Tab switcher. Only the switcher "
+"options without \"previews\" are supported. The standard Alt-Tab switcher "
+"can use static or dynamic blur, but dynamic is recommended."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->description
+#, fuzzy
+msgid "Apply effects to the 3D Alt-Tab switchers"
+msgstr "Käytä tehosteita ponnahdusikkunoissa"
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->tooltip
+msgid ""
+"Allow applying effects to the Coverflow and Timeline 3D Alt-Tab switchers. "
+"The 3D Alt-Tab switchers will use static blurring even when dynamic blurring "
+"is selected since they don't benifit from dynamic blurring."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
+msgid ""
+"What type of blur algorithm should be used to blur the background. A dynamic "
+"blur type can be used for the standard switcher but static blurring is "
+"always used for the 3D switchers as they do not benefit from dynamic effects."
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->description
@@ -998,6 +1171,19 @@ msgid ""
 "effect\" extension will be disabled for windows with Blur Cinnamon effects "
 "applied. This option will have no effect unless the \"Compiz window effect\" "
 "extension is installed and active."
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->description
+msgid "Use artifact mitigation techniques"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->tooltip
+msgid ""
+"When enabled, steps will be taken to eliminate background graphical "
+"artifacts for windows that use dynamic blur effects. The mitigation steps "
+"will have some minor persistent CPU costs when a dynamic blurred window is "
+"on top of two or more other windows. This option is recommended unless you "
+"are using video wallpaper like Hidamari"
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-06 00:29-0500\n"
+"POT-Creation-Date: 2026-06-06 17:40-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -18,31 +18,29 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
-#. 6.0/extension.js:2399
+#. 6.0/extension.js:2600 6.0/extension.js:2603 6.0/extension.js:2713
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:2544
+#. 6.0/extension.js:2861
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:2545
+#. 6.0/extension.js:2862
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3301
+#. 6.0/extension.js:3716
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Flou pour Cinnamon"
 
-#. 6.0/extension.js:3302
+#. 6.0/extension.js:3717
 msgid ""
-"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
-"Timeline effects.\n"
+"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
 "Open the Blur Cinnamon Settings to enable additional effects on several "
 "other desktop elements like menus, notifications and windows, or disable "
@@ -51,16 +49,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:3306
+#. 6.0/extension.js:3721
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Flou pour Cinnamon"
 
-#. 6.0/extension.js:3388
+#. 6.0/extension.js:3806
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:3389
+#. 6.0/extension.js:3807
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -105,6 +103,11 @@ msgstr ""
 #, fuzzy
 msgid "Cinnamon desktop components where effects will be applied"
 msgstr "Composants de Cinnamon où les effets seront appliqués"
+
+#. 6.0->settings-schema.json->monte-carlo-settings->title
+#, fuzzy
+msgid "Monte Carlo specific settings"
+msgstr "Paramètres spécifiques au Panneau"
 
 #. 6.0->settings-schema.json->component-selector-section->title
 msgid "Component Selector"
@@ -299,8 +302,8 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners and Gaussian effects are based on code by aunetx (Blur-"
-"my-shell)\n"
+"The rounded corners, Gaussian and Monte Carlo effects\n"
+"are based on code by aunetx (Blur-my-shell)\n"
 "<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
 "href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
 "\n"
@@ -405,14 +408,13 @@ msgstr ""
 "déborde pas sur les bords arrondis."
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->description
-msgid "Alt-Tab application switcher (Coverflow & Timeline only)"
+msgid "Alt-Tab application switcher"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->tooltip
-msgid ""
-"Apply effects to the Alt-Tab application switcher background when setup to "
-"use the Coverflow or Timeline styles"
-msgstr ""
+#, fuzzy
+msgid "Apply effects to the Alt-Tab application switcher background"
+msgstr "Utiliser des paramètres d'effet spécifiques pour l'Expo"
 
 #. 6.0->settings-schema.json->enable-tooltips-effects->description
 #, fuzzy
@@ -522,46 +524,104 @@ msgstr ""
 "utilise déjà un menu principal transparent et que vous souhaitez que les "
 "paramètres du thème s'appliquent."
 
+#. 6.0->settings-schema.json->allow-transparent-color-
+#. notifications->description
+#, fuzzy
+msgid "Override some of the notification theme settings (recommended)"
+msgstr "Remplacer certains paramètres du thème des panneaux (recommandé)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-notifications->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the notification transparency and background "
+"color settings. If this is disabled the extension will only apply a blur "
+"background under the notifications. This setting should only be disabled "
+"when the theme already uses transparent notifications and you want the "
+"themes setting to apply."
+msgstr ""
+"Permet à cette extension de modifier les paramètres de transparence et de "
+"couleur d'arrière-plan des panneaux. Si ce paramètre est désactivé, "
+"l'extension n'appliquera qu'une superposition floue sous les panneaux. Ce "
+"paramètre ne doit être désactivé que si le thème utilise déjà des panneaux "
+"transparents et que vous souhaitez que les paramètres du thème s'appliquent."
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->description
+#, fuzzy
+msgid "Override some of the tooltip theme settings (recommended)"
+msgstr "Remplacer certains paramètres du thème des panneaux (recommandé)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the tooltip transparency and background color "
+"settings. If this is disabled the extension will only apply a blur "
+"background under the tooltips. This setting should only be disabled when the "
+"theme already uses transparent tooltips and you want the themes setting to "
+"apply."
+msgstr ""
+"Permet à cette extension de modifier les paramètres de transparence et de "
+"couleur d'arrière-plan des panneaux. Si ce paramètre est désactivé, "
+"l'extension n'appliquera qu'une superposition floue sous les panneaux. Ce "
+"paramètre ne doit être désactivé que si le thème utilise déjà des panneaux "
+"transparents et que vous souhaitez que les paramètres du thème s'appliquent."
+
 #. 6.0->settings-schema.json->enable-overview-override->description
-msgid "Use unique effect settings for the Overview"
+#, fuzzy
+msgid "Override the generic effect settings for the Overview"
 msgstr "Utiliser des paramètres d'effet spécifiques pour la Vue d'ensemble"
 
+#. 6.0->settings-schema.json->enable-overview-override->tooltip
+#. 6.0->settings-schema.json->enable-expo-override->tooltip
+#. 6.0->settings-schema.json->enable-panels-override->tooltip
+#. 6.0->settings-schema.json->enable-popup-override->tooltip
+#. 6.0->settings-schema.json->enable-desktop-override->tooltip
+#. 6.0->settings-schema.json->enable-notification-override->tooltip
+#. 6.0->settings-schema.json->enable-appswitcher-override->tooltip
+#. 6.0->settings-schema.json->enable-tooltips-override->tooltip
+#. 6.0->settings-schema.json->enable-desklets-override->tooltip
+msgid ""
+"Override the settings found on the \"Generic effect settings\" tab with "
+"unique settings for this cinnamon component."
+msgstr ""
+
 #. 6.0->settings-schema.json->enable-expo-override->description
-msgid "Use unique effect settings for the Expo"
+#, fuzzy
+msgid "Override the generic effect settings for the Expo"
 msgstr "Utiliser des paramètres d'effet spécifiques pour l'Expo"
 
 #. 6.0->settings-schema.json->enable-panels-override->description
-msgid "Use unique effect settings for the Panels"
+#, fuzzy
+msgid "Override the generic effect settings for the Panels"
 msgstr "Utiliser des paramètres d'effet spécifiques pour les Panneaux"
 
 #. 6.0->settings-schema.json->enable-popup-override->description
 #, fuzzy
-msgid "Use unique effect settings for the popup menus"
+msgid "Override the generic effect settings for popup menus"
 msgstr "Utiliser des paramètres d'effet spécifiques pour l'Expo"
 
 #. 6.0->settings-schema.json->enable-desktop-override->description
 #, fuzzy
-msgid "Use unique effect settings for the desktop background"
+msgid "Override the generic effect settings for the desktop background"
 msgstr "Utiliser des paramètres d'effet spécifiques pour l'Expo"
 
 #. 6.0->settings-schema.json->enable-notification-override->description
 #, fuzzy
-msgid "Use unique effect settings for the notification popups"
+msgid "Override the generic effect settings for notification popups"
 msgstr "Utiliser des paramètres d'effet spécifiques pour l'Expo"
 
 #. 6.0->settings-schema.json->enable-appswitcher-override->description
 #, fuzzy
-msgid "Use unique effect settings for the Alt-Tab app switcher"
+msgid "Override the generic effect settings for the Alt-Tab app switcher"
 msgstr "Utiliser des paramètres d'effet spécifiques pour l'Expo"
 
 #. 6.0->settings-schema.json->enable-tooltips-override->description
 #, fuzzy
-msgid "Use unique effect settings for the panel tooltips"
+msgid "Override the generic effect settings for panel tooltips"
 msgstr "Utiliser des paramètres d'effet spécifiques pour les Panneaux"
 
 #. 6.0->settings-schema.json->enable-desklets-override->description
 #, fuzzy
-msgid "Use unique effect settings for the Desklets"
+msgid "Override the generic effect settings for Desklets"
 msgstr "Utiliser des paramètres d'effet spécifiques pour les Panneaux"
 
 #. 6.0->settings-schema.json->enable-desklets-unique-settings->description
@@ -742,7 +802,9 @@ msgstr ""
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple static blur"
 msgstr ""
 
@@ -750,13 +812,30 @@ msgstr ""
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 #, fuzzy
 msgid "Gaussian static blur"
 msgstr "Intensité du flou gaussien"
 
 #. 6.0->settings-schema.json->blurType->options
 msgid "Gaussian dynamic blur (if applicable)"
+msgstr ""
+
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo static blur"
+msgstr "Intensité du flou gaussien"
+
+#. 6.0->settings-schema.json->blurType->options
+msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr ""
 
 #. 6.0->settings-schema.json->blurType->description
@@ -772,7 +851,6 @@ msgstr "Type d'effet de flou"
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Type d'algorithme à utiliser pour rendre l'arrière-plan flou"
@@ -787,7 +865,8 @@ msgstr "Type d'algorithme à utiliser pour rendre l'arrière-plan flou"
 #. 6.0->settings-schema.json->appswitcher-radius->description
 #. 6.0->settings-schema.json->tooltips-radius->description
 #. 6.0->settings-schema.json->desklets-radius->description
-msgid "Gaussian blur intensity"
+#, fuzzy
+msgid "Blur intensity"
 msgstr "Intensité du flou gaussien"
 
 #. 6.0->settings-schema.json->radius->tooltip
@@ -834,6 +913,48 @@ msgid ""
 "color."
 msgstr ""
 
+#. 6.0->settings-schema.json->monte-carlo-iterations->description
+msgid "Iterations"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
+msgid ""
+"Increasing number of iterations will make the blur appear smoother at the "
+"cost of some CPU power."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
+msgid "Use base pixel"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->tooltip
+msgid ""
+"Whether or not the original pixel is counted for the blur. If it is, the "
+"image will be more legible."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->description
+msgid "Prefer closer pixels"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->tooltip
+msgid ""
+"Whether or not the pixels that are closer to the original pixel will have "
+"more weight."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->description
+msgid ""
+"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->tooltip
+msgid ""
+"The above Monte Carlo settings are used globally for all components that are "
+"configured to use the Monte Carlo blur algorithm, these settings can not be "
+"configured separately for each component"
+msgstr ""
+
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
@@ -845,18 +966,20 @@ msgstr "Aucun"
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Simple"
 
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gaussien"
+
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Monte Carlo"
+msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
@@ -875,9 +998,21 @@ msgstr ""
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 #, fuzzy
 msgid "Gaussian dynamic blur"
+msgstr "Intensité du flou gaussien"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo dynamic blur"
 msgstr "Intensité du flou gaussien"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -966,10 +1101,45 @@ msgid ""
 "your notification setting behave."
 msgstr ""
 
-#. 6.0->settings-schema.json->appswitcher-info->description
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->description
+msgid "Hide panels while using the Coverflow/Timeline 3D Alt-Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->tooltip
 msgid ""
-"Note: Alt-Tab effects only apply to the Coverflow and Timeline 3D Alt-Tab "
-"configurations"
+"Make the panels invisible when using the Coverflow or the Timeline 3D Alt-"
+"Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->description
+#, fuzzy
+msgid "Apply effects to the standard Alt-Tab switcher"
+msgstr "Utiliser des paramètres d'effet spécifiques pour l'Expo"
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->tooltip
+msgid ""
+"Allow applying effects to the standard Alt-Tab switcher. Only the switcher "
+"options without \"previews\" are supported. The standard Alt-Tab switcher "
+"can use static or dynamic blur, but dynamic is recommended."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->description
+#, fuzzy
+msgid "Apply effects to the 3D Alt-Tab switchers"
+msgstr "Utiliser des paramètres d'effet spécifiques pour l'Expo"
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->tooltip
+msgid ""
+"Allow applying effects to the Coverflow and Timeline 3D Alt-Tab switchers. "
+"The 3D Alt-Tab switchers will use static blurring even when dynamic blurring "
+"is selected since they don't benifit from dynamic blurring."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
+msgid ""
+"What type of blur algorithm should be used to blur the background. A dynamic "
+"blur type can be used for the standard switcher but static blurring is "
+"always used for the 3D switchers as they do not benefit from dynamic effects."
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->description
@@ -1024,6 +1194,19 @@ msgid ""
 "effect\" extension will be disabled for windows with Blur Cinnamon effects "
 "applied. This option will have no effect unless the \"Compiz window effect\" "
 "extension is installed and active."
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->description
+msgid "Use artifact mitigation techniques"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->tooltip
+msgid ""
+"When enabled, steps will be taken to eliminate background graphical "
+"artifacts for windows that use dynamic blur effects. The mitigation steps "
+"will have some minor persistent CPU costs when a dynamic blurred window is "
+"on top of two or more other windows. This option is recommended unless you "
+"are using video wallpaper like Hidamari"
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/hu.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-06 00:29-0500\n"
+"POT-Creation-Date: 2026-06-06 17:40-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,16 +18,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
-#. 6.0/extension.js:2399
+#. 6.0/extension.js:2600 6.0/extension.js:2603 6.0/extension.js:2713
 msgid "Default window settings"
 msgstr "Alapértelmezett ablakbeállítások"
 
-#. 6.0/extension.js:2544
+#. 6.0/extension.js:2861
 msgid "Error"
 msgstr "Hiba"
 
-#. 6.0/extension.js:2545
+#. 6.0/extension.js:2862
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
@@ -37,14 +36,14 @@ msgstr ""
 "WM_CLASS osztályát, ezért a Cinnamon Elhomályosítása effektek nem "
 "alkalmazhatók erre az ablakra"
 
-#. 6.0/extension.js:3301
+#. 6.0/extension.js:3716
 msgid "Welcome to Blur Cinnamon"
 msgstr "Üdvözöljük a Cinnamon Elhomályosításában"
 
-#. 6.0/extension.js:3302
+#. 6.0/extension.js:3717
+#, fuzzy
 msgid ""
-"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
-"Timeline effects.\n"
+"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
 "Open the Blur Cinnamon Settings to enable additional effects on several "
 "other desktop elements like menus, notifications and windows, or disable "
@@ -61,15 +60,15 @@ msgstr ""
 "Módosíthatod az effektek tulajdonságait is, például az elmosás intenzitását, "
 "a színtelítettséget és a fényerőt."
 
-#. 6.0/extension.js:3306
+#. 6.0/extension.js:3721
 msgid "Open Blur Cinnamon Settings"
 msgstr "Nyissa meg a Cinnamon Elhomályosítása beállításait"
 
-#. 6.0/extension.js:3388
+#. 6.0/extension.js:3806
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Cinnamon Elhomályosítása értesítési effektek tesztelése"
 
-#. 6.0/extension.js:3389
+#. 6.0/extension.js:3807
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -115,6 +114,11 @@ msgstr "Névjegy"
 #. 6.0->settings-schema.json->general-settings->title
 msgid "Cinnamon desktop components where effects will be applied"
 msgstr "Cinnamon asztali komponensek, ahol az effektek alkalmazásra kerülnek"
+
+#. 6.0->settings-schema.json->monte-carlo-settings->title
+#, fuzzy
+msgid "Monte Carlo specific settings"
+msgstr "Panelspecifikus beállítások"
 
 #. 6.0->settings-schema.json->component-selector-section->title
 msgid "Component Selector"
@@ -302,6 +306,7 @@ msgid "Show settings for component:"
 msgstr "Az összetevő beállításainak megjelenítése:"
 
 #. 6.0->settings-schema.json->about-text->description
+#, fuzzy
 msgid ""
 "\n"
 "<b>Bringing your style into focus</b>\n"
@@ -310,11 +315,11 @@ msgid ""
 "Developed by: Kevin Langman\n"
 "<a href=\"https://github.com/klangman/BlurCinnamon\">Github</a> / <a "
 "href=\"https://github.com/klangman/BlurCinnamon/issues/new\">Report an "
-"issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/"
-"view/104\">Website</a>\n"
+"issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
+"104\">Website</a>\n"
 "\n"
-"The rounded corners and Gaussian effects are based on code by aunetx (Blur-"
-"my-shell)\n"
+"The rounded corners, Gaussian and Monte Carlo effects\n"
+"are based on code by aunetx (Blur-my-shell)\n"
 "<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
 "href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
 "\n"
@@ -328,8 +333,8 @@ msgstr ""
 "Fejlesztő: Kevin Langman\n"
 "<a href=\"https://github.com/klangman/BlurCinnamon\">Github</a> / <a "
 "href=\"https://github.com/klangman/BlurCinnamon/issues/new\">Hiba jelentése</"
-"a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/"
-"view/104\">Weboldal</a>\n"
+"a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
+"104\">Weboldal</a>\n"
 "\n"
 "A lekerekített sarkok és a Gauss-effektusok az aunetx (Blur-my-shell) kódján "
 "alapulnak.\n"
@@ -424,13 +429,13 @@ msgstr ""
 "látható."
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->description
-msgid "Alt-Tab application switcher (Coverflow & Timeline only)"
+#, fuzzy
+msgid "Alt-Tab application switcher"
 msgstr "Alt-Tab alkalmazásváltó (csak Coverflow és Timeline)"
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->tooltip
-msgid ""
-"Apply effects to the Alt-Tab application switcher background when setup to "
-"use the Coverflow or Timeline styles"
+#, fuzzy
+msgid "Apply effects to the Alt-Tab application switcher background"
 msgstr ""
 "Effektek alkalmazása az Alt-Tab alkalmazásváltó hátterére, ha a Coverflow "
 "vagy az Idővonal stílusok használata van beállítva"
@@ -533,41 +538,105 @@ msgstr ""
 "letiltani, ha a téma már átlátszó felugró menüket használ, és szeretné, hogy "
 "a témabeállítás érvényes legyen."
 
+#. 6.0->settings-schema.json->allow-transparent-color-
+#. notifications->description
+#, fuzzy
+msgid "Override some of the notification theme settings (recommended)"
+msgstr "Néhány paneltéma beállítás felülírása (ajánlott)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-notifications->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the notification transparency and background "
+"color settings. If this is disabled the extension will only apply a blur "
+"background under the notifications. This setting should only be disabled "
+"when the theme already uses transparent notifications and you want the "
+"themes setting to apply."
+msgstr ""
+"Engedélyezi a bővítménynek a panelek átlátszósági és háttérszín-"
+"beállításainak módosítását. Ha ez le van tiltva, a bővítmény csak elmosódott "
+"hátteret alkalmaz a panelek alatt. Ezt a beállítást csak akkor szabad "
+"letiltani, ha a téma már átlátszó paneleket használ, és szeretné, hogy a "
+"témabeállítás érvényes legyen."
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->description
+#, fuzzy
+msgid "Override some of the tooltip theme settings (recommended)"
+msgstr "Néhány paneltéma beállítás felülírása (ajánlott)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the tooltip transparency and background color "
+"settings. If this is disabled the extension will only apply a blur "
+"background under the tooltips. This setting should only be disabled when the "
+"theme already uses transparent tooltips and you want the themes setting to "
+"apply."
+msgstr ""
+"Engedélyezi a bővítménynek a panelek átlátszósági és háttérszín-"
+"beállításainak módosítását. Ha ez le van tiltva, a bővítmény csak elmosódott "
+"hátteret alkalmaz a panelek alatt. Ezt a beállítást csak akkor szabad "
+"letiltani, ha a téma már átlátszó paneleket használ, és szeretné, hogy a "
+"témabeállítás érvényes legyen."
+
 #. 6.0->settings-schema.json->enable-overview-override->description
-msgid "Use unique effect settings for the Overview"
+#, fuzzy
+msgid "Override the generic effect settings for the Overview"
 msgstr "Használjon egyedi effektbeállításokat az Áttekintéshez"
 
+#. 6.0->settings-schema.json->enable-overview-override->tooltip
+#. 6.0->settings-schema.json->enable-expo-override->tooltip
+#. 6.0->settings-schema.json->enable-panels-override->tooltip
+#. 6.0->settings-schema.json->enable-popup-override->tooltip
+#. 6.0->settings-schema.json->enable-desktop-override->tooltip
+#. 6.0->settings-schema.json->enable-notification-override->tooltip
+#. 6.0->settings-schema.json->enable-appswitcher-override->tooltip
+#. 6.0->settings-schema.json->enable-tooltips-override->tooltip
+#. 6.0->settings-schema.json->enable-desklets-override->tooltip
+msgid ""
+"Override the settings found on the \"Generic effect settings\" tab with "
+"unique settings for this cinnamon component."
+msgstr ""
+
 #. 6.0->settings-schema.json->enable-expo-override->description
-msgid "Use unique effect settings for the Expo"
+#, fuzzy
+msgid "Override the generic effect settings for the Expo"
 msgstr "Használjon egyedi effektbeállításokat az Expo-n"
 
 #. 6.0->settings-schema.json->enable-panels-override->description
-msgid "Use unique effect settings for the Panels"
+#, fuzzy
+msgid "Override the generic effect settings for the Panels"
 msgstr "Használjon egyedi effektbeállításokat a panelekhez"
 
 #. 6.0->settings-schema.json->enable-popup-override->description
-msgid "Use unique effect settings for the popup menus"
+#, fuzzy
+msgid "Override the generic effect settings for popup menus"
 msgstr "Használjon egyedi effektbeállításokat a felugró menükhöz"
 
 #. 6.0->settings-schema.json->enable-desktop-override->description
-msgid "Use unique effect settings for the desktop background"
+#, fuzzy
+msgid "Override the generic effect settings for the desktop background"
 msgstr "Használjon egyedi effektbeállításokat az asztal hátteréhez"
 
 #. 6.0->settings-schema.json->enable-notification-override->description
-msgid "Use unique effect settings for the notification popups"
+#, fuzzy
+msgid "Override the generic effect settings for notification popups"
 msgstr ""
 "Használjon egyedi effektusbeállításokat az értesítési felugró ablakokhoz"
 
 #. 6.0->settings-schema.json->enable-appswitcher-override->description
-msgid "Use unique effect settings for the Alt-Tab app switcher"
+#, fuzzy
+msgid "Override the generic effect settings for the Alt-Tab app switcher"
 msgstr "Használjon egyedi effektusbeállításokat az Alt-Tab alkalmazásváltóhoz"
 
 #. 6.0->settings-schema.json->enable-tooltips-override->description
-msgid "Use unique effect settings for the panel tooltips"
+#, fuzzy
+msgid "Override the generic effect settings for panel tooltips"
 msgstr "Használjon egyedi effektusbeállításokat a panel eszköztippjeihez"
 
 #. 6.0->settings-schema.json->enable-desklets-override->description
-msgid "Use unique effect settings for the Desklets"
+#, fuzzy
+msgid "Override the generic effect settings for Desklets"
 msgstr "Használjon egyedi effektusbeállításokat az asztalkalmazáshoz"
 
 #. 6.0->settings-schema.json->enable-desklets-unique-settings->description
@@ -764,7 +833,9 @@ msgstr "Nincs / Átlátszó a tapétához képest"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple static blur"
 msgstr "Egyszerű statikus elmosódás"
 
@@ -772,12 +843,30 @@ msgstr "Egyszerű statikus elmosódás"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian static blur"
 msgstr "Gauss-féle statikus elmosódás"
 
 #. 6.0->settings-schema.json->blurType->options
 msgid "Gaussian dynamic blur (if applicable)"
+msgstr "Gauss-féle dinamikus elmosás (ha alkalmazható)"
+
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo static blur"
+msgstr "Egyszerű statikus elmosódás"
+
+#. 6.0->settings-schema.json->blurType->options
+#, fuzzy
+msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr "Gauss-féle dinamikus elmosás (ha alkalmazható)"
 
 #. 6.0->settings-schema.json->blurType->description
@@ -793,7 +882,6 @@ msgstr "Az elmosódási hatás típusa"
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr ""
@@ -809,7 +897,8 @@ msgstr ""
 #. 6.0->settings-schema.json->appswitcher-radius->description
 #. 6.0->settings-schema.json->tooltips-radius->description
 #. 6.0->settings-schema.json->desklets-radius->description
-msgid "Gaussian blur intensity"
+#, fuzzy
+msgid "Blur intensity"
 msgstr "Gauss-elmosódás intenzitása"
 
 #. 6.0->settings-schema.json->radius->tooltip
@@ -857,6 +946,49 @@ msgid ""
 msgstr ""
 "A háttérkép színtelítettségét állítja be szürkeárnyalatosról teljes színűre."
 
+#. 6.0->settings-schema.json->monte-carlo-iterations->description
+#, fuzzy
+msgid "Iterations"
+msgstr "Telítettség"
+
+#. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
+msgid ""
+"Increasing number of iterations will make the blur appear smoother at the "
+"cost of some CPU power."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
+msgid "Use base pixel"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->tooltip
+msgid ""
+"Whether or not the original pixel is counted for the blur. If it is, the "
+"image will be more legible."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->description
+msgid "Prefer closer pixels"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->tooltip
+msgid ""
+"Whether or not the pixels that are closer to the original pixel will have "
+"more weight."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->description
+msgid ""
+"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->tooltip
+msgid ""
+"The above Monte Carlo settings are used globally for all components that are "
+"configured to use the Monte Carlo blur algorithm, these settings can not be "
+"configured separately for each component"
+msgstr ""
+
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
@@ -868,18 +1000,20 @@ msgstr "Semmi"
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Egyszerű"
 
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gauss-féle"
+
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Monte Carlo"
+msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
@@ -898,8 +1032,20 @@ msgstr "Átlátszó a háttérkép számára"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian dynamic blur"
+msgstr "Gauss-féle dinamikus elmosódás"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo dynamic blur"
 msgstr "Gauss-féle dinamikus elmosódás"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -934,9 +1080,9 @@ msgstr "További felugró menü kiemelő elemeinek halványítása (%)"
 
 #. 6.0->settings-schema.json->popup-accent-opacity->tooltip
 msgid ""
-"Defines the additional dimming applied to the popup menu accent elements (i."
-"e. the main menu favorites box and entry boxes) which allow these elements "
-"to stand out from the other popup menu areas"
+"Defines the additional dimming applied to the popup menu accent elements "
+"(i.e. the main menu favorites box and entry boxes) which allow these "
+"elements to stand out from the other popup menu areas"
 msgstr ""
 "Meghatározza a felugró menü ékezetes elemeire (azaz a főmenü kedvencei "
 "mezőjére és a beviteli mezőkre) alkalmazott további tompítást, amely "
@@ -992,13 +1138,46 @@ msgstr ""
 "Ez a gomb egy értesítési üzenet megjelenítését váltja ki, így láthatod, "
 "hogyan működnek az értesítési beállításaid."
 
-#. 6.0->settings-schema.json->appswitcher-info->description
-msgid ""
-"Note: Alt-Tab effects only apply to the Coverflow and Timeline 3D Alt-Tab "
-"configurations"
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->description
+msgid "Hide panels while using the Coverflow/Timeline 3D Alt-Tab switchers"
 msgstr ""
-"Megjegyzés: Az Alt-Tab effektek csak a Coverflow és a Timeline 3D Alt-Tab "
-"konfigurációkra vonatkoznak"
+
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->tooltip
+msgid ""
+"Make the panels invisible when using the Coverflow or the Timeline 3D Alt-"
+"Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->description
+#, fuzzy
+msgid "Apply effects to the standard Alt-Tab switcher"
+msgstr "Használjon egyedi effektusbeállításokat az Alt-Tab alkalmazásváltóhoz"
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->tooltip
+msgid ""
+"Allow applying effects to the standard Alt-Tab switcher. Only the switcher "
+"options without \"previews\" are supported. The standard Alt-Tab switcher "
+"can use static or dynamic blur, but dynamic is recommended."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->description
+#, fuzzy
+msgid "Apply effects to the 3D Alt-Tab switchers"
+msgstr "Használjon egyedi effektusbeállításokat az Alt-Tab alkalmazásváltóhoz"
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->tooltip
+msgid ""
+"Allow applying effects to the Coverflow and Timeline 3D Alt-Tab switchers. "
+"The 3D Alt-Tab switchers will use static blurring even when dynamic blurring "
+"is selected since they don't benifit from dynamic blurring."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
+msgid ""
+"What type of blur algorithm should be used to blur the background. A dynamic "
+"blur type can be used for the standard switcher but static blurring is "
+"always used for the 3D switchers as they do not benefit from dynamic effects."
+msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->description
 msgid "Application window inclusion list"
@@ -1066,6 +1245,19 @@ msgstr ""
 "ablakmozgató effektus le lesz tiltva azokon az ablakokon, amelyeken Blur "
 "Cinnamon effektusok vannak alkalmazva. Ennek az opciónak csak akkor lesz "
 "hatása, ha a „Compiz ablakeffektus” kiterjesztés telepítve és aktív."
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->description
+msgid "Use artifact mitigation techniques"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->tooltip
+msgid ""
+"When enabled, steps will be taken to eliminate background graphical "
+"artifacts for windows that use dynamic blur effects. The mitigation steps "
+"will have some minor persistent CPU costs when a dynamic blurred window is "
+"on top of two or more other windows. This option is recommended unless you "
+"are using video wallpaper like Hidamari"
+msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description
 msgid "Automatically enable effects for newly added Desklets"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/it.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-06 00:29-0500\n"
+"POT-Creation-Date: 2026-06-06 17:40-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -18,31 +18,29 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
-#. 6.0/extension.js:2399
+#. 6.0/extension.js:2600 6.0/extension.js:2603 6.0/extension.js:2713
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:2544
+#. 6.0/extension.js:2861
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:2545
+#. 6.0/extension.js:2862
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3301
+#. 6.0/extension.js:3716
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Sfoca Cinnamom"
 
-#. 6.0/extension.js:3302
+#. 6.0/extension.js:3717
 msgid ""
-"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
-"Timeline effects.\n"
+"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
 "Open the Blur Cinnamon Settings to enable additional effects on several "
 "other desktop elements like menus, notifications and windows, or disable "
@@ -51,16 +49,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:3306
+#. 6.0/extension.js:3721
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Sfoca Cinnamom"
 
-#. 6.0/extension.js:3388
+#. 6.0/extension.js:3806
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:3389
+#. 6.0/extension.js:3807
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -106,6 +104,11 @@ msgstr ""
 #, fuzzy
 msgid "Cinnamon desktop components where effects will be applied"
 msgstr "Componenti di Cinnamon dove verranno applicati gli effetti"
+
+#. 6.0->settings-schema.json->monte-carlo-settings->title
+#, fuzzy
+msgid "Monte Carlo specific settings"
+msgstr "Impostazioni specifiche pannello"
 
 #. 6.0->settings-schema.json->component-selector-section->title
 msgid "Component Selector"
@@ -301,8 +304,8 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners and Gaussian effects are based on code by aunetx (Blur-"
-"my-shell)\n"
+"The rounded corners, Gaussian and Monte Carlo effects\n"
+"are based on code by aunetx (Blur-my-shell)\n"
 "<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
 "href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
 "\n"
@@ -408,14 +411,13 @@ msgstr ""
 "bordi arrotondati."
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->description
-msgid "Alt-Tab application switcher (Coverflow & Timeline only)"
+msgid "Alt-Tab application switcher"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->tooltip
-msgid ""
-"Apply effects to the Alt-Tab application switcher background when setup to "
-"use the Coverflow or Timeline styles"
-msgstr ""
+#, fuzzy
+msgid "Apply effects to the Alt-Tab application switcher background"
+msgstr "Utilizza impostazioni di effetti unici per i Menù a comparsa"
 
 #. 6.0->settings-schema.json->enable-tooltips-effects->description
 #, fuzzy
@@ -522,44 +524,104 @@ msgstr ""
 "utilizza già menù a comparsa trasparenti e si desidera applicare le "
 "impostazioni del tema."
 
+#. 6.0->settings-schema.json->allow-transparent-color-
+#. notifications->description
+#, fuzzy
+msgid "Override some of the notification theme settings (recommended)"
+msgstr "Ignora alcune impostazioni del tema dei pannelli (consigliato)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-notifications->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the notification transparency and background "
+"color settings. If this is disabled the extension will only apply a blur "
+"background under the notifications. This setting should only be disabled "
+"when the theme already uses transparent notifications and you want the "
+"themes setting to apply."
+msgstr ""
+"Consente a questa estensione di modificare le impostazioni di trasparenza e "
+"colore di sfondo dei pannelli. Se questa opzione è disabilitata, "
+"l'estensione applicherà solo una sfocatura sotto i pannelli. Questa "
+"impostazione dovrebbe essere disabilitata solo se il tema utilizza già "
+"pannelli trasparenti e si desidera applicare le impostazioni del tema."
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->description
+#, fuzzy
+msgid "Override some of the tooltip theme settings (recommended)"
+msgstr "Ignora alcune impostazioni del tema dei pannelli (consigliato)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the tooltip transparency and background color "
+"settings. If this is disabled the extension will only apply a blur "
+"background under the tooltips. This setting should only be disabled when the "
+"theme already uses transparent tooltips and you want the themes setting to "
+"apply."
+msgstr ""
+"Consente a questa estensione di modificare le impostazioni di trasparenza e "
+"colore di sfondo dei pannelli. Se questa opzione è disabilitata, "
+"l'estensione applicherà solo una sfocatura sotto i pannelli. Questa "
+"impostazione dovrebbe essere disabilitata solo se il tema utilizza già "
+"pannelli trasparenti e si desidera applicare le impostazioni del tema."
+
 #. 6.0->settings-schema.json->enable-overview-override->description
-msgid "Use unique effect settings for the Overview"
+#, fuzzy
+msgid "Override the generic effect settings for the Overview"
 msgstr "Utilizza impostazioni di effetti uniche per la Panoramica"
 
+#. 6.0->settings-schema.json->enable-overview-override->tooltip
+#. 6.0->settings-schema.json->enable-expo-override->tooltip
+#. 6.0->settings-schema.json->enable-panels-override->tooltip
+#. 6.0->settings-schema.json->enable-popup-override->tooltip
+#. 6.0->settings-schema.json->enable-desktop-override->tooltip
+#. 6.0->settings-schema.json->enable-notification-override->tooltip
+#. 6.0->settings-schema.json->enable-appswitcher-override->tooltip
+#. 6.0->settings-schema.json->enable-tooltips-override->tooltip
+#. 6.0->settings-schema.json->enable-desklets-override->tooltip
+msgid ""
+"Override the settings found on the \"Generic effect settings\" tab with "
+"unique settings for this cinnamon component."
+msgstr ""
+
 #. 6.0->settings-schema.json->enable-expo-override->description
-msgid "Use unique effect settings for the Expo"
+#, fuzzy
+msgid "Override the generic effect settings for the Expo"
 msgstr "Utilizza impostazioni di effetti unici per l'Expo"
 
 #. 6.0->settings-schema.json->enable-panels-override->description
-msgid "Use unique effect settings for the Panels"
+#, fuzzy
+msgid "Override the generic effect settings for the Panels"
 msgstr "Utilizza impostazioni di effetti unici per i Pannelli"
 
 #. 6.0->settings-schema.json->enable-popup-override->description
-msgid "Use unique effect settings for the popup menus"
+#, fuzzy
+msgid "Override the generic effect settings for popup menus"
 msgstr "Utilizza impostazioni di effetti unici per i Menù a comparsa"
 
 #. 6.0->settings-schema.json->enable-desktop-override->description
-msgid "Use unique effect settings for the desktop background"
+#, fuzzy
+msgid "Override the generic effect settings for the desktop background"
 msgstr "Utilizza impostazioni di effetti unici per lo sfondo del desktop"
 
 #. 6.0->settings-schema.json->enable-notification-override->description
 #, fuzzy
-msgid "Use unique effect settings for the notification popups"
+msgid "Override the generic effect settings for notification popups"
 msgstr "Utilizza impostazioni di effetti unici per i Menù a comparsa"
 
 #. 6.0->settings-schema.json->enable-appswitcher-override->description
 #, fuzzy
-msgid "Use unique effect settings for the Alt-Tab app switcher"
+msgid "Override the generic effect settings for the Alt-Tab app switcher"
 msgstr "Utilizza impostazioni di effetti unici per i Menù a comparsa"
 
 #. 6.0->settings-schema.json->enable-tooltips-override->description
 #, fuzzy
-msgid "Use unique effect settings for the panel tooltips"
+msgid "Override the generic effect settings for panel tooltips"
 msgstr "Utilizza impostazioni di effetti unici per i Pannelli"
 
 #. 6.0->settings-schema.json->enable-desklets-override->description
 #, fuzzy
-msgid "Use unique effect settings for the Desklets"
+msgid "Override the generic effect settings for Desklets"
 msgstr "Utilizza impostazioni di effetti unici per i Pannelli"
 
 #. 6.0->settings-schema.json->enable-desklets-unique-settings->description
@@ -742,7 +804,9 @@ msgstr "Sfondo del desktop"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple static blur"
 msgstr ""
 
@@ -750,13 +814,30 @@ msgstr ""
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 #, fuzzy
 msgid "Gaussian static blur"
 msgstr "Intensità della sfocatura gaussiana"
 
 #. 6.0->settings-schema.json->blurType->options
 msgid "Gaussian dynamic blur (if applicable)"
+msgstr ""
+
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo static blur"
+msgstr "Intensità della sfocatura gaussiana"
+
+#. 6.0->settings-schema.json->blurType->options
+msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr ""
 
 #. 6.0->settings-schema.json->blurType->description
@@ -772,7 +853,6 @@ msgstr "Tipo di effetto sfocatura"
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr ""
@@ -789,7 +869,8 @@ msgstr ""
 #. 6.0->settings-schema.json->appswitcher-radius->description
 #. 6.0->settings-schema.json->tooltips-radius->description
 #. 6.0->settings-schema.json->desklets-radius->description
-msgid "Gaussian blur intensity"
+#, fuzzy
+msgid "Blur intensity"
 msgstr "Intensità della sfocatura gaussiana"
 
 #. 6.0->settings-schema.json->radius->tooltip
@@ -837,6 +918,49 @@ msgid ""
 "color."
 msgstr "Regola la saturazione del colore dell'immagine di sfondo."
 
+#. 6.0->settings-schema.json->monte-carlo-iterations->description
+#, fuzzy
+msgid "Iterations"
+msgstr "Saturazione"
+
+#. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
+msgid ""
+"Increasing number of iterations will make the blur appear smoother at the "
+"cost of some CPU power."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
+msgid "Use base pixel"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->tooltip
+msgid ""
+"Whether or not the original pixel is counted for the blur. If it is, the "
+"image will be more legible."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->description
+msgid "Prefer closer pixels"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->tooltip
+msgid ""
+"Whether or not the pixels that are closer to the original pixel will have "
+"more weight."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->description
+msgid ""
+"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->tooltip
+msgid ""
+"The above Monte Carlo settings are used globally for all components that are "
+"configured to use the Monte Carlo blur algorithm, these settings can not be "
+"configured separately for each component"
+msgstr ""
+
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
@@ -848,18 +972,20 @@ msgstr "Nessuno"
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Semplice"
 
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gaussiana"
+
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Monte Carlo"
+msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
@@ -879,9 +1005,21 @@ msgstr "Sfondo del desktop"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 #, fuzzy
 msgid "Gaussian dynamic blur"
+msgstr "Intensità della sfocatura gaussiana"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo dynamic blur"
 msgstr "Intensità della sfocatura gaussiana"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -978,10 +1116,45 @@ msgid ""
 "your notification setting behave."
 msgstr ""
 
-#. 6.0->settings-schema.json->appswitcher-info->description
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->description
+msgid "Hide panels while using the Coverflow/Timeline 3D Alt-Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->tooltip
 msgid ""
-"Note: Alt-Tab effects only apply to the Coverflow and Timeline 3D Alt-Tab "
-"configurations"
+"Make the panels invisible when using the Coverflow or the Timeline 3D Alt-"
+"Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->description
+#, fuzzy
+msgid "Apply effects to the standard Alt-Tab switcher"
+msgstr "Utilizza impostazioni di effetti unici per i Menù a comparsa"
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->tooltip
+msgid ""
+"Allow applying effects to the standard Alt-Tab switcher. Only the switcher "
+"options without \"previews\" are supported. The standard Alt-Tab switcher "
+"can use static or dynamic blur, but dynamic is recommended."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->description
+#, fuzzy
+msgid "Apply effects to the 3D Alt-Tab switchers"
+msgstr "Utilizza impostazioni di effetti unici per i Menù a comparsa"
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->tooltip
+msgid ""
+"Allow applying effects to the Coverflow and Timeline 3D Alt-Tab switchers. "
+"The 3D Alt-Tab switchers will use static blurring even when dynamic blurring "
+"is selected since they don't benifit from dynamic blurring."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
+msgid ""
+"What type of blur algorithm should be used to blur the background. A dynamic "
+"blur type can be used for the standard switcher but static blurring is "
+"always used for the 3D switchers as they do not benefit from dynamic effects."
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->description
@@ -1036,6 +1209,19 @@ msgid ""
 "effect\" extension will be disabled for windows with Blur Cinnamon effects "
 "applied. This option will have no effect unless the \"Compiz window effect\" "
 "extension is installed and active."
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->description
+msgid "Use artifact mitigation techniques"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->tooltip
+msgid ""
+"When enabled, steps will be taken to eliminate background graphical "
+"artifacts for windows that use dynamic blur effects. The mitigation steps "
+"will have some minor persistent CPU costs when a dynamic blurred window is "
+"on top of two or more other windows. This option is recommended unless you "
+"are using video wallpaper like Hidamari"
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/nl.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-06 00:29-0500\n"
+"POT-Creation-Date: 2026-06-06 17:40-0400\n"
 "PO-Revision-Date: 2025-06-13 17:14+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,31 +16,29 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
-#. 6.0/extension.js:2399
+#. 6.0/extension.js:2600 6.0/extension.js:2603 6.0/extension.js:2713
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:2544
+#. 6.0/extension.js:2861
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:2545
+#. 6.0/extension.js:2862
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3301
+#. 6.0/extension.js:3716
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Vervaag Cinnamon"
 
-#. 6.0/extension.js:3302
+#. 6.0/extension.js:3717
 msgid ""
-"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
-"Timeline effects.\n"
+"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
 "Open the Blur Cinnamon Settings to enable additional effects on several "
 "other desktop elements like menus, notifications and windows, or disable "
@@ -49,16 +47,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:3306
+#. 6.0/extension.js:3721
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Vervaag Cinnamon"
 
-#. 6.0/extension.js:3388
+#. 6.0/extension.js:3806
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:3389
+#. 6.0/extension.js:3807
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -104,6 +102,11 @@ msgstr ""
 #, fuzzy
 msgid "Cinnamon desktop components where effects will be applied"
 msgstr "Cinnamon-componenten waarop effecten worden toegepast"
+
+#. 6.0->settings-schema.json->monte-carlo-settings->title
+#, fuzzy
+msgid "Monte Carlo specific settings"
+msgstr "Paneelspecifieke instellingen"
 
 #. 6.0->settings-schema.json->component-selector-section->title
 msgid "Component Selector"
@@ -299,8 +302,8 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners and Gaussian effects are based on code by aunetx (Blur-"
-"my-shell)\n"
+"The rounded corners, Gaussian and Monte Carlo effects\n"
+"are based on code by aunetx (Blur-my-shell)\n"
 "<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
 "href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
 "\n"
@@ -406,14 +409,13 @@ msgstr ""
 "uitloopt."
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->description
-msgid "Alt-Tab application switcher (Coverflow & Timeline only)"
+msgid "Alt-Tab application switcher"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->tooltip
-msgid ""
-"Apply effects to the Alt-Tab application switcher background when setup to "
-"use the Coverflow or Timeline styles"
-msgstr ""
+#, fuzzy
+msgid "Apply effects to the Alt-Tab application switcher background"
+msgstr "Unieke effectinstellingen gebruiken voor pop-upmenu’s"
 
 #. 6.0->settings-schema.json->enable-tooltips-effects->description
 #, fuzzy
@@ -521,44 +523,104 @@ msgstr ""
 "transparante pop-upmenu’s gebruikt en je wil dat deze thema-instellingen "
 "toegepast worden."
 
+#. 6.0->settings-schema.json->allow-transparent-color-
+#. notifications->description
+#, fuzzy
+msgid "Override some of the notification theme settings (recommended)"
+msgstr "Sommige thema-instellingen voor panelen overschrijven (aanbevolen)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-notifications->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the notification transparency and background "
+"color settings. If this is disabled the extension will only apply a blur "
+"background under the notifications. This setting should only be disabled "
+"when the theme already uses transparent notifications and you want the "
+"themes setting to apply."
+msgstr ""
+"Sta deze extensie toe om instellingen in verband met de transparantie en "
+"achtergrondkleur van de panelen aan te passen. Als dit is uitgeschakeld, "
+"wordt alleen een vervagingslaag onder de panelen toegepast. Deze instelling "
+"moet alleen worden uitgeschakeld als het thema al transparante panelen "
+"gebruikt en je wil dat deze thema-instellingen toegepast worden."
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->description
+#, fuzzy
+msgid "Override some of the tooltip theme settings (recommended)"
+msgstr "Sommige thema-instellingen voor panelen overschrijven (aanbevolen)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the tooltip transparency and background color "
+"settings. If this is disabled the extension will only apply a blur "
+"background under the tooltips. This setting should only be disabled when the "
+"theme already uses transparent tooltips and you want the themes setting to "
+"apply."
+msgstr ""
+"Sta deze extensie toe om instellingen in verband met de transparantie en "
+"achtergrondkleur van de panelen aan te passen. Als dit is uitgeschakeld, "
+"wordt alleen een vervagingslaag onder de panelen toegepast. Deze instelling "
+"moet alleen worden uitgeschakeld als het thema al transparante panelen "
+"gebruikt en je wil dat deze thema-instellingen toegepast worden."
+
 #. 6.0->settings-schema.json->enable-overview-override->description
-msgid "Use unique effect settings for the Overview"
+#, fuzzy
+msgid "Override the generic effect settings for the Overview"
 msgstr "Unieke effectinstellingen gebruiken voor Overzicht"
 
+#. 6.0->settings-schema.json->enable-overview-override->tooltip
+#. 6.0->settings-schema.json->enable-expo-override->tooltip
+#. 6.0->settings-schema.json->enable-panels-override->tooltip
+#. 6.0->settings-schema.json->enable-popup-override->tooltip
+#. 6.0->settings-schema.json->enable-desktop-override->tooltip
+#. 6.0->settings-schema.json->enable-notification-override->tooltip
+#. 6.0->settings-schema.json->enable-appswitcher-override->tooltip
+#. 6.0->settings-schema.json->enable-tooltips-override->tooltip
+#. 6.0->settings-schema.json->enable-desklets-override->tooltip
+msgid ""
+"Override the settings found on the \"Generic effect settings\" tab with "
+"unique settings for this cinnamon component."
+msgstr ""
+
 #. 6.0->settings-schema.json->enable-expo-override->description
-msgid "Use unique effect settings for the Expo"
+#, fuzzy
+msgid "Override the generic effect settings for the Expo"
 msgstr "Unieke effectinstellingen gebruiken voor Expo"
 
 #. 6.0->settings-schema.json->enable-panels-override->description
-msgid "Use unique effect settings for the Panels"
+#, fuzzy
+msgid "Override the generic effect settings for the Panels"
 msgstr "Unieke effectinstellingen gebruiken voor Panelen"
 
 #. 6.0->settings-schema.json->enable-popup-override->description
-msgid "Use unique effect settings for the popup menus"
+#, fuzzy
+msgid "Override the generic effect settings for popup menus"
 msgstr "Unieke effectinstellingen gebruiken voor pop-upmenu’s"
 
 #. 6.0->settings-schema.json->enable-desktop-override->description
-msgid "Use unique effect settings for the desktop background"
+#, fuzzy
+msgid "Override the generic effect settings for the desktop background"
 msgstr "Unieke effectinstellingen gebruiken voor de bureaubladachtergrond"
 
 #. 6.0->settings-schema.json->enable-notification-override->description
 #, fuzzy
-msgid "Use unique effect settings for the notification popups"
+msgid "Override the generic effect settings for notification popups"
 msgstr "Unieke effectinstellingen gebruiken voor pop-upmenu’s"
 
 #. 6.0->settings-schema.json->enable-appswitcher-override->description
 #, fuzzy
-msgid "Use unique effect settings for the Alt-Tab app switcher"
+msgid "Override the generic effect settings for the Alt-Tab app switcher"
 msgstr "Unieke effectinstellingen gebruiken voor pop-upmenu’s"
 
 #. 6.0->settings-schema.json->enable-tooltips-override->description
 #, fuzzy
-msgid "Use unique effect settings for the panel tooltips"
+msgid "Override the generic effect settings for panel tooltips"
 msgstr "Unieke effectinstellingen gebruiken voor Panelen"
 
 #. 6.0->settings-schema.json->enable-desklets-override->description
 #, fuzzy
-msgid "Use unique effect settings for the Desklets"
+msgid "Override the generic effect settings for Desklets"
 msgstr "Unieke effectinstellingen gebruiken voor Panelen"
 
 #. 6.0->settings-schema.json->enable-desklets-unique-settings->description
@@ -741,7 +803,9 @@ msgstr "Bureaubladachtergrond"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple static blur"
 msgstr ""
 
@@ -749,13 +813,30 @@ msgstr ""
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 #, fuzzy
 msgid "Gaussian static blur"
 msgstr "Gaussiaanse vervagingsintensiteit"
 
 #. 6.0->settings-schema.json->blurType->options
 msgid "Gaussian dynamic blur (if applicable)"
+msgstr ""
+
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo static blur"
+msgstr "Gaussiaanse vervagingsintensiteit"
+
+#. 6.0->settings-schema.json->blurType->options
+msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr ""
 
 #. 6.0->settings-schema.json->blurType->description
@@ -771,7 +852,6 @@ msgstr "Type van het vervagingseffect"
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Welk type algoritme wordt gebruikt om de achtergrond te vervagen."
@@ -786,7 +866,8 @@ msgstr "Welk type algoritme wordt gebruikt om de achtergrond te vervagen."
 #. 6.0->settings-schema.json->appswitcher-radius->description
 #. 6.0->settings-schema.json->tooltips-radius->description
 #. 6.0->settings-schema.json->desklets-radius->description
-msgid "Gaussian blur intensity"
+#, fuzzy
+msgid "Blur intensity"
 msgstr "Gaussiaanse vervagingsintensiteit"
 
 #. 6.0->settings-schema.json->radius->tooltip
@@ -834,6 +915,49 @@ msgid ""
 "color."
 msgstr "Past de kleurverzadiging van de achtergrondafbeelding aan."
 
+#. 6.0->settings-schema.json->monte-carlo-iterations->description
+#, fuzzy
+msgid "Iterations"
+msgstr "Verzadiging"
+
+#. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
+msgid ""
+"Increasing number of iterations will make the blur appear smoother at the "
+"cost of some CPU power."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
+msgid "Use base pixel"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->tooltip
+msgid ""
+"Whether or not the original pixel is counted for the blur. If it is, the "
+"image will be more legible."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->description
+msgid "Prefer closer pixels"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->tooltip
+msgid ""
+"Whether or not the pixels that are closer to the original pixel will have "
+"more weight."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->description
+msgid ""
+"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->tooltip
+msgid ""
+"The above Monte Carlo settings are used globally for all components that are "
+"configured to use the Monte Carlo blur algorithm, these settings can not be "
+"configured separately for each component"
+msgstr ""
+
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
@@ -845,18 +969,20 @@ msgstr "Geen"
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Eenvoudig"
 
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gaussiaans"
+
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Monte Carlo"
+msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
@@ -876,9 +1002,21 @@ msgstr "Bureaubladachtergrond"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 #, fuzzy
 msgid "Gaussian dynamic blur"
+msgstr "Gaussiaanse vervagingsintensiteit"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo dynamic blur"
 msgstr "Gaussiaanse vervagingsintensiteit"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -972,10 +1110,45 @@ msgid ""
 "your notification setting behave."
 msgstr ""
 
-#. 6.0->settings-schema.json->appswitcher-info->description
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->description
+msgid "Hide panels while using the Coverflow/Timeline 3D Alt-Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->tooltip
 msgid ""
-"Note: Alt-Tab effects only apply to the Coverflow and Timeline 3D Alt-Tab "
-"configurations"
+"Make the panels invisible when using the Coverflow or the Timeline 3D Alt-"
+"Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->description
+#, fuzzy
+msgid "Apply effects to the standard Alt-Tab switcher"
+msgstr "Unieke effectinstellingen gebruiken voor pop-upmenu’s"
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->tooltip
+msgid ""
+"Allow applying effects to the standard Alt-Tab switcher. Only the switcher "
+"options without \"previews\" are supported. The standard Alt-Tab switcher "
+"can use static or dynamic blur, but dynamic is recommended."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->description
+#, fuzzy
+msgid "Apply effects to the 3D Alt-Tab switchers"
+msgstr "Unieke effectinstellingen gebruiken voor pop-upmenu’s"
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->tooltip
+msgid ""
+"Allow applying effects to the Coverflow and Timeline 3D Alt-Tab switchers. "
+"The 3D Alt-Tab switchers will use static blurring even when dynamic blurring "
+"is selected since they don't benifit from dynamic blurring."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
+msgid ""
+"What type of blur algorithm should be used to blur the background. A dynamic "
+"blur type can be used for the standard switcher but static blurring is "
+"always used for the 3D switchers as they do not benefit from dynamic effects."
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->description
@@ -1030,6 +1203,19 @@ msgid ""
 "effect\" extension will be disabled for windows with Blur Cinnamon effects "
 "applied. This option will have no effect unless the \"Compiz window effect\" "
 "extension is installed and active."
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->description
+msgid "Use artifact mitigation techniques"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->tooltip
+msgid ""
+"When enabled, steps will be taken to eliminate background graphical "
+"artifacts for windows that use dynamic blur effects. The mitigation steps "
+"will have some minor persistent CPU costs when a dynamic blurred window is "
+"on top of two or more other windows. This option is recommended unless you "
+"are using video wallpaper like Hidamari"
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ru.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ru.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 2.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-06 00:29-0500\n"
+"POT-Creation-Date: 2026-06-06 17:40-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Grom-TS\n"
 "Language-Team: \n"
@@ -17,16 +17,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
-#. 6.0/extension.js:2399
+#. 6.0/extension.js:2600 6.0/extension.js:2603 6.0/extension.js:2713
 msgid "Default window settings"
 msgstr "Настройки окон по умолчанию"
 
-#. 6.0/extension.js:2544
+#. 6.0/extension.js:2861
 msgid "Error"
 msgstr "Ошибка"
 
-#. 6.0/extension.js:2545
+#. 6.0/extension.js:2862
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
@@ -35,14 +34,14 @@ msgstr ""
 "Не удалось определить приложение или WM_CLASS ранее активного окна, поэтому "
 "эффекты Blur Cinnamon не могут быть применены к этому окну"
 
-#. 6.0/extension.js:3301
+#. 6.0/extension.js:3716
 msgid "Welcome to Blur Cinnamon"
 msgstr "Добро пожаловать в Blur Cinnamon"
 
-#. 6.0/extension.js:3302
+#. 6.0/extension.js:3717
+#, fuzzy
 msgid ""
-"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
-"Timeline effects.\n"
+"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
 "Open the Blur Cinnamon Settings to enable additional effects on several "
 "other desktop elements like menus, notifications and windows, or disable "
@@ -50,23 +49,23 @@ msgid ""
 "changes to the effect properties like blur intensity, color saturation and "
 "dimming."
 msgstr ""
-"Надеемся, вам понравились новые эффекты для панели, Expo, обзора окон и "
-"Alt-Tab (Coverflow/Timeline).\n"
+"Надеемся, вам понравились новые эффекты для панели, Expo, обзора окон и Alt-"
+"Tab (Coverflow/Timeline).\n"
 "\n"
 "Откройте настройки Blur Cinnamon, чтобы включить дополнительные эффекты для "
 "других элементов рабочего стола, таких как меню, уведомления и окна, либо "
 "отключить эффекты, включённые по умолчанию. Также можно настроить параметры "
 "эффектов, такие как интенсивность размытия, насыщенность цветов и затемнение."
 
-#. 6.0/extension.js:3306
+#. 6.0/extension.js:3721
 msgid "Open Blur Cinnamon Settings"
 msgstr "Открыть настройки Blur Cinnamon"
 
-#. 6.0/extension.js:3388
+#. 6.0/extension.js:3806
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Тестирование эффектов уведомлений Blur Cinnamon"
 
-#. 6.0/extension.js:3389
+#. 6.0/extension.js:3807
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -77,8 +76,8 @@ msgstr ""
 "Так будут выглядеть уведомления при использовании текущих эффектов "
 "всплывающих уведомлений Blur Cinnamon.\n"
 "\n"
-"Любые дальнейшие изменения настроек эффектов уведомлений будут "
-"автоматически применяться к этому сообщению."
+"Любые дальнейшие изменения настроек эффектов уведомлений будут автоматически "
+"применяться к этому сообщению."
 
 #. metadata.json->name
 msgid "Blur Cinnamon"
@@ -112,6 +111,11 @@ msgstr "О дополнении"
 #. 6.0->settings-schema.json->general-settings->title
 msgid "Cinnamon desktop components where effects will be applied"
 msgstr "Компоненты Cinnamon, к которым будут применяться эффекты"
+
+#. 6.0->settings-schema.json->monte-carlo-settings->title
+#, fuzzy
+msgid "Monte Carlo specific settings"
+msgstr "Настройки отдельных панелей"
 
 #. 6.0->settings-schema.json->component-selector-section->title
 msgid "Component Selector"
@@ -203,9 +207,9 @@ msgid ""
 msgstr ""
 "Чтобы эффекты Blur Cinnamon для десклетов были видны, фон десклета должен "
 "быть прозрачным. Это позволяет отображать эффект размытия под десклетом. "
-"Большинство десклетов можно настроить на использование прозрачного фона. "
-"На рабочем столе щёлкните правой кнопкой мыши по десклету и выберите пункт "
-"меню «Настроить...», чтобы открыть окно его настройки."
+"Большинство десклетов можно настроить на использование прозрачного фона. На "
+"рабочем столе щёлкните правой кнопкой мыши по десклету и выберите пункт меню "
+"«Настроить...», чтобы открыть окно его настройки."
 
 #. 6.0->settings-schema.json->windows-label->description
 msgid ""
@@ -281,8 +285,8 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners and Gaussian effects are based on code by aunetx (Blur-"
-"my-shell)\n"
+"The rounded corners, Gaussian and Monte Carlo effects\n"
+"are based on code by aunetx (Blur-my-shell)\n"
 "<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
 "href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
 "\n"
@@ -353,14 +357,15 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->description
-msgid "Alt-Tab application switcher (Coverflow & Timeline only)"
+msgid "Alt-Tab application switcher"
 msgstr ""
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->tooltip
-msgid ""
-"Apply effects to the Alt-Tab application switcher background when setup to "
-"use the Coverflow or Timeline styles"
+#, fuzzy
+msgid "Apply effects to the Alt-Tab application switcher background"
 msgstr ""
+"Использовать отдельные настройки эффектов для переключателя приложений Alt-"
+"Tab"
 
 #. 6.0->settings-schema.json->enable-tooltips-effects->description
 msgid "Panel tooltips (Please read tooltip)"
@@ -430,7 +435,8 @@ msgstr ""
 
 #. 6.0->settings-schema.json->allow-transparent-color-popup->description
 msgid "Override some of the popup menu theme settings (recommended)"
-msgstr "Переопределять некоторые настройки темы всплывающих меню (рекомендуется)"
+msgstr ""
+"Переопределять некоторые настройки темы всплывающих меню (рекомендуется)"
 
 #. 6.0->settings-schema.json->allow-transparent-color-popup->tooltip
 msgid ""
@@ -446,45 +452,114 @@ msgstr ""
 "только в том случае, если используемая тема уже поддерживает прозрачные "
 "всплывающие меню и вы хотите использовать настройки самой темы."
 
+#. 6.0->settings-schema.json->allow-transparent-color-
+#. notifications->description
+#, fuzzy
+msgid "Override some of the notification theme settings (recommended)"
+msgstr "Переопределять некоторые настройки темы панелей (рекомендуется)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-notifications->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the notification transparency and background "
+"color settings. If this is disabled the extension will only apply a blur "
+"background under the notifications. This setting should only be disabled "
+"when the theme already uses transparent notifications and you want the "
+"themes setting to apply."
+msgstr ""
+"Разрешить этому расширению изменять параметры прозрачности и цвета фона "
+"панелей. Если параметр отключён, расширение будет применять только эффект "
+"размытия под панелями. Отключать этот параметр следует только в том случае, "
+"если используемая тема уже поддерживает прозрачные панели и вы хотите "
+"использовать настройки самой темы."
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->description
+#, fuzzy
+msgid "Override some of the tooltip theme settings (recommended)"
+msgstr "Переопределять некоторые настройки темы панелей (рекомендуется)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the tooltip transparency and background color "
+"settings. If this is disabled the extension will only apply a blur "
+"background under the tooltips. This setting should only be disabled when the "
+"theme already uses transparent tooltips and you want the themes setting to "
+"apply."
+msgstr ""
+"Разрешить этому расширению изменять параметры прозрачности и цвета фона "
+"панелей. Если параметр отключён, расширение будет применять только эффект "
+"размытия под панелями. Отключать этот параметр следует только в том случае, "
+"если используемая тема уже поддерживает прозрачные панели и вы хотите "
+"использовать настройки самой темы."
+
 #. 6.0->settings-schema.json->enable-overview-override->description
-msgid "Use unique effect settings for the Overview"
+#, fuzzy
+msgid "Override the generic effect settings for the Overview"
 msgstr "Использовать отдельные настройки эффектов для режима обзора"
 
+#. 6.0->settings-schema.json->enable-overview-override->tooltip
+#. 6.0->settings-schema.json->enable-expo-override->tooltip
+#. 6.0->settings-schema.json->enable-panels-override->tooltip
+#. 6.0->settings-schema.json->enable-popup-override->tooltip
+#. 6.0->settings-schema.json->enable-desktop-override->tooltip
+#. 6.0->settings-schema.json->enable-notification-override->tooltip
+#. 6.0->settings-schema.json->enable-appswitcher-override->tooltip
+#. 6.0->settings-schema.json->enable-tooltips-override->tooltip
+#. 6.0->settings-schema.json->enable-desklets-override->tooltip
+msgid ""
+"Override the settings found on the \"Generic effect settings\" tab with "
+"unique settings for this cinnamon component."
+msgstr ""
+
 #. 6.0->settings-schema.json->enable-expo-override->description
-msgid "Use unique effect settings for the Expo"
+#, fuzzy
+msgid "Override the generic effect settings for the Expo"
 msgstr "Использовать отдельные настройки эффектов для Expo"
 
 #. 6.0->settings-schema.json->enable-panels-override->description
-msgid "Use unique effect settings for the Panels"
+#, fuzzy
+msgid "Override the generic effect settings for the Panels"
 msgstr "Использовать отдельные настройки эффектов для панелей"
 
 #. 6.0->settings-schema.json->enable-popup-override->description
-msgid "Use unique effect settings for the popup menus"
+#, fuzzy
+msgid "Override the generic effect settings for popup menus"
 msgstr "Использовать отдельные настройки эффектов для всплывающих меню"
 
 #. 6.0->settings-schema.json->enable-desktop-override->description
-msgid "Use unique effect settings for the desktop background"
+#, fuzzy
+msgid "Override the generic effect settings for the desktop background"
 msgstr "Использовать отдельные настройки эффектов для фона рабочего стола"
 
 #. 6.0->settings-schema.json->enable-notification-override->description
-msgid "Use unique effect settings for the notification popups"
+#, fuzzy
+msgid "Override the generic effect settings for notification popups"
 msgstr "Использовать отдельные настройки эффектов для всплывающих уведомлений"
 
 #. 6.0->settings-schema.json->enable-appswitcher-override->description
-msgid "Use unique effect settings for the Alt-Tab app switcher"
-msgstr "Использовать отдельные настройки эффектов для переключателя приложений Alt-Tab"
+#, fuzzy
+msgid "Override the generic effect settings for the Alt-Tab app switcher"
+msgstr ""
+"Использовать отдельные настройки эффектов для переключателя приложений Alt-"
+"Tab"
 
 #. 6.0->settings-schema.json->enable-tooltips-override->description
-msgid "Use unique effect settings for the panel tooltips"
-msgstr "Использовать отдельные настройки эффектов для всплывающих подсказок панели"
+#, fuzzy
+msgid "Override the generic effect settings for panel tooltips"
+msgstr ""
+"Использовать отдельные настройки эффектов для всплывающих подсказок панели"
 
 #. 6.0->settings-schema.json->enable-desklets-override->description
-msgid "Use unique effect settings for the Desklets"
+#, fuzzy
+msgid "Override the generic effect settings for Desklets"
 msgstr "Использовать отдельные настройки эффектов для десклетов"
 
 #. 6.0->settings-schema.json->enable-desklets-unique-settings->description
 msgid "Enable advanced options to apply unique settings for each Desklet"
-msgstr "Включить расширенные параметры для применения отдельных настроек к каждому десклету"
+msgstr ""
+"Включить расширенные параметры для применения отдельных настроек к каждому "
+"десклету"
 
 #. 6.0->settings-schema.json->enable-desklets-unique-settings->tooltip
 msgid ""
@@ -492,7 +567,8 @@ msgid ""
 "disable effects completely for some Desklets."
 msgstr ""
 "Если этот параметр включён, каждый десклет сможет использовать собственные "
-"настройки, либо вы сможете полностью отключить эффекты для отдельных десклетов."
+"настройки, либо вы сможете полностью отключить эффекты для отдельных "
+"десклетов."
 
 #. 6.0->settings-schema.json->window-settings-button->description
 msgid "Open Alt-Tab Cinnamon settings"
@@ -500,7 +576,9 @@ msgstr "Открыть настройки Alt-Tab Cinnamon"
 
 #. 6.0->settings-schema.json->enable-panel-unique-settings->description
 msgid "Enable advanced options to apply unique settings for each panel"
-msgstr "Включить расширенные параметры для применения отдельных настроек к каждой панели"
+msgstr ""
+"Включить расширенные параметры для применения отдельных настроек к каждой "
+"панели"
 
 #. 6.0->settings-schema.json->enable-panel-unique-settings->tooltip
 msgid ""
@@ -582,8 +660,8 @@ msgstr ""
 "применяться эффекты. Будет использоваться первое подходящее правило из "
 "списка. Флажок «Custom» определяет, используются ли общие настройки эффектов "
 "или собственные настройки из этой таблицы. Поле цвета задаётся в формате "
-"rgb(#,#,#), при отсутствии цвета или некорректном формате будет использоваться "
-"чёрный цвет."
+"rgb(#,#,#), при отсутствии цвета или некорректном формате будет "
+"использоваться чёрный цвет."
 
 #. 6.0->settings-schema.json->no-panel-effects-maximized->description
 msgid "Restore theme settings when a window is maximized"
@@ -669,7 +747,9 @@ msgstr "Нет / Прозрачность до обоев"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple static blur"
 msgstr "Простое статическое размытие"
 
@@ -677,12 +757,29 @@ msgstr "Простое статическое размытие"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian static blur"
 msgstr ""
 
 #. 6.0->settings-schema.json->blurType->options
 msgid "Gaussian dynamic blur (if applicable)"
+msgstr ""
+
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo static blur"
+msgstr "Простое статическое размытие"
+
+#. 6.0->settings-schema.json->blurType->options
+msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr ""
 
 #. 6.0->settings-schema.json->blurType->description
@@ -698,7 +795,6 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr ""
@@ -713,8 +809,9 @@ msgstr ""
 #. 6.0->settings-schema.json->appswitcher-radius->description
 #. 6.0->settings-schema.json->tooltips-radius->description
 #. 6.0->settings-schema.json->desklets-radius->description
-msgid "Gaussian blur intensity"
-msgstr ""
+#, fuzzy
+msgid "Blur intensity"
+msgstr "Интенсивность"
 
 #. 6.0->settings-schema.json->radius->tooltip
 #. 6.0->settings-schema.json->overview-radius->tooltip
@@ -758,6 +855,49 @@ msgid ""
 "color."
 msgstr ""
 
+#. 6.0->settings-schema.json->monte-carlo-iterations->description
+#, fuzzy
+msgid "Iterations"
+msgstr "Насыщенность"
+
+#. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
+msgid ""
+"Increasing number of iterations will make the blur appear smoother at the "
+"cost of some CPU power."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
+msgid "Use base pixel"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->tooltip
+msgid ""
+"Whether or not the original pixel is counted for the blur. If it is, the "
+"image will be more legible."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->description
+msgid "Prefer closer pixels"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->tooltip
+msgid ""
+"Whether or not the pixels that are closer to the original pixel will have "
+"more weight."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->description
+msgid ""
+"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->tooltip
+msgid ""
+"The above Monte Carlo settings are used globally for all components that are "
+"configured to use the Monte Carlo blur algorithm, these settings can not be "
+"configured separately for each component"
+msgstr ""
+
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
@@ -769,17 +909,19 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr ""
 
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
+msgstr ""
+
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Monte Carlo"
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->options
@@ -799,8 +941,19 @@ msgstr ""
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian dynamic blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+msgid "Monte Carlo dynamic blur"
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -880,10 +1033,49 @@ msgid ""
 "your notification setting behave."
 msgstr ""
 
-#. 6.0->settings-schema.json->appswitcher-info->description
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->description
+msgid "Hide panels while using the Coverflow/Timeline 3D Alt-Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->tooltip
 msgid ""
-"Note: Alt-Tab effects only apply to the Coverflow and Timeline 3D Alt-Tab "
-"configurations"
+"Make the panels invisible when using the Coverflow or the Timeline 3D Alt-"
+"Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->description
+#, fuzzy
+msgid "Apply effects to the standard Alt-Tab switcher"
+msgstr ""
+"Использовать отдельные настройки эффектов для переключателя приложений Alt-"
+"Tab"
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->tooltip
+msgid ""
+"Allow applying effects to the standard Alt-Tab switcher. Only the switcher "
+"options without \"previews\" are supported. The standard Alt-Tab switcher "
+"can use static or dynamic blur, but dynamic is recommended."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->description
+#, fuzzy
+msgid "Apply effects to the 3D Alt-Tab switchers"
+msgstr ""
+"Использовать отдельные настройки эффектов для переключателя приложений Alt-"
+"Tab"
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->tooltip
+msgid ""
+"Allow applying effects to the Coverflow and Timeline 3D Alt-Tab switchers. "
+"The 3D Alt-Tab switchers will use static blurring even when dynamic blurring "
+"is selected since they don't benifit from dynamic blurring."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
+msgid ""
+"What type of blur algorithm should be used to blur the background. A dynamic "
+"blur type can be used for the standard switcher but static blurring is "
+"always used for the 3D switchers as they do not benefit from dynamic effects."
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->description
@@ -938,6 +1130,19 @@ msgid ""
 "effect\" extension will be disabled for windows with Blur Cinnamon effects "
 "applied. This option will have no effect unless the \"Compiz window effect\" "
 "extension is installed and active."
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->description
+msgid "Use artifact mitigation techniques"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->tooltip
+msgid ""
+"When enabled, steps will be taken to eliminate background graphical "
+"artifacts for windows that use dynamic blur effects. The mitigation steps "
+"will have some minor persistent CPU costs when a dynamic blurred window is "
+"on top of two or more other windows. This option is recommended unless you "
+"are using video wallpaper like Hidamari"
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/vi.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/vi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.5.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-06 00:29-0500\n"
+"POT-Creation-Date: 2026-06-06 17:40-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: loccun <huynhloc.contact@gmail.com>\n"
 "Language-Team: \n"
@@ -18,32 +18,30 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
-#. 6.0/extension.js:2399
+#. 6.0/extension.js:2600 6.0/extension.js:2603 6.0/extension.js:2713
 #, fuzzy
 msgid "Default window settings"
 msgstr "Mở cài đặt Alt-Tab Cinnamon"
 
-#. 6.0/extension.js:2544
+#. 6.0/extension.js:2861
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:2545
+#. 6.0/extension.js:2862
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3301
+#. 6.0/extension.js:3716
 msgid "Welcome to Blur Cinnamon"
 msgstr "Chào mừng đến với Blur Cinnamon"
 
-#. 6.0/extension.js:3302
+#. 6.0/extension.js:3717
 #, fuzzy
 msgid ""
-"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/"
-"Timeline effects.\n"
+"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
 "Open the Blur Cinnamon Settings to enable additional effects on several "
 "other desktop elements like menus, notifications and windows, or disable "
@@ -59,15 +57,15 @@ msgstr ""
 "phần được bật theo mặc định. Bạn cũng có thể thay đổi các thuộc tính hiệu "
 "ứng như cường độ làm mờ, độ bão hòa màu và làm tối."
 
-#. 6.0/extension.js:3306
+#. 6.0/extension.js:3721
 msgid "Open Blur Cinnamon Settings"
 msgstr "Mở Cài đặt Blur Cinnamon"
 
-#. 6.0/extension.js:3388
+#. 6.0/extension.js:3806
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Đang thử nghiệm Hiệu ứng Thông báo Blur Cinnamon"
 
-#. 6.0/extension.js:3389
+#. 6.0/extension.js:3807
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -116,6 +114,11 @@ msgstr ""
 #, fuzzy
 msgid "Cinnamon desktop components where effects will be applied"
 msgstr "Các thành phần Cinnamon sẽ áp dụng hiệu ứng"
+
+#. 6.0->settings-schema.json->monte-carlo-settings->title
+#, fuzzy
+msgid "Monte Carlo specific settings"
+msgstr "Cài đặt cụ thể cho panel"
 
 #. 6.0->settings-schema.json->component-selector-section->title
 msgid "Component Selector"
@@ -291,8 +294,8 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners and Gaussian effects are based on code by aunetx (Blur-"
-"my-shell)\n"
+"The rounded corners, Gaussian and Monte Carlo effects\n"
+"are based on code by aunetx (Blur-my-shell)\n"
 "<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
 "href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
 "\n"
@@ -389,13 +392,13 @@ msgstr ""
 "để nền mờ không tràn ra các cạnh bo tròn."
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->description
-msgid "Alt-Tab application switcher (Coverflow & Timeline only)"
+#, fuzzy
+msgid "Alt-Tab application switcher"
 msgstr "Bộ chuyển đổi ứng dụng Alt-Tab (chỉ Coverflow & Timeline)"
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->tooltip
-msgid ""
-"Apply effects to the Alt-Tab application switcher background when setup to "
-"use the Coverflow or Timeline styles"
+#, fuzzy
+msgid "Apply effects to the Alt-Tab application switcher background"
 msgstr ""
 "Áp dụng hiệu ứng cho nền bộ chuyển đổi ứng dụng Alt-Tab khi được thiết lập "
 "để sử dụng kiểu Coverflow hoặc Timeline"
@@ -492,41 +495,102 @@ msgstr ""
 "chủ đề đã sử dụng trình đơn bật lên trong suốt và bạn muốn áp dụng cài đặt "
 "chủ đề."
 
+#. 6.0->settings-schema.json->allow-transparent-color-
+#. notifications->description
+#, fuzzy
+msgid "Override some of the notification theme settings (recommended)"
+msgstr "Ghi đè một số cài đặt chủ đề panel (được khuyến nghị)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-notifications->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the notification transparency and background "
+"color settings. If this is disabled the extension will only apply a blur "
+"background under the notifications. This setting should only be disabled "
+"when the theme already uses transparent notifications and you want the "
+"themes setting to apply."
+msgstr ""
+"Cho phép tiện ích mở rộng này sửa đổi cài đặt độ trong suốt và màu nền của "
+"panel. Nếu bị tắt, tiện ích mở rộng sẽ chỉ áp dụng một lớp phủ mờ bên dưới "
+"panel. Cài đặt này chỉ nên bị tắt khi chủ đề đã sử dụng panel trong suốt và "
+"bạn muốn áp dụng cài đặt chủ đề."
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->description
+#, fuzzy
+msgid "Override some of the tooltip theme settings (recommended)"
+msgstr "Ghi đè một số cài đặt chủ đề panel (được khuyến nghị)"
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the tooltip transparency and background color "
+"settings. If this is disabled the extension will only apply a blur "
+"background under the tooltips. This setting should only be disabled when the "
+"theme already uses transparent tooltips and you want the themes setting to "
+"apply."
+msgstr ""
+"Cho phép tiện ích mở rộng này sửa đổi cài đặt độ trong suốt và màu nền của "
+"panel. Nếu bị tắt, tiện ích mở rộng sẽ chỉ áp dụng một lớp phủ mờ bên dưới "
+"panel. Cài đặt này chỉ nên bị tắt khi chủ đề đã sử dụng panel trong suốt và "
+"bạn muốn áp dụng cài đặt chủ đề."
+
 #. 6.0->settings-schema.json->enable-overview-override->description
-msgid "Use unique effect settings for the Overview"
+#, fuzzy
+msgid "Override the generic effect settings for the Overview"
 msgstr "Sử dụng cài đặt hiệu ứng duy nhất cho Tổng quan"
 
+#. 6.0->settings-schema.json->enable-overview-override->tooltip
+#. 6.0->settings-schema.json->enable-expo-override->tooltip
+#. 6.0->settings-schema.json->enable-panels-override->tooltip
+#. 6.0->settings-schema.json->enable-popup-override->tooltip
+#. 6.0->settings-schema.json->enable-desktop-override->tooltip
+#. 6.0->settings-schema.json->enable-notification-override->tooltip
+#. 6.0->settings-schema.json->enable-appswitcher-override->tooltip
+#. 6.0->settings-schema.json->enable-tooltips-override->tooltip
+#. 6.0->settings-schema.json->enable-desklets-override->tooltip
+msgid ""
+"Override the settings found on the \"Generic effect settings\" tab with "
+"unique settings for this cinnamon component."
+msgstr ""
+
 #. 6.0->settings-schema.json->enable-expo-override->description
-msgid "Use unique effect settings for the Expo"
+#, fuzzy
+msgid "Override the generic effect settings for the Expo"
 msgstr "Sử dụng cài đặt hiệu ứng duy nhất cho Expo"
 
 #. 6.0->settings-schema.json->enable-panels-override->description
-msgid "Use unique effect settings for the Panels"
+#, fuzzy
+msgid "Override the generic effect settings for the Panels"
 msgstr "Sử dụng cài đặt hiệu ứng duy nhất cho Panel"
 
 #. 6.0->settings-schema.json->enable-popup-override->description
-msgid "Use unique effect settings for the popup menus"
+#, fuzzy
+msgid "Override the generic effect settings for popup menus"
 msgstr "Sử dụng cài đặt hiệu ứng duy nhất cho trình đơn bật lên"
 
 #. 6.0->settings-schema.json->enable-desktop-override->description
-msgid "Use unique effect settings for the desktop background"
+#, fuzzy
+msgid "Override the generic effect settings for the desktop background"
 msgstr "Sử dụng cài đặt hiệu ứng duy nhất cho nền màn hình"
 
 #. 6.0->settings-schema.json->enable-notification-override->description
-msgid "Use unique effect settings for the notification popups"
+#, fuzzy
+msgid "Override the generic effect settings for notification popups"
 msgstr "Sử dụng cài đặt hiệu ứng duy nhất cho thông báo bật lên"
 
 #. 6.0->settings-schema.json->enable-appswitcher-override->description
-msgid "Use unique effect settings for the Alt-Tab app switcher"
+#, fuzzy
+msgid "Override the generic effect settings for the Alt-Tab app switcher"
 msgstr "Sử dụng cài đặt hiệu ứng duy nhất cho bộ chuyển đổi ứng dụng Alt-Tab"
 
 #. 6.0->settings-schema.json->enable-tooltips-override->description
-msgid "Use unique effect settings for the panel tooltips"
+#, fuzzy
+msgid "Override the generic effect settings for panel tooltips"
 msgstr "Sử dụng cài đặt hiệu ứng duy nhất cho chú giải công cụ panel"
 
 #. 6.0->settings-schema.json->enable-desklets-override->description
 #, fuzzy
-msgid "Use unique effect settings for the Desklets"
+msgid "Override the generic effect settings for Desklets"
 msgstr "Sử dụng cài đặt hiệu ứng duy nhất cho Panel"
 
 #. 6.0->settings-schema.json->enable-desklets-unique-settings->description
@@ -714,7 +778,9 @@ msgstr "Nền màn hình"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple static blur"
 msgstr ""
 
@@ -722,13 +788,30 @@ msgstr ""
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 #, fuzzy
 msgid "Gaussian static blur"
 msgstr "Cường độ làm mờ Gaussian"
 
 #. 6.0->settings-schema.json->blurType->options
 msgid "Gaussian dynamic blur (if applicable)"
+msgstr ""
+
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo static blur"
+msgstr "Cường độ làm mờ Gaussian"
+
+#. 6.0->settings-schema.json->blurType->options
+msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr ""
 
 #. 6.0->settings-schema.json->blurType->description
@@ -744,7 +827,6 @@ msgstr "Loại hiệu ứng làm mờ"
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Loại thuật toán làm mờ nào nên được sử dụng để làm mờ nền"
@@ -759,7 +841,8 @@ msgstr "Loại thuật toán làm mờ nào nên được sử dụng để làm
 #. 6.0->settings-schema.json->appswitcher-radius->description
 #. 6.0->settings-schema.json->tooltips-radius->description
 #. 6.0->settings-schema.json->desklets-radius->description
-msgid "Gaussian blur intensity"
+#, fuzzy
+msgid "Blur intensity"
 msgstr "Cường độ làm mờ Gaussian"
 
 #. 6.0->settings-schema.json->radius->tooltip
@@ -807,6 +890,49 @@ msgid ""
 "color."
 msgstr "Điều chỉnh độ bão hòa màu của hình nền."
 
+#. 6.0->settings-schema.json->monte-carlo-iterations->description
+#, fuzzy
+msgid "Iterations"
+msgstr "Độ bão hòa"
+
+#. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
+msgid ""
+"Increasing number of iterations will make the blur appear smoother at the "
+"cost of some CPU power."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
+msgid "Use base pixel"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->tooltip
+msgid ""
+"Whether or not the original pixel is counted for the blur. If it is, the "
+"image will be more legible."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->description
+msgid "Prefer closer pixels"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->tooltip
+msgid ""
+"Whether or not the pixels that are closer to the original pixel will have "
+"more weight."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->description
+msgid ""
+"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->tooltip
+msgid ""
+"The above Monte Carlo settings are used globally for all components that are "
+"configured to use the Monte Carlo blur algorithm, these settings can not be "
+"configured separately for each component"
+msgstr ""
+
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
@@ -818,18 +944,20 @@ msgstr "Không"
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "Đơn giản"
 
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "Gaussian"
+
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Monte Carlo"
+msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
@@ -849,9 +977,21 @@ msgstr "Nền màn hình"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 #, fuzzy
 msgid "Gaussian dynamic blur"
+msgstr "Cường độ làm mờ Gaussian"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo dynamic blur"
 msgstr "Cường độ làm mờ Gaussian"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -944,10 +1084,45 @@ msgstr ""
 "Nút này sẽ làm xuất hiện một thông báo để bạn có thể xem cài đặt thông báo "
 "của mình hoạt động như thế nào."
 
-#. 6.0->settings-schema.json->appswitcher-info->description
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->description
+msgid "Hide panels while using the Coverflow/Timeline 3D Alt-Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->tooltip
 msgid ""
-"Note: Alt-Tab effects only apply to the Coverflow and Timeline 3D Alt-Tab "
-"configurations"
+"Make the panels invisible when using the Coverflow or the Timeline 3D Alt-"
+"Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->description
+#, fuzzy
+msgid "Apply effects to the standard Alt-Tab switcher"
+msgstr "Sử dụng cài đặt hiệu ứng duy nhất cho bộ chuyển đổi ứng dụng Alt-Tab"
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->tooltip
+msgid ""
+"Allow applying effects to the standard Alt-Tab switcher. Only the switcher "
+"options without \"previews\" are supported. The standard Alt-Tab switcher "
+"can use static or dynamic blur, but dynamic is recommended."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->description
+#, fuzzy
+msgid "Apply effects to the 3D Alt-Tab switchers"
+msgstr "Sử dụng cài đặt hiệu ứng duy nhất cho bộ chuyển đổi ứng dụng Alt-Tab"
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->tooltip
+msgid ""
+"Allow applying effects to the Coverflow and Timeline 3D Alt-Tab switchers. "
+"The 3D Alt-Tab switchers will use static blurring even when dynamic blurring "
+"is selected since they don't benifit from dynamic blurring."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
+msgid ""
+"What type of blur algorithm should be used to blur the background. A dynamic "
+"blur type can be used for the standard switcher but static blurring is "
+"always used for the 3D switchers as they do not benefit from dynamic effects."
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->description
@@ -1002,6 +1177,19 @@ msgid ""
 "effect\" extension will be disabled for windows with Blur Cinnamon effects "
 "applied. This option will have no effect unless the \"Compiz window effect\" "
 "extension is installed and active."
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->description
+msgid "Use artifact mitigation techniques"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->tooltip
+msgid ""
+"When enabled, steps will be taken to eliminate background graphical "
+"artifacts for windows that use dynamic blur effects. The mitigation steps "
+"will have some minor persistent CPU costs when a dynamic blurred window is "
+"on top of two or more other windows. This option is recommended unless you "
+"are using video wallpaper like Hidamari"
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/zh_TW.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/zh_TW.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 2.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-03-06 00:29-0500\n"
+"POT-Creation-Date: 2026-06-06 17:40-0400\n"
 "PO-Revision-Date: 2026-06-01 18:00+0800\n"
 "Last-Translator: Alang Hsu <alang.hsu@gmail.com>\n"
 "Language-Team: \n"
@@ -16,47 +16,57 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-
-#. 6.0/extension.js:2268 6.0/extension.js:2271 6.0/extension.js:2331
-#. 6.0/extension.js:2399
+#. 6.0/extension.js:2600 6.0/extension.js:2603 6.0/extension.js:2713
 msgid "Default window settings"
 msgstr "預設視窗設定"
 
-#. 6.0/extension.js:2544
+#. 6.0/extension.js:2861
 msgid "Error"
 msgstr "錯誤"
 
-#. 6.0/extension.js:2545
-msgid "Unable to determine the application or the WM_CLASS of the previously focused window, therefore Blur Cinnamon effects can not be applied to that window"
-msgstr "無法判斷先前聚焦的視窗或其 WM_CLASS，因此無法對該視窗套用 Blur Cinnamon 效果"
+#. 6.0/extension.js:2862
+msgid ""
+"Unable to determine the application or the WM_CLASS of the previously "
+"focused window, therefore Blur Cinnamon effects can not be applied to that "
+"window"
+msgstr ""
+"無法判斷先前聚焦的視窗或其 WM_CLASS，因此無法對該視窗套用 Blur Cinnamon 效果"
 
-#. 6.0/extension.js:3301
+#. 6.0/extension.js:3716
 msgid "Welcome to Blur Cinnamon"
 msgstr "歡迎使用 Blur Cinnamon"
 
-#. 6.0/extension.js:3302
+#. 6.0/extension.js:3717
+#, fuzzy
 msgid ""
-"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab Coverflow/Timeline effects.\n"
+"Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
-"Open the Blur Cinnamon Settings to enable additional effects on several other desktop elements like menus, notifications and windows, or disable effects on components that were enabled by default. You can also make changes to the effect properties like blur intensity, color saturation and dimming."
+"Open the Blur Cinnamon Settings to enable additional effects on several "
+"other desktop elements like menus, notifications and windows, or disable "
+"effects on components that were enabled by default. You can also make "
+"changes to the effect properties like blur intensity, color saturation and "
+"dimming."
 msgstr ""
 "希望您喜歡新的面板、Expo、Overview 及 Alt-Tab Coverflow/Timeline 效果。\n"
 "\n"
-"開啟 Blur Cinnamon 設定以啟用其他桌面元素（如選單、通知和視窗）的效果，或停用預設啟用的元件效果。您也可以調整效果屬性，如模糊強度、色彩飽和度和調暗程度。"
+"開啟 Blur Cinnamon 設定以啟用其他桌面元素（如選單、通知和視窗）的效果，或停用"
+"預設啟用的元件效果。您也可以調整效果屬性，如模糊強度、色彩飽和度和調暗程度。"
 
-#. 6.0/extension.js:3306
+#. 6.0/extension.js:3721
 msgid "Open Blur Cinnamon Settings"
 msgstr "開啟 Blur Cinnamon 設定"
 
-#. 6.0/extension.js:3388
+#. 6.0/extension.js:3806
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "測試 Blur Cinnamon 通知效果"
 
-#. 6.0/extension.js:3389
+#. 6.0/extension.js:3807
 msgid ""
-"This is how notifications will appear when using the current Blur Cinnamon Notification Popup effects.\n"
+"This is how notifications will appear when using the current Blur Cinnamon "
+"Notification Popup effects.\n"
 "\n"
-"Making further changes to the notification effect settings will automatically apply to this notification message."
+"Making further changes to the notification effect settings will "
+"automatically apply to this notification message."
 msgstr ""
 "這是使用目前 Blur Cinnamon 通知彈出效果時，通知的呈現樣貌。\n"
 "\n"
@@ -67,7 +77,9 @@ msgid "Blur Cinnamon"
 msgstr "Blur Cinnamon"
 
 #. metadata.json->description
-msgid "Allows you to blur, colorize, desaturate and adjust the dimming of several Cinnamon Desktop components"
+msgid ""
+"Allows you to blur, colorize, desaturate and adjust the dimming of several "
+"Cinnamon Desktop components"
 msgstr "可讓您對多個 Cinnamon 桌面元件進行模糊、著色、降低飽和度及調整調暗效果"
 
 #. 6.0->settings-schema.json->general-page->title
@@ -91,6 +103,11 @@ msgstr "關於"
 msgid "Cinnamon desktop components where effects will be applied"
 msgstr "將套用效果的 Cinnamon 桌面元件"
 
+#. 6.0->settings-schema.json->monte-carlo-settings->title
+#, fuzzy
+msgid "Monte Carlo specific settings"
+msgstr "面板專屬設定"
+
 #. 6.0->settings-schema.json->component-selector-section->title
 msgid "Component Selector"
 msgstr "元件選擇器"
@@ -104,60 +121,100 @@ msgid "About Blur Cinnamon"
 msgstr "關於 Blur Cinnamon"
 
 #. 6.0->settings-schema.json->appswitcher-warning->description
-msgid "Note: The Alt-Tab effects are currently disabled under the \"General setup\" tab."
+msgid ""
+"Note: The Alt-Tab effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr "注意：Alt-Tab 效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->desklets-warning->description
-msgid "Note: The Desklet effects are currently disabled under the \"General setup\" tab."
+msgid ""
+"Note: The Desklet effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr "注意：Desklet 效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->desktop-warning->description
-msgid "Note: The Desktop effects are currently disabled under the \"General setup\" tab."
+msgid ""
+"Note: The Desktop effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr "注意：桌面效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->expo-warning->description
-msgid "Note: The Expo effects are currently disabled under the \"General setup\" tab."
+msgid ""
+"Note: The Expo effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr "注意：Expo 效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->popup-warning->description
-msgid "Note: The Menu effects are currently disabled under the \"General setup\" tab."
+msgid ""
+"Note: The Menu effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr "注意：選單效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->notification-warning->description
-msgid "Note: The Notification effects are currently disabled under the \"General setup\" tab."
+msgid ""
+"Note: The Notification effects are currently disabled under the \"General "
+"setup\" tab."
 msgstr "注意：通知效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->overview-warning->description
-msgid "Note: The Overview effects are currently disabled under the \"General setup\" tab."
+msgid ""
+"Note: The Overview effects are currently disabled under the \"General "
+"setup\" tab."
 msgstr "注意：Overview 效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->panel-warning->description
-msgid "Note: The Panel effects are currently disabled under the \"General setup\" tab."
+msgid ""
+"Note: The Panel effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr "注意：面板效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->tooltips-warning->description
-msgid "Note: The Tooltip effects are currently disabled under the \"General setup\" tab."
+msgid ""
+"Note: The Tooltip effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr "注意：工具提示效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->windows-warning->description
-msgid "Note: The Window effects are currently disabled under the \"General setup\" tab."
+msgid ""
+"Note: The Window effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr "注意：視窗效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->desklets-label->description
-msgid "<b>Note:</b> You must configure your Desklets to be transparent! (see tooltip)"
+msgid ""
+"<b>Note:</b> You must configure your Desklets to be transparent! (see "
+"tooltip)"
 msgstr "<b>注意：</b>您必須將 Desklet 設為透明！（請參閱工具提示）"
 
 #. 6.0->settings-schema.json->desklets-label->tooltip
-msgid "In order for Blur Cinnamon Desklet effects to be visible, a Desklets background must be transparent. This allows the blur effect to be visible below the Desklet. Most Desklets can be configured to have transparent backgrounds. On the Desktop, right-click on a Desklet, select the \"Configure...\" menu item to open a Desklet's configuration window."
-msgstr "為了讓 Blur Cinnamon Desklet 效果可視，Desklet 的背景必須為透明。這樣模糊效果才能在 Desklet 下方顯示。大多數 Desklet 都可設定為透明背景。在桌面上，在 Desklet 上按右鍵，選擇「設定...」選單項目即可開啟 Desklet 的設定視窗。"
+msgid ""
+"In order for Blur Cinnamon Desklet effects to be visible, a Desklets "
+"background must be transparent. This allows the blur effect to be visible "
+"below the Desklet. Most Desklets can be configured to have transparent "
+"backgrounds. On the Desktop, right-click on a Desklet, select the "
+"\"Configure...\" menu item to open a Desklet's configuration window."
+msgstr ""
+"為了讓 Blur Cinnamon Desklet 效果可視，Desklet 的背景必須為透明。這樣模糊效果"
+"才能在 Desklet 下方顯示。大多數 Desklet 都可設定為透明背景。在桌面上，在 "
+"Desklet 上按右鍵，選擇「設定...」選單項目即可開啟 Desklet 的設定視窗。"
 
 #. 6.0->settings-schema.json->windows-label->description
-msgid "<b>Note:</b> Read tooltip for information about the \"Default window settings\""
+msgid ""
+"<b>Note:</b> Read tooltip for information about the \"Default window "
+"settings\""
 msgstr "<b>注意：</b>請參閱工具提示以瞭解「預設視窗設定」的相關資訊"
 
 #. 6.0->settings-schema.json->windows-label->tooltip
-msgid "If the special \"Default window settings\" table entry is enabled then all windows will have effects applied. If it is disabled then only the applications defined in the table will have effects applied. If the \"Enabled\" option is unchecked for a particular application then effects will be disabled even if the \"Default window settings\" row is enabled."
-msgstr "如果啟用了特殊的「預設視窗設定」表格項目，則所有視窗都將套用效果。如果停用，則只有表格中定義的應用程式才會套用效果。如果某個應用程式的「已啟用」選項未勾選，則即使「預設視窗設定」列已啟用，效果也會被停用。"
+msgid ""
+"If the special \"Default window settings\" table entry is enabled then all "
+"windows will have effects applied. If it is disabled then only the "
+"applications defined in the table will have effects applied. If the "
+"\"Enabled\" option is unchecked for a particular application then effects "
+"will be disabled even if the \"Default window settings\" row is enabled."
+msgstr ""
+"如果啟用了特殊的「預設視窗設定」表格項目，則所有視窗都將套用效果。如果停用，"
+"則只有表格中定義的應用程式才會套用效果。如果某個應用程式的「已啟用」選項未勾"
+"選，則即使「預設視窗設定」列已啟用，效果也會被停用。"
 
 #. 6.0->settings-schema.json->component-selector->options
 msgid "Alt-Tab"
@@ -207,37 +264,52 @@ msgid "Show settings for component:"
 msgstr "顯示元件的設定："
 
 #. 6.0->settings-schema.json->about-text->description
+#, fuzzy
 msgid ""
 "\n"
 "<b>Bringing your style into focus</b>\n"
 "Version: ext-version\n"
 "\n"
 "Developed by: Kevin Langman\n"
-"<a href=\"https://github.com/klangman/BlurCinnamon\">Github</a> / <a href=\"https://github.com/klangman/BlurCinnamon/issues/new\">Report an issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/104\">Website</a>\n"
+"<a href=\"https://github.com/klangman/BlurCinnamon\">Github</a> / <a "
+"href=\"https://github.com/klangman/BlurCinnamon/issues/new\">Report an "
+"issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
+"104\">Website</a>\n"
 "\n"
-"The rounded corners and Gaussian effects are based on code by aunetx (Blur-my-shell)\n"
-"<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
+"The rounded corners, Gaussian and Monte Carlo effects\n"
+"are based on code by aunetx (Blur-my-shell)\n"
+"<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
+"href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
 "\n"
-"The Overview effect is partially based on the BlurOverview extension by nailfarmer"
+"The Overview effect is partially based on the BlurOverview extension by "
+"nailfarmer"
 msgstr ""
 "\n"
 "<b>讓您的風格成為焦點</b>\n"
 "版本：ext-version\n"
 "\n"
 "開發者：Kevin Langman\n"
-"<a href=\"https://github.com/klangman/BlurCinnamon\">Github</a> / <a href=\"https://github.com/klangman/BlurCinnamon/issues/new\">回報問題</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/104\">網站</a>\n"
+"<a href=\"https://github.com/klangman/BlurCinnamon\">Github</a> / <a "
+"href=\"https://github.com/klangman/BlurCinnamon/issues/new\">回報問題</a> / "
+"<a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/104\">網站</"
+"a>\n"
 "\n"
 "圓角和高斯效果基於 aunetx (Blur-my-shell) 的程式碼\n"
-"<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
+"<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
+"href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
 "\n"
 "Overview 效果部分基於 nailfarmer 的 BlurOverview 擴充套件"
 
 #. 6.0->settings-schema.json->enable-overview-effects->tooltip
-msgid "Apply effects to the Overview (default: Ctrl+Alt+Down / 'Show all windows` hot corner)"
+msgid ""
+"Apply effects to the Overview (default: Ctrl+Alt+Down / 'Show all windows` "
+"hot corner)"
 msgstr "將效果套用至 Overview（預設：Ctrl+Alt+Down /「顯示所有視窗」熱角）"
 
 #. 6.0->settings-schema.json->enable-expo-effects->tooltip
-msgid "Apply effects to the Expo (default: Ctrl+Alt+Up / 'Show all workspaces` hot corner)"
+msgid ""
+"Apply effects to the Expo (default: Ctrl+Alt+Up / 'Show all workspaces` hot "
+"corner)"
 msgstr "將效果套用至 Expo（預設：Ctrl+Alt+Up /「顯示所有工作區」熱角）"
 
 #. 6.0->settings-schema.json->enable-panels-effects->description
@@ -245,119 +317,254 @@ msgid "Panels  (Please read tooltip)"
 msgstr "面板（請閱讀工具提示）"
 
 #. 6.0->settings-schema.json->enable-panels-effects->tooltip
-msgid "Apply effects to the Panels. This option should work well with most dark desktop themes but light themes could also be made to work with some creative use of the dimming color settings and an appropriate background image. It overrides some themes settings to achieve a (semi-)transparent panel so that the blurred background is visible."
-msgstr "將效果套用至面板。此選項在大多數深色桌面主題下應能正常運作，但淺色主題也可透過巧妙使用調暗色彩設定和合適的背景圖片來達成效果。它會覆寫部分主題設定，以實現（半）透明面板，使模糊背景可見。"
+msgid ""
+"Apply effects to the Panels. This option should work well with most dark "
+"desktop themes but light themes could also be made to work with some "
+"creative use of the dimming color settings and an appropriate background "
+"image. It overrides some themes settings to achieve a (semi-)transparent "
+"panel so that the blurred background is visible."
+msgstr ""
+"將效果套用至面板。此選項在大多數深色桌面主題下應能正常運作，但淺色主題也可透"
+"過巧妙使用調暗色彩設定和合適的背景圖片來達成效果。它會覆寫部分主題設定，以實"
+"現（半）透明面板，使模糊背景可見。"
 
 #. 6.0->settings-schema.json->enable-popup-effects->description
 msgid "Popup Menus  (Please read tooltip)"
 msgstr "彈出式選單（請閱讀工具提示）"
 
 #. 6.0->settings-schema.json->enable-popup-effects->tooltip
-msgid "Apply effects to panel popup menus. This option is intended for the Cinnamon (6.4) and Mint-Y dark desktop themes but might work well with other themes. Light themes are unlikely to give good results but might be made to work with some creative use of the dimming color settings and an appropriate background image. It overrides some theme settings to achieve a (semi-)transparent menu so that the blurred background is visible."
-msgstr "將效果套用至面板彈出式選單。此選項專為 Cinnamon (6.4) 和 Mint-Y 深色桌面主題設計，但可能也適用於其他主題。淺色主題不太可能獲得良好效果，但可透過巧妙使用調暗色彩設定和合適的背景圖片來嘗試。它會覆寫部分主題設定，以實現（半）透明選單，使模糊背景可見。"
+msgid ""
+"Apply effects to panel popup menus. This option is intended for the Cinnamon "
+"(6.4) and Mint-Y dark desktop themes but might work well with other themes. "
+"Light themes are unlikely to give good results but might be made to work "
+"with some creative use of the dimming color settings and an appropriate "
+"background image. It overrides some theme settings to achieve a "
+"(semi-)transparent menu so that the blurred background is visible."
+msgstr ""
+"將效果套用至面板彈出式選單。此選項專為 Cinnamon (6.4) 和 Mint-Y 深色桌面主題"
+"設計，但可能也適用於其他主題。淺色主題不太可能獲得良好效果，但可透過巧妙使用"
+"調暗色彩設定和合適的背景圖片來嘗試。它會覆寫部分主題設定，以實現（半）透明選"
+"單，使模糊背景可見。"
 
 #. 6.0->settings-schema.json->enable-desktop-effects->description
 msgid "Desktop background"
 msgstr "桌面背景"
 
 #. 6.0->settings-schema.json->enable-desktop-effects->tooltip
-msgid "Apply effects to desktop background image. Desktop effects can be applies always or just when a window has the focus."
-msgstr "將效果套用至桌面背景圖片。桌面效果可以始終套用，或僅在視窗取得焦點時套用。"
+msgid ""
+"Apply effects to desktop background image. Desktop effects can be applies "
+"always or just when a window has the focus."
+msgstr ""
+"將效果套用至桌面背景圖片。桌面效果可以始終套用，或僅在視窗取得焦點時套用。"
 
 #. 6.0->settings-schema.json->enable-notification-effects->description
 msgid "Notification popups (Please read tooltip)"
 msgstr "通知彈出視窗（請閱讀工具提示）"
 
 #. 6.0->settings-schema.json->enable-notification-effects->tooltip
-msgid "Apply effects to the notification popups. This option has been tested with the Cinnamon (6.4) and Mint-Y dark desktop themes but might work will with other themes. It overrides some theme settings to achieve a (semi-)transparent Notification popup window so that the blurred background is visible."
-msgstr "將效果套用至通知彈出視窗。此選項已與 Cinnamon (6.4) 和 Mint-Y 深色桌面主題進行過測試，但可能也適用於其他主題。它會覆寫部分主題設定，以實現（半）透明通知彈出視窗，使模糊背景可見。"
+msgid ""
+"Apply effects to the notification popups. This option has been tested with "
+"the Cinnamon (6.4) and Mint-Y dark desktop themes but might work will with "
+"other themes. It overrides some theme settings to achieve a "
+"(semi-)transparent Notification popup window so that the blurred background "
+"is visible."
+msgstr ""
+"將效果套用至通知彈出視窗。此選項已與 Cinnamon (6.4) 和 Mint-Y 深色桌面主題進"
+"行過測試，但可能也適用於其他主題。它會覆寫部分主題設定，以實現（半）透明通知"
+"彈出視窗，使模糊背景可見。"
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->description
-msgid "Alt-Tab application switcher (Coverflow & Timeline only)"
+#, fuzzy
+msgid "Alt-Tab application switcher"
 msgstr "Alt-Tab 應用程式切換器（僅限 Coverflow 和 Timeline）"
 
 #. 6.0->settings-schema.json->enable-appswitcher-effects->tooltip
-msgid "Apply effects to the Alt-Tab application switcher background when setup to use the Coverflow or Timeline styles"
-msgstr "將效果套用至設定為使用 Coverflow 或 Timeline 樣式的 Alt-Tab 應用程式切換器背景"
+#, fuzzy
+msgid "Apply effects to the Alt-Tab application switcher background"
+msgstr ""
+"將效果套用至設定為使用 Coverflow 或 Timeline 樣式的 Alt-Tab 應用程式切換器背"
+"景"
 
 #. 6.0->settings-schema.json->enable-tooltips-effects->description
 msgid "Panel tooltips (Please read tooltip)"
 msgstr "面板工具提示（請閱讀工具提示）"
 
 #. 6.0->settings-schema.json->enable-tooltips-effects->tooltip
-msgid "Apply effects to the panel tooltip backgrounds. It overrides some theme settings to achieve a (semi-)transparent tooltip so that the blurred background is visible."
-msgstr "將效果套用至面板工具提示背景。它會覆寫部分主題設定，以實現（半）透明工具提示，使模糊背景可見。"
+msgid ""
+"Apply effects to the panel tooltip backgrounds. It overrides some theme "
+"settings to achieve a (semi-)transparent tooltip so that the blurred "
+"background is visible."
+msgstr ""
+"將效果套用至面板工具提示背景。它會覆寫部分主題設定，以實現（半）透明工具提"
+"示，使模糊背景可見。"
 
 #. 6.0->settings-schema.json->enable-window-effects->description
 msgid "Application windows (Please read tooltip)"
 msgstr "應用程式視窗（請閱讀工具提示）"
 
 #. 6.0->settings-schema.json->enable-window-effects->tooltip
-msgid "Allow application window background effects by adding an effect actor below all existing graphical elements of affected windows. This means the effects will NOT be visible unless the application is setup to be transparent or the \"Opacity\" setting for the window is less than 100%. The table under the \"Windows\" component settings is used to determine which applications (if any) will have effects applied to its windows, enabling this option alone will not add effects to any windows."
-msgstr "允許透過在受影響視窗的所有現有圖形元素下方新增效果角色來套用應用程式視窗背景效果。這表示除非應用程式設為透明，或視窗的「不透明度」設定低於 100%，否則效果將不可見。「視窗」元件設定下的表格用於判斷哪些應用程式（如果有的話）的視窗將套用效果，僅啟用此選項不會為任何視窗新增效果。"
+msgid ""
+"Allow application window background effects by adding an effect actor below "
+"all existing graphical elements of affected windows. This means the effects "
+"will NOT be visible unless the application is setup to be transparent or the "
+"\"Opacity\" setting for the window is less than 100%. The table under the "
+"\"Windows\" component settings is used to determine which applications (if "
+"any) will have effects applied to its windows, enabling this option alone "
+"will not add effects to any windows."
+msgstr ""
+"允許透過在受影響視窗的所有現有圖形元素下方新增效果角色來套用應用程式視窗背景"
+"效果。這表示除非應用程式設為透明，或視窗的「不透明度」設定低於 100%，否則效果"
+"將不可見。「視窗」元件設定下的表格用於判斷哪些應用程式（如果有的話）的視窗將"
+"套用效果，僅啟用此選項不會為任何視窗新增效果。"
 
 #. 6.0->settings-schema.json->enable-desklet-effects->tooltip
-msgid "Apply effects to Desklet backgrounds. Desklets must be setup to be transparent in order for the Blur Cinnamon effects to be visible."
-msgstr "將效果套用至 Desklet 背景。Desklet 必須設為透明，Blur Cinnamon 效果才能顯示。"
+msgid ""
+"Apply effects to Desklet backgrounds. Desklets must be setup to be "
+"transparent in order for the Blur Cinnamon effects to be visible."
+msgstr ""
+"將效果套用至 Desklet 背景。Desklet 必須設為透明，Blur Cinnamon 效果才能顯示。"
 
 #. 6.0->settings-schema.json->focused-window-backlight->description
 msgid "Focused window backlight effect"
 msgstr "聚焦視窗背光效果"
 
 #. 6.0->settings-schema.json->focused-window-backlight->tooltip
-msgid "Apply a background image based backlight effect to the currently focused window. The effect spills over the focused windows borders making the window appear to glow around the edges. If the focused window is transparent, this effect will also show a blurred background image behind the window."
-msgstr "對目前聚焦的視窗套用基於背景圖片的背光效果。該效果會溢出聚焦視窗的邊框，使視窗邊緣呈現發光效果。如果聚焦視窗為透明，此效果還會在視窗後方顯示模糊的背景圖片。"
+msgid ""
+"Apply a background image based backlight effect to the currently focused "
+"window. The effect spills over the focused windows borders making the window "
+"appear to glow around the edges. If the focused window is transparent, this "
+"effect will also show a blurred background image behind the window."
+msgstr ""
+"對目前聚焦的視窗套用基於背景圖片的背光效果。該效果會溢出聚焦視窗的邊框，使視"
+"窗邊緣呈現發光效果。如果聚焦視窗為透明，此效果還會在視窗後方顯示模糊的背景圖"
+"片。"
 
 #. 6.0->settings-schema.json->allow-transparent-color-panels->description
 msgid "Override some of the panels theme settings (recommended)"
 msgstr "覆寫部分面板主題設定（建議）"
 
 #. 6.0->settings-schema.json->allow-transparent-color-panels->tooltip
-msgid "Allow this extension to modify the panels transparency and background color settings. If this is disabled the extension will only apply a blur background under the panels. This setting should only be disabled when the theme already uses transparent panels and you want the themes setting to apply."
-msgstr "允許此擴充套件修改面板的透明度和背景色彩設定。如果停用，擴充套件只會在面板下方套用模糊背景。僅當主題已使用透明面板且您希望套用主題設定時，才應停用此設定。"
+msgid ""
+"Allow this extension to modify the panels transparency and background color "
+"settings. If this is disabled the extension will only apply a blur "
+"background under the panels. This setting should only be disabled when the "
+"theme already uses transparent panels and you want the themes setting to "
+"apply."
+msgstr ""
+"允許此擴充套件修改面板的透明度和背景色彩設定。如果停用，擴充套件只會在面板下"
+"方套用模糊背景。僅當主題已使用透明面板且您希望套用主題設定時，才應停用此設"
+"定。"
 
 #. 6.0->settings-schema.json->allow-transparent-color-popup->description
 msgid "Override some of the popup menu theme settings (recommended)"
 msgstr "覆寫部分彈出式選單主題設定（建議）"
 
 #. 6.0->settings-schema.json->allow-transparent-color-popup->tooltip
-msgid "Allow this extension to modify the popup Menu transparency and background color settings. If this is disabled the extension will only apply a blur background under the popup menus. This setting should only be disabled when the theme already uses transparent popup menus and you want the themes setting to apply."
-msgstr "允許此擴充套件修改彈出式選單的透明度和背景色彩設定。如果停用，擴充套件只會在彈出式選單下方套用模糊背景。僅當主題已使用透明彈出式選單且您希望套用主題設定時，才應停用此設定。"
+msgid ""
+"Allow this extension to modify the popup Menu transparency and background "
+"color settings. If this is disabled the extension will only apply a blur "
+"background under the popup menus. This setting should only be disabled when "
+"the theme already uses transparent popup menus and you want the themes "
+"setting to apply."
+msgstr ""
+"允許此擴充套件修改彈出式選單的透明度和背景色彩設定。如果停用，擴充套件只會在"
+"彈出式選單下方套用模糊背景。僅當主題已使用透明彈出式選單且您希望套用主題設定"
+"時，才應停用此設定。"
+
+#. 6.0->settings-schema.json->allow-transparent-color-
+#. notifications->description
+#, fuzzy
+msgid "Override some of the notification theme settings (recommended)"
+msgstr "覆寫部分面板主題設定（建議）"
+
+#. 6.0->settings-schema.json->allow-transparent-color-notifications->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the notification transparency and background "
+"color settings. If this is disabled the extension will only apply a blur "
+"background under the notifications. This setting should only be disabled "
+"when the theme already uses transparent notifications and you want the "
+"themes setting to apply."
+msgstr ""
+"允許此擴充套件修改面板的透明度和背景色彩設定。如果停用，擴充套件只會在面板下"
+"方套用模糊背景。僅當主題已使用透明面板且您希望套用主題設定時，才應停用此設"
+"定。"
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->description
+#, fuzzy
+msgid "Override some of the tooltip theme settings (recommended)"
+msgstr "覆寫部分面板主題設定（建議）"
+
+#. 6.0->settings-schema.json->allow-transparent-color-tooltips->tooltip
+#, fuzzy
+msgid ""
+"Allow this extension to modify the tooltip transparency and background color "
+"settings. If this is disabled the extension will only apply a blur "
+"background under the tooltips. This setting should only be disabled when the "
+"theme already uses transparent tooltips and you want the themes setting to "
+"apply."
+msgstr ""
+"允許此擴充套件修改面板的透明度和背景色彩設定。如果停用，擴充套件只會在面板下"
+"方套用模糊背景。僅當主題已使用透明面板且您希望套用主題設定時，才應停用此設"
+"定。"
 
 #. 6.0->settings-schema.json->enable-overview-override->description
-msgid "Use unique effect settings for the Overview"
+#, fuzzy
+msgid "Override the generic effect settings for the Overview"
 msgstr "為 Overview 使用專屬效果設定"
 
+#. 6.0->settings-schema.json->enable-overview-override->tooltip
+#. 6.0->settings-schema.json->enable-expo-override->tooltip
+#. 6.0->settings-schema.json->enable-panels-override->tooltip
+#. 6.0->settings-schema.json->enable-popup-override->tooltip
+#. 6.0->settings-schema.json->enable-desktop-override->tooltip
+#. 6.0->settings-schema.json->enable-notification-override->tooltip
+#. 6.0->settings-schema.json->enable-appswitcher-override->tooltip
+#. 6.0->settings-schema.json->enable-tooltips-override->tooltip
+#. 6.0->settings-schema.json->enable-desklets-override->tooltip
+msgid ""
+"Override the settings found on the \"Generic effect settings\" tab with "
+"unique settings for this cinnamon component."
+msgstr ""
+
 #. 6.0->settings-schema.json->enable-expo-override->description
-msgid "Use unique effect settings for the Expo"
+#, fuzzy
+msgid "Override the generic effect settings for the Expo"
 msgstr "為 Expo 使用專屬效果設定"
 
 #. 6.0->settings-schema.json->enable-panels-override->description
-msgid "Use unique effect settings for the Panels"
+#, fuzzy
+msgid "Override the generic effect settings for the Panels"
 msgstr "為面板使用專屬效果設定"
 
 #. 6.0->settings-schema.json->enable-popup-override->description
-msgid "Use unique effect settings for the popup menus"
+#, fuzzy
+msgid "Override the generic effect settings for popup menus"
 msgstr "為彈出式選單使用專屬效果設定"
 
 #. 6.0->settings-schema.json->enable-desktop-override->description
-msgid "Use unique effect settings for the desktop background"
+#, fuzzy
+msgid "Override the generic effect settings for the desktop background"
 msgstr "為桌面背景使用專屬效果設定"
 
 #. 6.0->settings-schema.json->enable-notification-override->description
-msgid "Use unique effect settings for the notification popups"
+#, fuzzy
+msgid "Override the generic effect settings for notification popups"
 msgstr "為通知彈出視窗使用專屬效果設定"
 
 #. 6.0->settings-schema.json->enable-appswitcher-override->description
-msgid "Use unique effect settings for the Alt-Tab app switcher"
+#, fuzzy
+msgid "Override the generic effect settings for the Alt-Tab app switcher"
 msgstr "為 Alt-Tab 應用程式切換器使用專屬效果設定"
 
 #. 6.0->settings-schema.json->enable-tooltips-override->description
-msgid "Use unique effect settings for the panel tooltips"
+#, fuzzy
+msgid "Override the generic effect settings for panel tooltips"
 msgstr "為面板工具提示使用專屬效果設定"
 
 #. 6.0->settings-schema.json->enable-desklets-override->description
-msgid "Use unique effect settings for the Desklets"
+#, fuzzy
+msgid "Override the generic effect settings for Desklets"
 msgstr "為 Desklet 使用專屬效果設定"
 
 #. 6.0->settings-schema.json->enable-desklets-unique-settings->description
@@ -365,8 +572,12 @@ msgid "Enable advanced options to apply unique settings for each Desklet"
 msgstr "啟用進階選項以對每個 Desklet 套用專屬設定"
 
 #. 6.0->settings-schema.json->enable-desklets-unique-settings->tooltip
-msgid "With this option enabled each Desklet can use different settings or you can disable effects completely for some Desklets."
-msgstr "啟用此選項後，每個 Desklet 可使用不同的設定，或者您可以完全停用某些 Desklet 的效果。"
+msgid ""
+"With this option enabled each Desklet can use different settings or you can "
+"disable effects completely for some Desklets."
+msgstr ""
+"啟用此選項後，每個 Desklet 可使用不同的設定，或者您可以完全停用某些 Desklet "
+"的效果。"
 
 #. 6.0->settings-schema.json->window-settings-button->description
 msgid "Open Alt-Tab Cinnamon settings"
@@ -377,8 +588,11 @@ msgid "Enable advanced options to apply unique settings for each panel"
 msgstr "啟用進階選項以對每個面板套用專屬設定"
 
 #. 6.0->settings-schema.json->enable-panel-unique-settings->tooltip
-msgid "With this option enabled each panel can use different settings or you can disable effects completely for some panels."
-msgstr "啟用此選項後，每個面板可使用不同的設定，或者您可以完全停用某些面板的效果。"
+msgid ""
+"With this option enabled each panel can use different settings or you can "
+"disable effects completely for some panels."
+msgstr ""
+"啟用此選項後，每個面板可使用不同的設定，或者您可以完全停用某些面板的效果。"
 
 #. 6.0->settings-schema.json->panel-unique-settings->description
 msgid "Panel specific settings"
@@ -438,24 +652,49 @@ msgid "Custom CSS"
 msgstr "自訂 CSS"
 
 #. 6.0->settings-schema.json->panel-unique-settings->tooltip
-msgid "Defines the effects applied to different panels. If a panel does not meet the criteria of any enabled entry in this list, it will have no effects applied. The settings of the first entry in this list that can apply to a given panel will take effect. The \"Custom\" check box determines if the generic effect settings are uses or this tables custom settings. The color field is in the rgb(#,#,#) syntax and black will be used when a color is not provided or is in an incorrect syntax"
-msgstr "定義套用至不同面板的效果。如果面板不符合此清單中任何已啟用項目的條件，則不會套用任何效果。此清單中第一個可套用至指定面板的項目的設定將生效。「自訂」核取方塊決定是使用通用效果設定還是此表格的自訂設定。色彩欄位使用 rgb(#,#,#) 語法，未提供色彩或語法不正確時將使用黑色。"
+msgid ""
+"Defines the effects applied to different panels. If a panel does not meet "
+"the criteria of any enabled entry in this list, it will have no effects "
+"applied. The settings of the first entry in this list that can apply to a "
+"given panel will take effect. The \"Custom\" check box determines if the "
+"generic effect settings are uses or this tables custom settings. The color "
+"field is in the rgb(#,#,#) syntax and black will be used when a color is not "
+"provided or is in an incorrect syntax"
+msgstr ""
+"定義套用至不同面板的效果。如果面板不符合此清單中任何已啟用項目的條件，則不會"
+"套用任何效果。此清單中第一個可套用至指定面板的項目的設定將生效。「自訂」核取"
+"方塊決定是使用通用效果設定還是此表格的自訂設定。色彩欄位使用 rgb(#,#,#) 語"
+"法，未提供色彩或語法不正確時將使用黑色。"
 
 #. 6.0->settings-schema.json->no-panel-effects-maximized->description
 msgid "Restore theme settings when a window is maximized"
 msgstr "當視窗最大化時還原主題設定"
 
 #. 6.0->settings-schema.json->no-panel-effects-maximized->tooltip
-msgid "Restore the themes panel settings when any window is maximized on the same monitor as the panel. For most themes this will restore a solid panel background when a window is maximized. Note: This does not remove the blurring, so if your theme uses a transparent panel then this setting may have no effect."
-msgstr "當任何視窗在與面板相同的顯示器上最大化時，還原主題的面板設定。對於大多數主題，這將在視窗最大化時還原為純色面板背景。注意：這不會移除模糊效果，因此如果您的主題使用透明面板，則此設定可能無效。"
+msgid ""
+"Restore the themes panel settings when any window is maximized on the same "
+"monitor as the panel. For most themes this will restore a solid panel "
+"background when a window is maximized. Note: This does not remove the "
+"blurring, so if your theme uses a transparent panel then this setting may "
+"have no effect."
+msgstr ""
+"當任何視窗在與面板相同的顯示器上最大化時，還原主題的面板設定。對於大多數主"
+"題，這將在視窗最大化時還原為純色面板背景。注意：這不會移除模糊效果，因此如果"
+"您的主題使用透明面板，則此設定可能無效。"
 
 #. 6.0->settings-schema.json->hover-brighten-panels->description
 msgid "Brighten panel when mouse is hovering a panel"
 msgstr "當滑鼠懸停在面板上時提高亮度"
 
 #. 6.0->settings-schema.json->hover-brighten-panels->tooltip
-msgid "While the mouse is hovering over a panel, set the panels dimming to 0 and the saturation to 100 so that the panel appears brighter. This setting is only effective when either dimming is greater than 0 or saturation is less than 100."
-msgstr "當滑鼠懸停在面板上時，將面板的調暗設為 0，飽和度設為 100，使面板看起來更亮。此設定僅在調暗大於 0 或飽和度低於 100 時有效。"
+msgid ""
+"While the mouse is hovering over a panel, set the panels dimming to 0 and "
+"the saturation to 100 so that the panel appears brighter. This setting is "
+"only effective when either dimming is greater than 0 or saturation is less "
+"than 100."
+msgstr ""
+"當滑鼠懸停在面板上時，將面板的調暗設為 0，飽和度設為 100，使面板看起來更亮。"
+"此設定僅在調暗大於 0 或飽和度低於 100 時有效。"
 
 #. 6.0->settings-schema.json->opacity->description
 #. 6.0->settings-schema.json->overview-opacity->description
@@ -491,8 +730,13 @@ msgstr "調暗疊加色彩"
 #. 6.0->settings-schema.json->appswitcher-blendColor->tooltip
 #. 6.0->settings-schema.json->tooltips-blendColor->tooltip
 #. 6.0->settings-schema.json->desklets-blendColor->tooltip
-msgid "Defines the color that is blended into the background based on the dimming control above. Use black for a normal dimming effect or some other color for a color blend effect"
-msgstr "定義根據上述調暗控制項混合到背景中的色彩。使用黑色可獲得一般的調暗效果，使用其他色彩可獲得色彩混合效果。"
+msgid ""
+"Defines the color that is blended into the background based on the dimming "
+"control above. Use black for a normal dimming effect or some other color for "
+"a color blend effect"
+msgstr ""
+"定義根據上述調暗控制項混合到背景中的色彩。使用黑色可獲得一般的調暗效果，使用"
+"其他色彩可獲得色彩混合效果。"
 
 #. 6.0->settings-schema.json->blurType->options
 msgid "None / Transparent to wallpaper"
@@ -502,7 +746,9 @@ msgstr "無 / 透明至桌布"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple static blur"
 msgstr "簡單靜態模糊"
 
@@ -510,12 +756,30 @@ msgstr "簡單靜態模糊"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian static blur"
 msgstr "高斯靜態模糊"
 
 #. 6.0->settings-schema.json->blurType->options
 msgid "Gaussian dynamic blur (if applicable)"
+msgstr "高斯動態模糊（如適用）"
+
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo static blur"
+msgstr "簡單靜態模糊"
+
+#. 6.0->settings-schema.json->blurType->options
+#, fuzzy
+msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr "高斯動態模糊（如適用）"
 
 #. 6.0->settings-schema.json->blurType->description
@@ -531,7 +795,6 @@ msgstr "模糊效果類型"
 #. 6.0->settings-schema.json->overview-blurType->tooltip
 #. 6.0->settings-schema.json->expo-blurType->tooltip
 #. 6.0->settings-schema.json->desktop-blurType->tooltip
-#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "要用哪種模糊演算法來模糊背景"
@@ -546,7 +809,8 @@ msgstr "要用哪種模糊演算法來模糊背景"
 #. 6.0->settings-schema.json->appswitcher-radius->description
 #. 6.0->settings-schema.json->tooltips-radius->description
 #. 6.0->settings-schema.json->desklets-radius->description
-msgid "Gaussian blur intensity"
+#, fuzzy
+msgid "Blur intensity"
 msgstr "高斯模糊強度"
 
 #. 6.0->settings-schema.json->radius->tooltip
@@ -559,7 +823,9 @@ msgstr "高斯模糊強度"
 #. 6.0->settings-schema.json->appswitcher-radius->tooltip
 #. 6.0->settings-schema.json->tooltips-radius->tooltip
 #. 6.0->settings-schema.json->desklets-radius->tooltip
-msgid "Adjusts the intensity of the blur effect by changing the radius use by the effect."
+msgid ""
+"Adjusts the intensity of the blur effect by changing the radius use by the "
+"effect."
 msgstr "透過變更效果使用的半徑來調整模糊效果的強度。"
 
 #. 6.0->settings-schema.json->saturation->description
@@ -584,8 +850,53 @@ msgstr "背景色彩飽和度"
 #. 6.0->settings-schema.json->appswitcher-saturation->tooltip
 #. 6.0->settings-schema.json->tooltips-saturation->tooltip
 #. 6.0->settings-schema.json->desklets-saturation->tooltip
-msgid "Adjusts the color saturation of the background image from gray-scale to full color."
+msgid ""
+"Adjusts the color saturation of the background image from gray-scale to full "
+"color."
 msgstr "調整背景圖片的色彩飽和度，從灰階到全彩。"
+
+#. 6.0->settings-schema.json->monte-carlo-iterations->description
+#, fuzzy
+msgid "Iterations"
+msgstr "飽和度"
+
+#. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
+msgid ""
+"Increasing number of iterations will make the blur appear smoother at the "
+"cost of some CPU power."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
+msgid "Use base pixel"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-use-base-pixel->tooltip
+msgid ""
+"Whether or not the original pixel is counted for the blur. If it is, the "
+"image will be more legible."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->description
+msgid "Prefer closer pixels"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-prefer-closer-pixels->tooltip
+msgid ""
+"Whether or not the pixels that are closer to the original pixel will have "
+"more weight."
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->description
+msgid ""
+"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgstr ""
+
+#. 6.0->settings-schema.json->monte-carlo-label->tooltip
+msgid ""
+"The above Monte Carlo settings are used globally for all components that are "
+"configured to use the Monte Carlo blur algorithm, these settings can not be "
+"configured separately for each component"
+msgstr ""
 
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
@@ -598,18 +909,20 @@ msgstr "無"
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Simple"
 msgstr "簡單"
 
 #. 6.0->settings-schema.json->overview-blurType->options
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
-#. 6.0->settings-schema.json->appswitcher-blurType->options
-#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian"
 msgstr "高斯"
+
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Monte Carlo"
+msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
@@ -628,8 +941,20 @@ msgstr "透明至桌布"
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
 #. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
 msgid "Gaussian dynamic blur"
+msgstr "高斯動態模糊"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#, fuzzy
+msgid "Monte Carlo dynamic blur"
 msgstr "高斯動態模糊"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -663,8 +988,13 @@ msgid "Additional popup menu accent elements dimming (%)"
 msgstr "額外的彈出式選單強調元素調暗（%）"
 
 #. 6.0->settings-schema.json->popup-accent-opacity->tooltip
-msgid "Defines the additional dimming applied to the popup menu accent elements (i.e. the main menu favorites box and entry boxes) which allow these elements to stand out from the other popup menu areas"
-msgstr "定義套用至彈出式選單強調元素（即主選單的常用項目框和輸入框）的額外調暗程度，使這些元素能從其他彈出式選單區域中凸顯出來"
+msgid ""
+"Defines the additional dimming applied to the popup menu accent elements "
+"(i.e. the main menu favorites box and entry boxes) which allow these "
+"elements to stand out from the other popup menu areas"
+msgstr ""
+"定義套用至彈出式選單強調元素（即主選單的常用項目框和輸入框）的額外調暗程度，"
+"使這些元素能從其他彈出式選單區域中凸顯出來"
 
 #. 6.0->settings-schema.json->popup-saturation->description
 msgid "Background image color saturation"
@@ -675,7 +1005,9 @@ msgid "Only apply effect settings if the desktop is not in focus"
 msgstr "僅在桌面未聚焦時套用效果設定"
 
 #. 6.0->settings-schema.json->desktop-without-focus->tooltip
-msgid "When enabled, the desktop background image effects will only apply when the desktop is not in focus"
+msgid ""
+"When enabled, the desktop background image effects will only apply when the "
+"desktop is not in focus"
 msgstr "啟用後，桌面背景圖片效果僅在桌面未聚焦時套用"
 
 #. 6.0->settings-schema.json->desktop-with-focus->description
@@ -683,8 +1015,13 @@ msgid "Apply the generic effect settings when the desktop is in focus"
 msgstr "在桌面聚焦時套用通用效果設定"
 
 #. 6.0->settings-schema.json->desktop-with-focus->tooltip
-msgid "When enabled, the generic effect settings (on the \"Generic effect settings\" tab) will apply to the desktop background image when the desktop is in focus"
-msgstr "啟用後，通用效果設定（在「通用效果設定」標籤上）將在桌面聚焦時套用至桌面背景圖片"
+msgid ""
+"When enabled, the generic effect settings (on the \"Generic effect "
+"settings\" tab) will apply to the desktop background image when the desktop "
+"is in focus"
+msgstr ""
+"啟用後，通用效果設定（在「通用效果設定」標籤上）將在桌面聚焦時套用至桌面背景"
+"圖片"
 
 #. 6.0->settings-schema.json->desktop-opacity->description
 #. 6.0->settings-schema.json->desklets-opacity->description
@@ -696,12 +1033,51 @@ msgid "Send a test notification"
 msgstr "發送測試通知"
 
 #. 6.0->settings-schema.json->notification-test-button->tooltip
-msgid "This button will cause a notification message to appear so you can see how your notification setting behave."
+msgid ""
+"This button will cause a notification message to appear so you can see how "
+"your notification setting behave."
 msgstr "此按鈕將使通知訊息出現，以便您查看通知設定的行為表現。"
 
-#. 6.0->settings-schema.json->appswitcher-info->description
-msgid "Note: Alt-Tab effects only apply to the Coverflow and Timeline 3D Alt-Tab configurations"
-msgstr "注意：Alt-Tab 效果僅適用於 Coverflow 和 Timeline 3D Alt-Tab 設定"
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->description
+msgid "Hide panels while using the Coverflow/Timeline 3D Alt-Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-disable-3d-panels->tooltip
+msgid ""
+"Make the panels invisible when using the Coverflow or the Timeline 3D Alt-"
+"Tab switchers"
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->description
+#, fuzzy
+msgid "Apply effects to the standard Alt-Tab switcher"
+msgstr "為 Alt-Tab 應用程式切換器使用專屬效果設定"
+
+#. 6.0->settings-schema.json->appswitcher-allow-classic->tooltip
+msgid ""
+"Allow applying effects to the standard Alt-Tab switcher. Only the switcher "
+"options without \"previews\" are supported. The standard Alt-Tab switcher "
+"can use static or dynamic blur, but dynamic is recommended."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->description
+#, fuzzy
+msgid "Apply effects to the 3D Alt-Tab switchers"
+msgstr "為 Alt-Tab 應用程式切換器使用專屬效果設定"
+
+#. 6.0->settings-schema.json->appswitcher-allow-3d->tooltip
+msgid ""
+"Allow applying effects to the Coverflow and Timeline 3D Alt-Tab switchers. "
+"The 3D Alt-Tab switchers will use static blurring even when dynamic blurring "
+"is selected since they don't benifit from dynamic blurring."
+msgstr ""
+
+#. 6.0->settings-schema.json->appswitcher-blurType->tooltip
+msgid ""
+"What type of blur algorithm should be used to blur the background. A dynamic "
+"blur type can be used for the standard switcher but static blurring is "
+"always used for the 3D switchers as they do not benefit from dynamic effects."
+msgstr ""
 
 #. 6.0->settings-schema.json->windows-inclusion-list->description
 msgid "Application window inclusion list"
@@ -728,15 +1104,24 @@ msgid "Rounded Bottom"
 msgstr "下方圓角"
 
 #. 6.0->settings-schema.json->windows-inclusion-list->tooltip
-msgid "This table controls which application windows will have effects applied and the effect settings. When \"Custom\" is enabled the setting defined by this table will apply, otherwise the \"Generic effect settings\" will apply. The \"Application\" field can be a WM_CLASS or a desktop file name."
-msgstr "此表格控制哪些應用程式視窗將套用效果及效果設定。啟用「自訂」時，將套用此表格定義的設定，否則將套用「通用效果設定」。「應用程式」欄位可以是 WM_CLASS 或桌面檔案名稱。"
+msgid ""
+"This table controls which application windows will have effects applied and "
+"the effect settings. When \"Custom\" is enabled the setting defined by this "
+"table will apply, otherwise the \"Generic effect settings\" will apply. The "
+"\"Application\" field can be a WM_CLASS or a desktop file name."
+msgstr ""
+"此表格控制哪些應用程式視窗將套用效果及效果設定。啟用「自訂」時，將套用此表格"
+"定義的設定，否則將套用「通用效果設定」。「應用程式」欄位可以是 WM_CLASS 或桌"
+"面檔案名稱。"
 
 #. 6.0->settings-schema.json->windows-add-button->description
 msgid "Add entry for the application of the most recently focused window"
 msgstr "為最近聚焦的視窗新增項目"
 
 #. 6.0->settings-schema.json->windows-add-button->tooltip
-msgid "Focus a window you want to enable window effects on then return here and press this button."
+msgid ""
+"Focus a window you want to enable window effects on then return here and "
+"press this button."
 msgstr "聚焦您想要啟用視窗效果的視窗，然後返回此處並按下此按鈕。"
 
 #. 6.0->settings-schema.json->windows-compiz-mitigation->description
@@ -744,16 +1129,43 @@ msgid "Disable \"Compiz\" effects for windows with Blur Cinnamon effects"
 msgstr "為套用 Blur Cinnamon 效果的視窗停用「Compiz」效果"
 
 #. 6.0->settings-schema.json->windows-compiz-mitigation->tooltip
-msgid "When enabled, the window moving effect created by the \"Compiz windows effect\" extension will be disabled for windows with Blur Cinnamon effects applied. This option will have no effect unless the \"Compiz window effect\" extension is installed and active."
-msgstr "啟用後，由「Compiz 視窗效果」擴充套件產生的視窗移動效果將對套用 Blur Cinnamon 效果的視窗停用。除非已安裝並啟用「Compiz 視窗效果」擴充套件，否則此選項無效。"
+msgid ""
+"When enabled, the window moving effect created by the \"Compiz windows "
+"effect\" extension will be disabled for windows with Blur Cinnamon effects "
+"applied. This option will have no effect unless the \"Compiz window effect\" "
+"extension is installed and active."
+msgstr ""
+"啟用後，由「Compiz 視窗效果」擴充套件產生的視窗移動效果將對套用 Blur "
+"Cinnamon 效果的視窗停用。除非已安裝並啟用「Compiz 視窗效果」擴充套件，否則此"
+"選項無效。"
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->description
+msgid "Use artifact mitigation techniques"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-atrifact-mitigation->tooltip
+msgid ""
+"When enabled, steps will be taken to eliminate background graphical "
+"artifacts for windows that use dynamic blur effects. The mitigation steps "
+"will have some minor persistent CPU costs when a dynamic blurred window is "
+"on top of two or more other windows. This option is recommended unless you "
+"are using video wallpaper like Hidamari"
+msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description
 msgid "Automatically enable effects for newly added Desklets"
 msgstr "自動為新新增的 Desklet 啟用效果"
 
 #. 6.0->settings-schema.json->desklets-auto->tooltip
-msgid "When enabled, new Desklets added to the desktop will automatically have Blur Cinnamon effects applied. When disabled, Desklets will only have effects applied when manually enabled in the table below. By default the settings applied to new Desklets will be the generic effect settings."
-msgstr "啟用後，新增至桌面的 Desklet 將自動套用 Blur Cinnamon 效果。停用後，Desklet 僅在下方表格中手動啟用時才會套用效果。預設情況下，套用至新 Desklet 的設定將是通用效果設定。"
+msgid ""
+"When enabled, new Desklets added to the desktop will automatically have Blur "
+"Cinnamon effects applied. When disabled, Desklets will only have effects "
+"applied when manually enabled in the table below. By default the settings "
+"applied to new Desklets will be the generic effect settings."
+msgstr ""
+"啟用後，新增至桌面的 Desklet 將自動套用 Blur Cinnamon 效果。停用後，Desklet "
+"僅在下方表格中手動啟用時才會套用效果。預設情況下，套用至新 Desklet 的設定將是"
+"通用效果設定。"
 
 #. 6.0->settings-schema.json->desklets-list->description
 msgid "Active Desklet list"
@@ -772,5 +1184,12 @@ msgid "Blur"
 msgstr "模糊"
 
 #. 6.0->settings-schema.json->desklets-list->tooltip
-msgid "The \"Enabled\" check box controls which Desklets will have effects applied. The \"Custom\" check box controls if a Desklet will use the generic effect settings or the custom settings defined in this table. The custom settings can be modified by double clicking on a table row."
-msgstr "「已啟用」核取方塊控制哪些 Desklet 將套用效果。「自訂」核取方塊控制 Desklet 將使用通用效果設定還是此表格中定義的自訂設定。自訂設定可透過雙擊表格列來修改。"
+msgid ""
+"The \"Enabled\" check box controls which Desklets will have effects applied. "
+"The \"Custom\" check box controls if a Desklet will use the generic effect "
+"settings or the custom settings defined in this table. The custom settings "
+"can be modified by double clicking on a table row."
+msgstr ""
+"「已啟用」核取方塊控制哪些 Desklet 將套用效果。「自訂」核取方塊控制 Desklet "
+"將使用通用效果設定還是此表格中定義的自訂設定。自訂設定可透過雙擊表格列來修"
+"改。"


### PR DESCRIPTION
1. Added the ability to apply effects to the Classic (default) Alt-Tab switcher
2. Added the Monte Carlo Blur alorithum from Blur-my-shell as a new blur option (static and dynamic)
3. Added option to hide panels when the 3d Alt-Tab switchers are used (default enabled)
4. Implemented atrifact mitigation techniques to eliminate artifacts with Dynamic Blur for Application Windows (also removed the "experimental" label for Dynamic Application Window effects).
5. Allow Desklets to use Dynamic Blurring so that the Super+S (show desklets) option can blur background windows under desklets
6. Added option to allow theme setting to remain for Notifications and Tooltips
7. Improved how window stacking is tracked for dynamic blurring (fixes issues with showing incorrect background windows)
8. Fixed a number of issues to allow proper support for video wallpapers (i.e. Hidamari)
9. Fixes some most cases where Application Window Dynamic blurring would cause issue with moving/resizing windows
10. Fix some issues that occur after changing the UI scale and/or screen resolution
11. Better window tracking for the focused window backlight effect
12. A bunch of other fixes that I didn't remember to document