### PR TITLE
centered-cinnamon-dock: fix dock becoming invisible after a workspace switch

### DIFF
--- a/centered-cinnamon-dock@mostlynick3/files/centered-cinnamon-dock@mostlynick3/6.4/extension.js
+++ b/centered-cinnamon-dock@mostlynick3/files/centered-cinnamon-dock@mostlynick3/6.4/extension.js
@@ -1185,8 +1185,14 @@ function initializePanels() {
                 state.isShowing = false;
                 panel.actor.opacity = 0;
                 panel.actor.show();
-                
+
                 checkAndApplyStyle(panel, true);
+                // Restore visibility after a workspace switch. The handler blanks the
+                // panel (opacity=0) to recompute geometry, but applyStyle() re-saves the
+                // current (0) opacity and nothing else restores it on the autoHide:false /
+                // no-fullscreen path, leaving the dock invisible. The 100ms timeout below
+                // re-hides it when hideOnFullscreen/autoHide actually require it.
+                panel.actor.opacity = 255;
             } catch(e) {}
         });
         


### PR DESCRIPTION
### Problem

With `autoHide: false` and `hideOnFullscreen: true` (the default mode), the dock panel becomes **invisible after any workspace switch** (keyboard `Ctrl+Alt+←/→` or a 3-finger touchpad swipe). The actor is still `show()`n but left at `opacity = 0`, so the dock vanishes until something else (closing a fullscreen window, or a hover that calls `showPanel`) happens to restore it.

Reproduced on Cinnamon 6.6.7 (X11).

### Root cause

In the `workspace-switched` handler (`6.4/extension.js`, ~line 1186) the panel is blanked to recompute geometry, but nothing restores it on the `autoHide:false` / no-fullscreen path:

```js
state.isHidden = false;
panel.actor.opacity = 0;          // blank to recompute
panel.actor.show();
checkAndApplyStyle(panel, true);  // -> applyStyle() reads back opacity 0 and re-applies it
```

1. `applyStyle()` computes `savedOpacity = state.isHidden ? 0 : panel.actor.opacity`. Since opacity was just set to `0` and `isHidden` is `false`, `savedOpacity` is **0**, and it re-applies that 0 — preserving the invisible state.
2. The follow-up `Mainloop.timeout_add(100, …)` only ever *hides* (`autoHide`/`hideOnFullscreen`); with `autoHide:false` and no fullscreen window it does nothing.
3. `startSizeMonitoring` only corrects opacity when it is strictly between 0 and 255 (`opacity > 0 && opacity < 255`), so exactly-0 is never recovered.

### Fix

Restore opacity after the style recompute. The existing 100ms timeout still re-hides correctly when `hideOnFullscreen`/`autoHide` require it, so fullscreen-hide behavior is unchanged.

Verified on Cinnamon 6.6.7: the dock now stays visible across workspace switches, and `hideOnFullscreen` still hides it when a fullscreen window is focused.

I kept this to the minimal code change. The `metadata.json` version is currently `1.2` while the CHANGELOG already lists a `1.3` entry, so I left the version bump / changelog to you to avoid muddying that — happy to add it if you prefer.

cc @mostlynick3 (original author)