### PR TITLE
centered-cinnamon-dock: hide actor when hiding dock and no active menus, fix dock occupying screen area after hiding

### DIFF
--- a/centered-cinnamon-dock@mostlynick3/files/centered-cinnamon-dock@mostlynick3/6.4/extension.js
+++ b/centered-cinnamon-dock@mostlynick3/files/centered-cinnamon-dock@mostlynick3/6.4/extension.js
@@ -2620,6 +2620,7 @@ function hidePanel(panel) {
                         state.isHiding = false;
                         if (!hasActiveMenus(panel)) {
                             panel.actor.set_scale(0.0, 0.0);
+                            panel.actor.hide();
                         } else {
                             state.isHidden = false;
                             showPanel(panel);
@@ -2689,6 +2690,7 @@ function hidePanel(panel) {
                         state.isHiding = false;
                         if (!hasActiveMenus(panel)) {
                             panel.actor.set_scale(0.0, 0.0);
+                            panel.actor.hide();
                         } else {
                             state.isHidden = false;
                             showPanel(panel);
@@ -2733,6 +2735,7 @@ function hidePanel(panel) {
                     state.isHiding = false;
                     if (!hasActiveMenus(panel)) {
                         panel.actor.set_scale(0.0, 0.0);
+                        panel.actor.hide();
                     } else {
                         state.isHidden = false;
                         showPanel(panel);


### PR DESCRIPTION
# centered-cinnamon-dock: hide actor when hiding dock and no active menus, fix dock occupying screen area after hiding

## Summary

The dock continues to occupy screen area and capture mouse clicks after hiding because the actor is scaled to 0,0 but not hidden. This change ensures that when the dock is hidden and there are no active menus, the actor is both scaled to 0,0 and hidden, allowing clicks to pass through.

Fixes #1098

## Changes

- Modified hidePanel function to call panel.actor.hide() when setting scale to 0,0 and there are no active menus.

## Testing

- Verified syntax with `node -c` on the modified file (no errors).
- Reviewed the code logic to ensure the fix addresses the issue without introducing regressions.

---
### AI assistance disclosure

This contribution was produced by an autonomous AI coding agent (Claude Code) that @Dodothereal operates and monitors. @Dodothereal is accountable for it, will address review feedback promptly, and will close this PR immediately if this kind of contribution is unwelcome in this project. Commits carry an `Assisted-by: Claude Code` trailer.
