### PR TITLE
dim-inactive-windows@jark: option to never dim fullscreen windows

### DIFF
--- a/dim-inactive-windows@jark/README.md
+++ b/dim-inactive-windows@jark/README.md
@@ -24,6 +24,8 @@ stands out at a glance while inactive content stays fully readable.
 - Smooth fade on focus change (configurable duration, or instant).
 - Leaves menus, tooltips, notifications, panels and the desktop untouched.
 - Optional: keep a window bright while one of its *modal* dialogs is focused.
+- Optional: never dim windows in *real* fullscreen — a video keeps playing at
+  full brightness on one monitor while you work on another.
 - No compositor patching, no overlays — uses Clutter effects on the window actors.
 
 ## Requirements
@@ -63,6 +65,7 @@ Open **System Settings → Extensions → Dim Inactive Windows → ⚙ (Configur
 | Fade duration | 150 ms | 0 = instant switch |
 | Keep parent bright for modal dialogs | off | Strict per-window when off (recommended) |
 | Dim when nothing is focused | off | Also dim everything after clicking the desktop |
+| Never dim fullscreen windows | on | A video in *real* fullscreen stays bright while you work on another monitor. Maximized windows are unaffected |
 
 ## How it works
 

--- a/dim-inactive-windows@jark/files/dim-inactive-windows@jark/extension.js
+++ b/dim-inactive-windows@jark/files/dim-inactive-windows@jark/extension.js
@@ -37,6 +37,7 @@ DimInactiveWindows.prototype = {
         this.animationTime = 150;      // ms
         this.respectTransient = false;
         this.dimWhenNoFocus = false;
+        this.skipFullscreen = true;
 
         this.settings = new Settings.ExtensionSettings(this, this.uuid);
         let reapply = () => this._updateAll(true);   // instant re-apply on change
@@ -46,6 +47,7 @@ DimInactiveWindows.prototype = {
         this.settings.bind("animation-time", "animationTime", reapply);
         this.settings.bind("respect-transient", "respectTransient", reapply);
         this.settings.bind("dim-when-no-focus", "dimWhenNoFocus", reapply);
+        this.settings.bind("skip-fullscreen", "skipFullscreen", reapply);
     },
 
     enable: function() {
@@ -53,6 +55,9 @@ DimInactiveWindows.prototype = {
         this._connect(global.window_manager, "map");
         this._connect(global.window_manager, "destroy");
         this._connect(global.window_manager, "switch-workspace");
+        // A window on another monitor can go fullscreen while the focus stays
+        // where it is, so the focus signal alone would not catch it.
+        this._connect(global.display, "in-fullscreen-changed");
         this._updateAll(true);   // snap to correct state, no initial fade
     },
 
@@ -103,6 +108,11 @@ DimInactiveWindows.prototype = {
     // its parent while a MODAL dialog child holds focus. Deliberately no app /
     // PID grouping, so sibling windows of one app stay independent.
     _isActive: function(mw, focus) {
+        // Real fullscreen (not merely maximised) is always left alone when the
+        // option is on: on a multi-monitor setup a video keeps playing at full
+        // brightness on one screen while you work on another.
+        if (this.skipFullscreen && mw.is_fullscreen())
+            return true;
         if (!focus)
             return !this.dimWhenNoFocus;
         if (mw === focus)

--- a/dim-inactive-windows@jark/files/dim-inactive-windows@jark/po/de.po
+++ b/dim-inactive-windows@jark/files/dim-inactive-windows@jark/po/de.po
@@ -80,3 +80,13 @@ msgid ""
 msgstr ""
 "Auch alle Fenster abdunkeln, wenn nichts fokussiert ist (z. B. nach Klick auf "
 "den Desktop)"
+
+#. settings-schema.json->skip-fullscreen->description
+msgid ""
+"Never dim windows in real fullscreen mode (videos, presentations). Maximized "
+"windows are not affected by this. Only makes a difference on multi-monitor "
+"setups"
+msgstr ""
+"Fenster im echten Vollbildmodus nie abdunkeln (Videos, Präsentationen). "
+"Maximierte Fenster sind davon nicht betroffen. Wirkt sich nur bei mehreren "
+"Monitoren aus"

--- a/dim-inactive-windows@jark/files/dim-inactive-windows@jark/po/dim-inactive-windows@jark.pot
+++ b/dim-inactive-windows@jark/files/dim-inactive-windows@jark/po/dim-inactive-windows@jark.pot
@@ -74,3 +74,10 @@ msgid ""
 "Also dim every window when nothing is focused (e.g. after clicking the "
 "desktop)"
 msgstr ""
+
+#. settings-schema.json->skip-fullscreen->description
+msgid ""
+"Never dim windows in real fullscreen mode (videos, presentations). Maximized "
+"windows are not affected by this. Only makes a difference on multi-monitor "
+"setups"
+msgstr ""

--- a/dim-inactive-windows@jark/files/dim-inactive-windows@jark/settings-schema.json
+++ b/dim-inactive-windows@jark/files/dim-inactive-windows@jark/settings-schema.json
@@ -51,5 +51,10 @@
         "type": "checkbox",
         "default": false,
         "description": "Also dim every window when nothing is focused (e.g. after clicking the desktop)"
+    },
+    "skip-fullscreen": {
+        "type": "checkbox",
+        "default": true,
+        "description": "Never dim windows in real fullscreen mode (videos, presentations). Maximized windows are not affected by this. Only makes a difference on multi-monitor setups"
     }
 }


### PR DESCRIPTION
Windows in real fullscreen (not merely maximized) can now be exempted from dimming, so a video keeps playing at full brightness on one monitor while you work on another. New checkbox "skip-fullscreen", default on.

Also listens to the display's in-fullscreen-changed signal: a window can enter fullscreen on another monitor while the focus stays where it is, which the focus-window signal alone would not catch.

Updates the .pot template and de.po; README documents the new option.