### PR TITLE
[CinnamonBurnMyWindows@klangman] V1.0.4 Add sound effect options

### DIFF
--- a/CinnamonBurnMyWindows@klangman/CHANGELOG.md
+++ b/CinnamonBurnMyWindows@klangman/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## 1.0.4
+
+* Improved the Fire and Mushroom effect settings to be more clean, the custom settings now only show when "custom" is selected in the drop-down list.
+
+* Added Effect settings sound options for each effect, allowing you to setup custom sounds for each effect open/unminimize and close/minimize events.. There are no default effects but you can download sound files and add them to BurnMyWindows.
+
 ## 1.0.3
 
 * Fix the location of the icon file used in the About tab of the configuration window.

--- a/CinnamonBurnMyWindows@klangman/README.md
+++ b/CinnamonBurnMyWindows@klangman/README.md
@@ -72,6 +72,24 @@ Because Cinnamon is missing a required API, the following effects are disabled. 
 5. Select the new "Burn My Windows" entry and then click the "+" button at the bottom of the window
 6. Use the "gears" icon next to the "Burn My Windows" entry to open the setting window and setup the preferred behaviour
 
+
+
+## Sound Effects
+
+Burn My  Windows can now play **unique sound effects** for each type of window effect. 
+
+By default the sound effects are disabled and **no sounds are shipped with the extension**, but you can download your own sound files and go to the "Effect Settings" tab in the Burn My Windows configuration (System-settings->Extension->Burn My Window->Configure(button)) to select different sound files to to be played when windows appear or disappear.
+
+**Burn My Windows respects the Cinnamon sound settings** and will only play sounds when the "Opening new windows", "Closing windows" and the "Minimizing windows" options are enabled under System-Setting->Sounds->Sounds(Tab), but the sound file played will be the one selected for the active Burn My Windows effect settings. The system wide sound file will play when no custom sound is selected for the active Burn My Windows effect.
+
+Cinnamon only supports a subset of sound file formats. You can convert most sound files using the following terminal command:
+
+```
+ffmpeg -i <input_sound_file_name> -c:a libvorbis -q:a 5 <output_sound_file_name>.ogg
+```
+
+You can also use GUI tools like "Audacity" to convert the files as well as do more functions like trimming, removing clicks, fading, volume adjustments and much more.
+
 ## Feedback
 
 Please leave a comment here on cinnamon-spices.linuxmint.com or you can create an issue on my Github (https://github.com/klangman/CinnamonBurnMyWindows) to give me feedback or to report any issues you find. 

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/CustomWidgets.py
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/CustomWidgets.py
@@ -1,11 +1,155 @@
 #!/usr/bin/python3
 
+import os
 import random
 import math
 import gi
+import re
 
+import JsonSettingsWidgets
 from JsonSettingsWidgets import *
 from gi.repository import Gio, Gtk, Gdk, GLib
+
+gi.require_version('GSound', '1.0')
+from gi.repository import GSound
+
+OPERATIONS = ['<=', '>=', '<', '>', '!=', '=']
+
+OPERATIONS_MAP = {'<': operator.lt, '<=': operator.le, '>': operator.gt, '>=': operator.ge, '!=': operator.ne, '=': operator.eq}
+
+gsound_context = None
+
+def _get_gsound_context() -> GSound.Context:
+   global gsound_context
+   if gsound_context is None:
+      gsound_context = GSound.Context()
+      gsound_context.init()
+   return gsound_context
+
+def is_number(s):
+   try:
+      float(s)  # Try converting to a float
+      return True
+   except ValueError:
+      return False
+
+def get_constant(settings, string):
+   if is_number(string):
+      value = float(string);
+   elif string.lower() == 'true':
+      value = True
+   elif string.lower() == "false":
+      value = False
+   else:
+      value = string
+   return value
+
+def customRevealerInit(self, settings, key):
+   super(JSONSettingsRevealer, self).__init__()
+   self.settings = settings
+
+   # Split the dependencies into a list of keys, operations and constants
+   expression = re.split(r'(!=|<=|>=|[<>=&| ])', key)
+   # Remove any blank entries and any whitespace within entries
+   self.expression = [item.strip() for item in expression if item.strip()]
+
+   # Listen to any keys found in the expression,
+   # expand all compares, decode constants,
+   # decode compare operators and check for errors
+   key = None
+   idx = 0
+   count = len(self.expression)
+   listening = []
+   #print( f"Preparing dependency: {self.expression}" )
+   while idx < count:
+      element = self.expression[idx]
+      if element == '&' or element == '|':
+         pass
+      elif element in OPERATIONS:  # ... key op constant ...
+         self.expression[idx] = OPERATIONS_MAP[element]
+         key = self.expression[idx-1]
+         if idx+1 < count and self.expression[idx+1] != '&' and self.expression[idx+1] != '|':
+            self.expression[idx+1] = get_constant(self.settings, self.expression[idx+1])
+         else:
+            self.expression.insert(idx+1, False)
+            count += 1
+         idx += 1
+      elif element[0] == '!':      # ... !key ...
+         key = element[1:]
+         self.expression[idx] = key
+         self.expression.insert(idx+1, False)
+         self.expression.insert(idx+1, operator.eq)
+         idx += 2
+         count += 2
+      elif idx == count-1 or self.expression[idx+1] == '&' or self.expression[idx+1] == '|':   # standalone key
+         key = element
+         self.expression.insert(idx+1, True)
+         self.expression.insert(idx+1, operator.eq)
+         idx += 2
+         count += 2
+      if key:
+         if self.settings.has_key(key):
+            if key not in listening:
+               self.settings.listen(key, self.key_changed)
+               listening.append(key)
+         else:
+            print( f"Error in json dependency: \"{key}\" is not a valid key" )
+         if idx+1 < count and self.expression[idx+1] != '&' and self.expression[idx+1] != '|':
+            print( f"Error in json dependency: Unexpected expression \"{self.expression[idx+1]}\"" )
+            self.expression = self.expression[:idx+1]  # remove the remaining elements since something is wrong with the syntax
+            break
+         key = None
+      idx += 1
+
+   self.box = Gtk.Box(orientation=Gtk.Orientation.VERTICAL, spacing=15)
+   Gtk.Revealer.add(self, self.box)
+
+   self.set_transition_type(Gtk.RevealerTransitionType.SLIDE_DOWN)
+   self.set_transition_duration(150)
+
+   # Fake out a key_changed event so that we have the correct reveal state
+   self.key_changed(None, None)
+
+
+def customRevealerKeyChanged(self, key, value):
+   evaluate = []
+   count = len(self.expression)
+   #print( f"Evaluating expression: {self.expression}" )
+
+   # Go through the expression to evaluate all the compares
+   # The init ensures that the list has this format: key op const [ <&/|> key op const ]...
+   idx = 0
+   while idx < count:
+      lhs = self.settings.get_value(self.expression[idx]) #get_value(self.settings, self.expression[idx])
+      op  = self.expression[idx+1]
+      rhs = self.expression[idx+2]
+      evaluate.append( op(lhs, rhs) )
+      idx += 3
+      if idx < count:
+         evaluate.append( self.expression[idx] )
+         idx += 1
+   #print( f"Post compare evaluation: {evaluate}" )
+
+   # Handle all the "and" operations first in accordance with the logical order of operations
+   while "&" in evaluate:
+      idx = evaluate.index("&")
+      result = (evaluate[idx-1] and evaluate[idx+1])
+      evaluate[idx-1:idx+2] = [] ## remove 3 elements: idx-1 through idx+1
+      evaluate.insert(idx-1, result);
+   #print( f"After evaluating the ands: {evaluate}" )
+
+   # Handle all the "or" operations (there should be nothing but "or" operations at this point)
+   while "|" in evaluate:
+      idx = evaluate.index("|")
+      result = (evaluate[idx-1] or evaluate[idx+1])
+      evaluate[idx-1:idx+2] = [] ## remove 3 elements: idx-1 through idx+1
+      evaluate.insert(idx-1, result);
+   #print( f"After evaluating ors: {evaluate}" )
+
+   # At this point we should only have one entry in the list, the final result
+   #print( f"Final result: {evaluate}" )
+   self.set_reveal_child(evaluate[0])
+
 
 class FireColorChooser(SettingsWidget):
    def __init__(self, info, key, settings):
@@ -304,6 +448,90 @@ class SetClearButtons(SettingsWidget):
          newList.append( {"name": element["name"], "open": False, "close": False, "minimize": False, "unminimize": False} )
       self.settings.set_value("random-include", newList)
 
+# A copy of SoundFileChooser with an X button to clear the sound file name
+class ClearableSoundFileChooser(SettingsWidget):
+   def __init__(self, info, key, settings):
+      SettingsWidget.__init__(self)
+      self.key = key
+      self.settings = settings
+      self.info = info
+
+      self.label = Gtk.Label(_(info['description']), halign=Gtk.Align.START)  # SettingsLabel(label)
+      self.content_widget = Gtk.Box()
+
+      c = self.content_widget.get_style_context()
+      c.add_class(Gtk.STYLE_CLASS_LINKED)
+
+      self.file_picker_button = Gtk.Button()
+      self.file_picker_button.connect("clicked", self.on_picker_clicked)
+
+      button_content = Gtk.Box(spacing=5)
+      self.file_picker_button.add(button_content)
+
+      self.button_label = Gtk.Label()
+      button_content.pack_start(Gtk.Image(icon_name="sound"), False, False, 0)
+      button_content.pack_start(self.button_label, False, False, 0)
+
+      self.content_widget.pack_start(self.file_picker_button, True, True, 0)
+
+      self.pack_start(self.label, False, False, 0)
+      self.pack_end(self.content_widget, False, False, 0)
+
+      self.play_button = Gtk.Button()
+      self.play_button.set_image(Gtk.Image.new_from_icon_name("media-playback-start-symbolic", Gtk.IconSize.BUTTON))
+      self.play_button.connect("clicked", self.on_play_clicked)
+      self.content_widget.pack_start(self.play_button, False, False, 0)
+
+      self.clear_button = Gtk.Button()
+      self.clear_button.set_image(Gtk.Image.new_from_icon_name("edit-clear-symbolic", Gtk.IconSize.BUTTON))
+      self.clear_button.connect("clicked", self.on_clear_clicked)
+      self.content_widget.pack_start(self.clear_button, False, False, 0)
+
+      self.update_button_label(info['value']);
+
+      if "tooltip" in info:
+         self.set_tooltip_text(info["tooltip"])
+
+   def on_clear_clicked(self, widget):
+      self.button_label.set_label("")
+      self.settings.set_value(self.key, "")
+
+   def on_play_clicked(self, widget):
+      path = self.settings.get_value(self.key)
+      if path != "":
+         params = {GSound.ATTR_MEDIA_FILENAME: path, GSound.ATTR_MEDIA_ROLE: "test"}
+         _get_gsound_context().play_simple(params)
+
+   def on_picker_clicked(self, widget):
+      dialog = Gtk.FileChooserDialog(title=self.label.get_text(),
+                                     action=Gtk.FileChooserAction.OPEN,
+                                     transient_for=self.get_toplevel(),
+                                     buttons=(_("_Cancel"), Gtk.ResponseType.CANCEL,
+                                              _("_Open"), Gtk.ResponseType.ACCEPT))
+
+      if os.path.exists(self.settings.get_value(self.key)):
+         dialog.set_filename(self.settings.get_value(self.key))
+      else:
+         dialog.set_current_folder('/usr/share/sounds')
+
+      sound_filter = Gtk.FileFilter()
+      sound_filter.add_mime_type("audio/x-wav")
+      sound_filter.add_mime_type("audio/x-vorbis+ogg")
+      sound_filter.set_name(_("Sound files"))
+      dialog.add_filter(sound_filter)
+
+      if dialog.run() == Gtk.ResponseType.ACCEPT:
+         name = dialog.get_filename()
+         self.settings.set_value(self.key, name)
+         self.update_button_label(name)
+
+      dialog.destroy()
+
+   def update_button_label(self, absolute_path):
+      if absolute_path != "":
+         f = Gio.File.new_for_path(absolute_path)
+         self.button_label.set_label(f.get_basename())
+
 
 # This is based on the Range class that handles the "scale" type. It's modified so that it fits on one line
 # to save space at the expense of the scale widget width. This allows the Effects Settings data to fit better
@@ -312,6 +540,15 @@ class CompactScale(SettingsWidget):
     bind_prop = "value"
     bind_dir = Gio.SettingsBindFlags.GET | Gio.SettingsBindFlags.NO_SENSITIVITY
     def __init__(self, info, key, settings):
+
+        # Monkey patch the JSONSettingsRevealer to use our custom methods which allows for "and" and "or" dependency operations
+        # This is the earliest point in the xlet-setting program that I can find to do this patching. Hopefully it's early enough!
+        # It does mean that we need to have a "CompactScale" instance without dependencies before any widgets with dependencies
+        if JsonSettingsWidgets.JSONSettingsRevealer.__init__ != customRevealerInit:
+           print( "Monkey patching JSONSettingsRevealer methods" )
+           JsonSettingsWidgets.JSONSettingsRevealer.__init__ = customRevealerInit
+           JsonSettingsWidgets.JSONSettingsRevealer.key_changed = customRevealerKeyChanged
+
         SettingsWidget.__init__(self)
         self.key = key
         self.settings = settings

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/extension.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/extension.js
@@ -58,6 +58,7 @@ const Cinnamon = imports.gi.Cinnamon;
 const Util = imports.misc.util;
 const SignalManager = imports.misc.signalManager;
 const UPowerGlib = imports.gi.UPowerGlib;
+const SoundManager = imports.ui.soundManager;
 
 const Effect = {
   Apparition:  {idx: 0,  name: "Apparition"},
@@ -191,6 +192,7 @@ class BurnMyWindows {
       this._settings.bind("dialog-close-effect", "dialogCloseEffect");
       this._settings.bind("power-close-effect", "powerCloseEffect");
       this._settings.bind("power-dialog-close-effect", "powerDialogCloseEffect");
+      this._settings.bind("enable-sound", "enableSound", this._enableSounds);
 
       // Keep track of the previously focused Application
       this._signalManager.connect(global.display, "notify::focus-window", this._onFocusChanged, this);
@@ -218,6 +220,9 @@ class BurnMyWindows {
       // This call will only connect to minimize/unminimize events if needed, that way MagicLampEffect can still work if it's installed
       this._enableMinimizeEffects();
 
+      // Monkey Patch the SoundManager.play() function if required
+      this._enableSounds();
+
       // Make sure to remove any effects if requested by the window manager.
       this._killEffectsSignal = global.window_manager.connect('kill-window-effects', (wm, actor) => {
          const shader = actor.get_effect('burn-my-windows-effect');
@@ -225,6 +230,26 @@ class BurnMyWindows {
             shader.endAnimation();
          }
       });
+  }
+
+  // Make sure the SoundManager Monkey patching is setup correctly according to the this.enableSound value
+  _enableSounds() {
+     if (this.enableSound && !this._originalPlay) {
+        this._originalPlay = SoundManager.SoundManager.prototype.play;
+        SoundManager.SoundManager.prototype.play = this._soundManager_play;
+     } else if (!this.enableSound && this._originalPlay) {
+        SoundManager.SoundManager.prototype.play = this._originalPlay;
+        delete this._originalPlay;
+     }
+  }
+
+  // Monkey patched play function, `this` will be a SoundManager instance
+  _soundManager_play(event) {
+     if (event == "map" || event == "close" || event == "minimize") {
+        // We will play these sounds later on when we know what file to play
+        return;
+     }
+     extensionThis._originalPlay.call(this, event);
   }
 
   // This function will rebuild the "random-include" list. After an upgrade,
@@ -318,6 +343,39 @@ class BurnMyWindows {
       Main.wm.desktop_effects_close_type = "traditional";
       Main.wm.desktop_effects_minimize_type = "traditional";
 
+      // If sound effects are enabled and the chosen effect has a sound effect file, then override the cinnamon effect file
+      if (extensionThis.enableSound) {
+         let soundSettings = new Gio.Settings({ schema_id: "org.cinnamon.sounds" });
+         let sfx = chosenEffect.effect.constructor.getSFX(extensionThis._settings, (event & ShouldAnimateManager.Events.MapWindow) || (event & ShouldAnimateManager.Events.Unminimize) );
+         switch(event) {
+            case ShouldAnimateManager.Events.MapWindow:
+               if (soundSettings.get_boolean("map-enabled")) {
+                  if (sfx)
+                     Main.soundManager.playSoundFile(0, sfx);
+                  else
+                     extensionThis._originalPlay.call(Main.soundManager, "map");
+               }
+               break;
+            case ShouldAnimateManager.Events.DestroyWindow:
+               if (soundSettings.get_boolean("close-enabled")) {
+                  if (sfx)
+                     Main.soundManager.playSoundFile(0, sfx);
+                  else
+                     extensionThis._originalPlay.call(Main.soundManager, "close");
+               }
+               break;
+            case ShouldAnimateManager.Events.Minimize:
+            case ShouldAnimateManager.Events.Unminimize:
+               if (soundSettings.get_boolean("minimize-enabled")) {
+                  if (sfx)
+                     Main.soundManager.playSoundFile(0, sfx);
+                  else
+                     extensionThis._originalPlay.call(Main.soundManager, "minimize");
+               }
+               break;
+         }
+      }
+
       // Record the windows current position before Cinnamon mucks with it's position
       let actorX = actor.x;
       let actorY = actor.y;
@@ -369,6 +427,12 @@ class BurnMyWindows {
 
     // Restore the original window-open, window-close, Minimize and Unminimize animations.
     this.shouldAnimateManager.disconnect();
+
+    // Restore the monkey patched SoundManager if it has been patched
+    if (this._originalPlay) {
+       SoundManager.SoundManager.prototype.play = this._originalPlay;
+       delete this._originalPlay;
+    }
 
     this._settings.finalize();
     this._settings = null;

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/settings-schema.json
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/6.2/settings-schema.json
@@ -11,7 +11,7 @@
     "effects-page" : {
       "type" : "page",
       "title" : "Effect Settings",
-      "sections" : ["effect-selector-section", "effect-settings", "mushroom-custom-section", "fire-custom-section"]
+      "sections" : ["effect-selector-section", "effect-settings"]
     },
     "application-page": {
       "type" : "page",
@@ -37,7 +37,7 @@
     "general-settings" : {
       "type" : "section",
       "title" : "Burn My Windows General Settings",
-      "keys" : ["open-window-effect", "close-window-effect", "minimize-effect", "unminimize-effect", "dialog-special", "dialog-open-effect", "dialog-close-effect"]
+      "keys" : ["open-window-effect", "close-window-effect", "minimize-effect", "unminimize-effect", "enable-sound", "dialog-special", "dialog-open-effect", "dialog-close-effect"]
     },
 
     "app-specific-settings" : {
@@ -54,41 +54,29 @@
     "effect-settings" : {
       "type" : "section",
       "title" : "Effect Specific Settings",
-      "keys" : ["apparition-shake-intensity", "apparition-twirl-intensity", "apparition-suction-intensity", "apparition-randomness", "apparition-animation-time", "apparition-reset",
-                "aura-glow-random-color", "aura-glow-start-hue", "aura-glow-speed", "aura-glow-saturation", "aura-glow-edge-size", "aura-glow-edge-hardness", "aura-glow-blur", "aura-glow-animation-time", "aura-glow-reset",
-                "doom-horizontal-scale", "doom-vertical-scale", "doom-pixel-size", "doom-y-hack", "doom-animation-time", "doom-reset",
-                "energize-a-scale", "energize-a-color", "energize-a-animation-time", "energize-a-reset",
-                "energize-b-scale", "energize-b-color", "energize-b-animation-time", "energize-b-reset",
-                "fire-presets", "fire-3d-noise", "fire-random-color", "fire-animation-time", "fire-reset",
-                "focus-blur-amount", "focus-blur-quality", "focus-animation-time", "focus-reset",
-                "glide-scale", "glide-squish", "glide-tilt", "glide-shift", "glide-animation-time", "glide-reset",
-                "glitch-scale", "glitch-strength", "glitch-speed", "glitch-color", "glitch-animation-time", "glitch-reset",
-                "hexagon-scale", "hexagon-line-width", "hexagon-line-color", "hexagon-glow-color", "hexagon-additive-blending", "hexagon-animation-time", "hexagon-reset",
-                "incinerate-scale", "incinerate-turbulence", "incinerate-color", "incinerate-use-pointer", "incinerate-animation-time", "incinerate-reset",
-                "magiclamp-effect", "magiclamp-edge", "magiclamp-edge-offset", "magiclamp-x-tiles", "magiclamp-y-tiles", "magiclamp-animation-time", "magiclamp-reset",
-                "mushroom-presets", "mushroom-animation-time", "mushroom-reset",
-                "pixelate-noise", "pixelate-pixel-size", "pixelate-animation-time", "pixelate-reset",
-                "pixel-wheel-spoke-count", "pixel-wheel-pixel-size", "pixel-wheel-animation-time", "pixel-wheel-reset",
-                "pixel-wipe-pixel-size", "pixel-wipe-animation-time", "pixel-wipe-reset",
-                "portal-color", "portal-rotation-speed", "portal-whirling", "portal-details", "portal-animation-time", "portal-reset",
-                "rgbwarp-brightness", "rgbwarp-speed-r", "rgbwarp-speed-g", "rgbwarp-speed-b", "rgbwarp-animation-time", "rgbwarp-reset",
-                "team-rocket-animation-split", "team-rocket-horizontal-sparkle-position", "team-rocket-vertical-sparkle-position", "team-rocket-window-rotation", "team-rocket-sparkle-rot", "team-rocket-sparkle-size", "team-rocket-animation-time", "team-rocket-reset",
-                "tv-effect-color", "tv-animation-time", "tv-reset",
-                "tv-glitch-scale", "tv-glitch-strength", "tv-glitch-speed", "tv-glitch-color", "tv-glitch-animation-time", "tv-glitch-reset",
-                "wisps-scale", "wisps-color-1", "wisps-color-2", "wisps-color-3", "wisps-animation-time", "wisps-reset",
+      "keys" : ["apparition-shake-intensity", "apparition-twirl-intensity", "apparition-suction-intensity", "apparition-randomness", "apparition-animation-time", "apparition-open-sound", "apparition-close-sound", "apparition-reset",
+                "aura-glow-random-color", "aura-glow-start-hue", "aura-glow-speed", "aura-glow-saturation", "aura-glow-edge-size", "aura-glow-edge-hardness", "aura-glow-blur", "aura-glow-animation-time", "aura-glow-open-sound", "aura-glow-close-sound", "aura-glow-reset",
+                "doom-horizontal-scale", "doom-vertical-scale", "doom-pixel-size", "doom-y-hack", "doom-animation-time", "doom-open-sound", "doom-close-sound", "doom-reset",
+                "energize-a-scale", "energize-a-color", "energize-a-animation-time", "energize-a-open-sound", "energize-a-close-sound", "energize-a-reset",
+                "energize-b-scale", "energize-b-color", "energize-b-animation-time", "energize-b-open-sound", "energize-b-close-sound", "energize-b-reset",
+                "fire-presets", "fire-custom-scale", "fire-custom-movement-speed", "fire-colors", "fire-3d-noise", "fire-random-color", "fire-animation-time", "fire-open-sound", "fire-close-sound", "fire-reset",
+                "focus-blur-amount", "focus-blur-quality", "focus-animation-time", "focus-open-sound", "focus-close-sound", "focus-reset",
+                "glide-scale", "glide-squish", "glide-tilt", "glide-shift", "glide-animation-time", "glide-open-sound", "glide-close-sound", "glide-reset",
+                "glitch-scale", "glitch-strength", "glitch-speed", "glitch-color", "glitch-animation-time", "glitch-open-sound", "glitch-close-sound", "glitch-reset",
+                "hexagon-scale", "hexagon-line-width", "hexagon-line-color", "hexagon-glow-color", "hexagon-additive-blending", "hexagon-animation-time", "hexagon-open-sound", "hexagon-close-sound", "hexagon-reset",
+                "incinerate-scale", "incinerate-turbulence", "incinerate-color", "incinerate-use-pointer", "incinerate-animation-time", "incinerate-open-sound", "incinerate-close-sound", "incinerate-reset",
+                "magiclamp-effect", "magiclamp-edge", "magiclamp-edge-offset", "magiclamp-x-tiles", "magiclamp-y-tiles", "magiclamp-animation-time", "magiclamp-open-sound", "magiclamp-close-sound", "magiclamp-reset",
+                "mushroom-presets", "mushroom-custom-scale-style", "mushroom-custom-spark-count", "mushroom-custom-spark-color", "mushroom-custom-spark-rotation", "mushroom-custom-rays-color", "mushroom-custom-ring-count", "mushroom-custom-ring-rotation", "mushroom-custom-star-count", "mushroom-star-colors", "mushroom-animation-time", "mushroom-open-sound", "mushroom-close-sound", "mushroom-reset",
+                "pixelate-noise", "pixelate-pixel-size", "pixelate-animation-time", "pixelate-open-sound", "pixelate-close-sound", "pixelate-reset",
+                "pixel-wheel-spoke-count", "pixel-wheel-pixel-size", "pixel-wheel-animation-time", "pixel-wheel-open-sound", "pixel-wheel-close-sound", "pixel-wheel-reset",
+                "pixel-wipe-pixel-size", "pixel-wipe-animation-time", "pixel-wipe-open-sound", "pixel-wipe-close-sound", "pixel-wipe-reset",
+                "portal-color", "portal-rotation-speed", "portal-whirling", "portal-details", "portal-animation-time", "portal-open-sound", "portal-close-sound", "portal-reset",
+                "rgbwarp-brightness", "rgbwarp-speed-r", "rgbwarp-speed-g", "rgbwarp-speed-b", "rgbwarp-animation-time", "rgbwarp-open-sound", "rgbwarp-close-sound", "rgbwarp-reset",
+                "team-rocket-animation-split", "team-rocket-horizontal-sparkle-position", "team-rocket-vertical-sparkle-position", "team-rocket-window-rotation", "team-rocket-sparkle-rot", "team-rocket-sparkle-size", "team-rocket-animation-time", "team-rocket-open-sound", "team-rocket-close-sound", "team-rocket-reset",
+                "tv-effect-color", "tv-animation-time", "tv-open-sound", "tv-close-sound", "tv-reset",
+                "tv-glitch-scale", "tv-glitch-strength", "tv-glitch-speed", "tv-glitch-color", "tv-glitch-animation-time", "tv-glitch-open-sound", "tv-glitch-close-sound", "tv-glitch-reset",
+                "wisps-scale", "wisps-color-1", "wisps-color-2", "wisps-color-3", "wisps-animation-time", "wisps-open-sound", "wisps-close-sound", "wisps-reset",
                 "test-effect"]
-    },
-    "fire-custom-section" : {
-     "type" : "section",
-     "title" : "Setting for the custom preset:",
-     "keys" : ["fire-custom-scale", "fire-custom-movement-speed", "fire-colors"],
-     "dependency" : "effect-selector=5"
-    },
-    "mushroom-custom-section" : {
-     "type" : "section",
-     "title" : "Setting for the custom preset:",
-     "keys" : ["mushroom-custom-scale-style", "mushroom-custom-spark-count", "mushroom-custom-spark-color", "mushroom-custom-spark-rotation", "mushroom-custom-rays-color", "mushroom-custom-ring-count", "mushroom-custom-ring-rotation", "mushroom-custom-star-count", "mushroom-star-colors"],
-     "dependency" : "effect-selector=25"
     },
     "random-section" : {
       "type" : "section",
@@ -396,6 +384,13 @@
       "None": 1000
     },
     "description": "Close window effect"
+  },
+
+  "enable-sound": {
+    "type" : "switch",
+    "description": "Allow Burn My Windows to override cinnamon sound effects",
+    "tooltip": "Allow Burn My Windows to override Cinnamon's window open/close/minimize sound effects with unique ones defined in the Effect Settings tab for each Burn My Windows effect. Note: Sounds will only play when Cinnamon's open/close/minimize sound effects are enabled under Cinnamon sounds settings. The default cinnamon sounds will be used unless a sound effect file is chosen for the active Burn My Windows effect.",
+     "default": true
   },
 
   "dialog-special": {
@@ -828,6 +823,24 @@
      "keys" : ["apparition-shake-intensity", "apparition-twirl-intensity", "apparition-suction-intensity", "apparition-randomness", "apparition-animation-time"]
   },
 
+  "apparition-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=0 & enable-sound=true",
+     "default" : ""
+  },
+
+  "apparition-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=0 & enable-sound=true",
+     "default" : ""
+  },
+
 
   "aura-glow-random-color": {
     "type" : "switch",
@@ -929,6 +942,24 @@
      "keys" : ["aura-glow-random-color", "aura-glow-start-hue", "aura-glow-speed", "aura-glow-saturation", "aura-glow-edge-size", "aura-glow-edge-hardness", "aura-glow-blur", "aura-glow-animation-time"]
   },
 
+  "aura-glow-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=22 & enable-sound=true",
+     "default" : ""
+  },
+
+  "aura-glow-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=22 & enable-sound=true",
+     "default" : ""
+  },
+
 
   "doom-horizontal-scale": {
      "type" : "custom",
@@ -1000,6 +1031,24 @@
      "keys" : ["doom-horizontal-scale", "doom-vertical-scale", "doom-pixel-size", "doom-y-hack", "doom-animation-time"]
   },
 
+  "doom-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=2 & enable-sound=true",
+     "default" : ""
+  },
+
+  "doom-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=2 & enable-sound=true",
+     "default" : ""
+  },
+
 
   "energize-a-scale": {
      "type" : "custom",
@@ -1040,6 +1089,25 @@
      "dependency" : "effect-selector=3",
      "keys" : ["energize-a-scale", "energize-a-color", "energize-a-animation-time"]
   },
+
+  "energize-a-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=3 & enable-sound=true",
+     "default" : ""
+  },
+
+  "energize-a-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=3 & enable-sound=true",
+     "default" : ""
+  },
+
 
 
   "energize-b-scale": {
@@ -1082,6 +1150,24 @@
      "keys" : ["energize-b-scale", "energize-b-color", "energize-b-animation-time"]
   },
 
+  "energize-b-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=4 & enable-sound=true",
+     "default" : ""
+  },
+
+  "energize-b-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=4 & enable-sound=true",
+     "default" : ""
+  },
+
 
   "fire-presets": {
     "type": "combobox",
@@ -1095,7 +1181,7 @@
       "Nuclear" : 5,
       "Custom" : 1000
     },
-    "description": "Fire Preset",
+    "description": "Fire effect style",
     "dependency" : "effect-selector=5"
   },
 
@@ -1107,7 +1193,7 @@
      "min" : 0.1,
      "max" : 3,
      "step" : 0.01,
-     "dependency" : "effect-selector=5",
+     "dependency" : "effect-selector=5 & fire-presets=1000",
      "default": 0.5
   },
 
@@ -1119,7 +1205,7 @@
      "min" : -2,
      "max" : 2,
      "step" : 0.01,
-     "dependency" : "effect-selector=5",
+     "dependency" : "effect-selector=5 & fire-presets=1000",
      "default": 0.5
   },
 
@@ -1127,7 +1213,7 @@
     "type" : "switch",
     "description": "Fire 3D Noise",
     "tooltip": "Creates a more dynamic fire but requires more GPU power.",
-    "dependency" : "effect-selector=5",
+    "dependency" : "effect-selector=5 & fire-presets=1000",
     "default": false
   },
 
@@ -1144,6 +1230,7 @@
     "file" : "CustomWidgets.py",
     "widget" : "FireColorChooser",
     "description" : "Colors 1-5",
+    "dependency" : "effect-selector=5 & fire-presets=1000",
     "color1" : "fire-custom-color-1",
     "color2" : "fire-custom-color-2",
     "color3" : "fire-custom-color-3",
@@ -1197,6 +1284,24 @@
      "keys" : ["fire-presets", "fire-3d-noise", "fire-animation-time", "fire-custom-scale", "fire-custom-movement-speed", "fire-custom-color-1", "fire-custom-color-2", "fire-custom-color-3", "fire-custom-color-4", "fire-custom-color-5"]
   },
 
+  "fire-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=5 & enable-sound=true",
+     "default" : ""
+  },
+
+  "fire-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=5 & enable-sound=true",
+     "default" : ""
+  },
+
 
   "focus-blur-amount": {
      "type" : "custom",
@@ -1244,6 +1349,24 @@
      "keys" : ["focus-blur-amount", "focus-blur-quality", "focus-animation-time"]
   },
 
+  "focus-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=21 & enable-sound=true",
+     "default" : ""
+  },
+
+  "focus-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=21 & enable-sound=true",
+     "default" : ""
+  },
+
 
   "glide-scale": {
      "type" : "custom",
@@ -1252,7 +1375,7 @@
      "description" : "Scale",
      "min" : 0.1,
      "max" : 1,
-     "step" : 0.1,
+     "step" : 0.01,
      "dependency" : "effect-selector=6",
      "default": 0.95
   },
@@ -1312,6 +1435,24 @@
      "description" : "Reset to default",
      "dependency" : "effect-selector=6",
      "keys" : ["glide-scale", "glide-squish", "glide-tilt", "glide-shift", "glide-animation-time"]
+  },
+
+  "glide-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=6 & enable-sound=true",
+     "default" : ""
+  },
+
+  "glide-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=6 & enable-sound=true",
+     "default" : ""
   },
 
 
@@ -1377,6 +1518,23 @@
      "description" : "Reset to default",
      "dependency" : "effect-selector=7",
      "keys" : ["glitch-scale", "glitch-strength", "glitch-speed", "glitch-color", "glitch-animation-time"]
+  },
+  "glitch-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=7 & enable-sound=true",
+     "default" : ""
+  },
+
+  "glitch-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=7 & enable-sound=true",
+     "default" : ""
   },
 
 
@@ -1447,6 +1605,24 @@
      "keys" : ["hexagon-scale", "hexagon-line-width", "hexagon-line-color", "hexagon-glow-color", "hexagon-additive-blending", "hexagon-animation-time"]
   },
 
+  "hexagon-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=8 & enable-sound=true",
+     "default" : ""
+  },
+
+  "hexagon-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=8 & enable-sound=true",
+     "default" : ""
+  },
+
 
   "incinerate-scale": {
      "type" : "custom",
@@ -1506,6 +1682,24 @@
      "description" : "Reset to default",
      "dependency" : "effect-selector=9",
      "keys" : ["incinerate-scale", "incinerate-turbulence", "incinerate-color", "incinerate-use-pointer", "incinerate-animation-time"]
+  },
+
+  "incinerate-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=9 & enable-sound=true",
+     "default" : ""
+  },
+
+  "incinerate-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=9 & enable-sound=true",
+     "default" : ""
   },
 
 
@@ -1599,35 +1793,22 @@
      "keys" : ["magiclamp-effect", "magiclamp-edge", "magiclamp-edge-offset", "magiclamp-x-tiles", "magiclamp-y-tiles", "magiclamp-animation-time"]
   },
 
-
-  "matrix-scale": {
-     "type": "generic",
-     "default": 20
+  "magiclamp-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=26 & enable-sound=true",
+     "default" : ""
   },
 
-  "matrix-randomness": {
-     "type": "generic",
-     "default": 1.0
-  },
-
-  "matrix-tip-color": {
-     "type": "generic",
-     "default": "rgb(255, 255, 255)"
-  },
-
-  "matrix-trail-color": {
-     "type": "generic",
-     "default": "rgb(25, 255, 89)"
-  },
-
-  "matrix-overshoot": {
-     "type": "generic",
-     "default": 0.25
-  },
-
-  "matrix-animation-time": {
-     "type": "generic",
-     "default": 1500
+  "magiclamp-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=26 & enable-sound=true",
+     "default" : ""
   },
 
 
@@ -1645,7 +1826,7 @@
       "Sparkle" : 7,
       "Custom" : 1000
     },
-    "description": "Mushroom Preset",
+    "description": "Mushroom effect style",
     "dependency" : "effect-selector=25"
   },
 
@@ -1657,7 +1838,7 @@
      "min" : 0,
      "max" : 1,
      "step" : 0.1,
-     "dependency" : "effect-selector=25",
+     "dependency" : "effect-selector=25 & mushroom-presets=1000",
      "default": 1
   },
 
@@ -1669,14 +1850,14 @@
      "min" : 0,
      "max" : 25,
      "step" : 1,
-     "dependency" : "effect-selector=25",
+     "dependency" : "effect-selector=25 & mushroom-presets=1000",
      "default": 4
   },
 
   "mushroom-custom-spark-color": {
      "type": "colorchooser",
      "description" : "Spark Color",
-     "dependency" : "effect-selector=25",
+     "dependency" : "effect-selector=25 & mushroom-presets=1000",
      "default": "rgba(255, 255, 255, 1.0)"
   },
 
@@ -1688,14 +1869,14 @@
      "min" : -3,
      "max" : 3,
      "step" : 0.5,
-     "dependency" : "effect-selector=25",
+     "dependency" : "effect-selector=25 & mushroom-presets=1000",
      "default": 0.3
   },
 
   "mushroom-custom-rays-color": {
      "type": "colorchooser",
      "description" : "Rays Color",
-     "dependency" : "effect-selector=25",
+     "dependency" : "effect-selector=25 & mushroom-presets=1000",
      "default": "rgba(255, 255, 255, 1.0)"
   },
 
@@ -1707,7 +1888,7 @@
      "min" : 0,
      "max" : 5,
      "step" : 1,
-     "dependency" : "effect-selector=25",
+     "dependency" : "effect-selector=25 & mushroom-presets=1000",
      "default": 3
   },
 
@@ -1719,7 +1900,7 @@
      "min" : -3,
      "max" : 3,
      "step" : 0.25,
-     "dependency" : "effect-selector=25",
+     "dependency" : "effect-selector=25 & mushroom-presets=1000",
      "default": 1.33
   },
 
@@ -1731,7 +1912,7 @@
      "min" : 0,
      "max" : 7,
      "step" : 1,
-     "dependency" : "effect-selector=25",
+     "dependency" : "effect-selector=25 & mushroom-presets=1000",
      "default": 4
   },
 
@@ -1740,6 +1921,7 @@
     "file" : "CustomWidgets.py",
     "widget" : "MushroomColorChooser",
     "description" : "Colors 1-6",
+    "dependency" : "effect-selector=25 & mushroom-presets=1000",
     "color1" : "mushroom-custom-star-color-0",
     "color2" : "mushroom-custom-star-color-1",
     "color3" : "mushroom-custom-star-color-2",
@@ -1799,6 +1981,24 @@
      "keys" : ["mushroom-presets", "mushroom-animation-time", "mushroom-custom-scale-style", "mushroom-custom-spark-count", "mushroom-custom-spark-color", "mushroom-custom-spark-rotation", "mushroom-custom-rays-color", "mushroom-custom-ring-count", "mushroom-custom-ring-rotation", "mushroom-custom-star-count", "mushroom-custom-star-color-0", "mushroom-custom-star-color-1", "mushroom-custom-star-color-2", "mushroom-custom-star-color-3", "mushroom-custom-star-color-4", "mushroom-custom-star-color-5"]
   },
 
+  "mushroom-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=25 & enable-sound=true",
+     "default" : ""
+  },
+
+  "mushroom-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=25 & enable-sound=true",
+     "default" : ""
+  },
+
 
   "pixelate-noise": {
      "type" : "custom",
@@ -1845,6 +2045,25 @@
      "keys" : ["pixelate-noise", "pixelate-pixel-size", "pixelate-animation-time"]
   },
 
+  "pixelate-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=12 & enable-sound=true",
+     "default" : ""
+  },
+
+  "pixelate-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=12 & enable-sound=true",
+     "default" : ""
+  },
+
+
   "pixel-wheel-spoke-count": {
      "type" : "custom",
      "file" : "CustomWidgets.py",
@@ -1890,6 +2109,24 @@
      "keys" : ["pixel-wheel-spoke-count", "pixel-wheel-pixel-size", "pixel-wheel-animation-time"]
   },
 
+  "pixel-wheel-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=13 & enable-sound=true",
+     "default" : ""
+  },
+
+  "pixel-wheel-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=13 & enable-sound=true",
+     "default" : ""
+  },
+
 
   "pixel-wipe-pixel-size": {
      "type" : "custom",
@@ -1922,6 +2159,24 @@
      "description" : "Reset to default",
      "dependency" : "effect-selector=14",
      "keys" : ["pixel-wipe-pixel-size", "pixel-wipe-animation-time"]
+  },
+
+  "pixel-wipe-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=14 & enable-sound=true",
+     "default" : ""
+  },
+
+  "pixel-wipe-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=14 & enable-sound=true",
+     "default" : ""
   },
 
 
@@ -1987,6 +2242,23 @@
      "description" : "Reset to default",
      "dependency" : "effect-selector=15",
      "keys" : ["portal-color", "portal-rotation-speed", "portal-whirling", "portal-details", "portal-animation-time"]
+  },
+  "portal-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=15 & enable-sound=true",
+     "default" : ""
+  },
+
+  "portal-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=15 & enable-sound=true",
+     "default" : ""
   },
 
 
@@ -2057,6 +2329,24 @@
      "description" : "Reset to default",
      "dependency" : "effect-selector=24",
      "keys" : ["rgbwarp-brightness", "rgbwarp-speed-r", "rgbwarp-speed-g", "rgbwarp-speed-b", "rgbwarp-animation-time"]
+  },
+
+  "rgbwarp-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=24 & enable-sound=true",
+     "default" : ""
+  },
+
+  "rgbwarp-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=24 & enable-sound=true",
+     "default" : ""
   },
 
 
@@ -2148,6 +2438,24 @@
      "keys" : ["team-rocket-animation-split", "team-rocket-horizontal-sparkle-position", "team-rocket-vertical-sparkle-position", "team-rocket-window-rotation", "team-rocket-sparkle-rot", "team-rocket-sparkle-size", "team-rocket-animation-time"]
   },
 
+  "team-rocket-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=23 & enable-sound=true",
+     "default" : ""
+  },
+
+  "team-rocket-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=23 & enable-sound=true",
+     "default" : ""
+  },
+
 
   "tv-effect-color": {
      "type": "colorchooser",
@@ -2175,6 +2483,24 @@
      "description" : "Reset to default",
      "dependency" : "effect-selector=18",
      "keys" : ["tv-effect-color", "tv-animation-time"]
+  },
+  
+  "tv-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=18 & enable-sound=true",
+     "default" : ""
+  },
+
+  "tv-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=18 & enable-sound=true",
+     "default" : ""
   },
 
 
@@ -2242,6 +2568,24 @@
      "keys" : ["tv-glitch-scale", "tv-glitch-strength", "tv-glitch-speed", "tv-glitch-color", "tv-glitch-animation-time"]
   },
 
+  "tv-glitch-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=19 & enable-sound=true",
+     "default" : ""
+  },
+
+  "tv-glitch-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=19 & enable-sound=true",
+     "default" : ""
+  },
+
 
   "wisps-scale": {
      "type" : "custom",
@@ -2296,6 +2640,25 @@
      "dependency" : "effect-selector=20",
      "keys" : ["wisps-scale", "wisps-color-1", "wisps-color-2", "wisps-color-3", "wisps-animation-time"]
   },
+
+  "wisps-open-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window appear events",
+     "dependency" : "effect-selector=20 & enable-sound=true",
+     "default" : ""
+  },
+
+  "wisps-close-sound" : {
+     "type" : "custom",
+     "file" : "CustomWidgets.py",
+     "widget" : "ClearableSoundFileChooser",
+     "description" : "Sound on window disappear events",
+     "dependency" : "effect-selector=20 & enable-sound=true",
+     "default" : ""
+  },
+
 
   "test-effect" : {
      "type" : "button",

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Apparition.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Apparition.js
@@ -114,4 +114,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 2.0, y: 2.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("apparition-open-sound");
+     } else {
+        return settings.getValue("apparition-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/AuraGlow.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/AuraGlow.js
@@ -145,4 +145,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("aura-glow-open-sound");
+     } else {
+        return settings.getValue("aura-glow-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/BrokenGlass.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/BrokenGlass.js
@@ -25,6 +25,8 @@ const GdkPixbuf = imports.gi.GdkPixbuf;
 const Cogl = imports.gi.Cogl;
 const Gettext = imports.gettext;
 const GLib = imports.gi.GLib;
+const St = imports.gi.St;
+
 
 const UUID = "CinnamonBurnMyWindows@klangman";
 
@@ -68,12 +70,11 @@ var Effect = class Effect {
     this.shaderFactory = new ShaderFactory(Effect.getNick(), (shader) => {
       // Create the texture in the first call.
       if (!this._shardTexture) {
-        const shardData    = GdkPixbuf.Pixbuf.new_from_file( GLib.get_home_dir() +
+        const shardData = GdkPixbuf.Pixbuf.new_from_file( GLib.get_home_dir() +
            '/.local/share/cinnamon/extensions/' + UUID + '/resources/img/shards.png');
-        this._shardTexture = new Clutter.Image();
+        this._shardTexture = new St.ImageContent({preferred_width: shardData.width, preferred_height: shardData.height});
         this._shardTexture.set_data(shardData.get_pixels(), Cogl.PixelFormat.RGB_888,
-                                    shardData.width, shardData.height,
-                                    shardData.rowstride);
+                                    shardData.width, shardData.height, shardData.rowstride);
       }
 
       // Store all uniform locations.
@@ -92,7 +93,7 @@ var Effect = class Effect {
           let epicenterY = 0.5;
 
           // However, if this option is set, we use the mouse pointer position.
-          if (!forOpening && settings.get_boolean('broken-glass-use-pointer')) {
+          if (!forOpening && settings.getValue('broken-glass-use-pointer')) {
             const [x, y]               = global.get_pointer();
             const [ok, localX, localY] = actor.transform_stage_point(x, y);
 
@@ -171,5 +172,14 @@ var Effect = class Effect {
   // bounds of the actor. This only works for GNOME 3.38+.
   static getActorScale(settings, forOpening, actor) {
     return {x: 2.0, y: 2.0};
+  }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("broken-glass-open-sound");
+     } else {
+        return settings.getValue("broken-glass-close-sound");
+     }
   }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Doom.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Doom.js
@@ -123,4 +123,13 @@ var Effect = class Effect {
     let actorScale = 2.0 * Math.max(1.0, global.stage.height / actor.height);
     return {x: 1.0, y: actorScale};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("doom-open-sound");
+     } else {
+        return settings.getValue("doom-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/EnergizeA.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/EnergizeA.js
@@ -108,4 +108,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("energize-a-open-sound");
+     } else {
+        return settings.getValue("energize-a-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/EnergizeB.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/EnergizeB.js
@@ -110,4 +110,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("energize-b-open-sound");
+     } else {
+        return settings.getValue("energize-b-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Fire.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Fire.js
@@ -171,6 +171,15 @@ var Effect = class Effect {
     return {x: 1.0, y: 1.0};
   }
 
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("fire-open-sound");
+     } else {
+        return settings.getValue("fire-close-sound");
+     }
+  }
+
   // ----------------------------------------------------------------------- private stuff
 
   // This set the fire effects settings based on the preset value currently set

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Focus.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Focus.js
@@ -111,4 +111,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("focus-open-sound");
+     } else {
+        return settings.getValue("focus-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Glide.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Glide.js
@@ -113,4 +113,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("glide-open-sound");
+     } else {
+        return settings.getValue("glide-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Glitch.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Glitch.js
@@ -117,4 +117,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("glitch-open-sound");
+     } else {
+        return settings.getValue("glitch-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Hexagon.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Hexagon.js
@@ -127,4 +127,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("hexagon-open-sound");
+     } else {
+        return settings.getValue("hexagon-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Incinerate.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Incinerate.js
@@ -164,4 +164,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("incinerate-open-sound");
+     } else {
+        return settings.getValue("incinerate-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/MagicLamp.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/MagicLamp.js
@@ -155,6 +155,15 @@ var Effect = class Effect {
    static getActorScale(settings, forOpening, actor) {
       return {x: 1.0, y: 1.0};
    }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("magiclamp-open-sound");
+     } else {
+        return settings.getValue("magiclamp-close-sound");
+     }
+  }
 }
 
 // Since the MagicLamp is not a GLSLEffect, we have to implement our own Factory.

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Matrix.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Matrix.js
@@ -21,6 +21,7 @@ const {ShaderFactory} = require('./ShaderFactory.js');
 const Clutter = imports.gi.Clutter;
 const GdkPixbuf = imports.gi.GdkPixbuf;
 const Cogl = imports.gi.Cogl;
+const St = imports.gi.St;
 
 const Gettext = imports.gettext;
 const GLib = imports.gi.GLib;
@@ -59,9 +60,8 @@ var Effect = class Effect {
       if (!this._fontTexture) {
         const fontData    = GdkPixbuf.Pixbuf.new_from_file( GLib.get_home_dir() +
            '/.local/share/cinnamon/extensions/' + UUID + '/resources/img/matrixFont.png');
-        this._fontTexture = new Clutter.Image();
-        this._fontTexture.set_data(
-          fontData.get_pixels(),
+        this._fontTexture = new St.ImageContent({preferred_width: fontData.width, preferred_height: fontData.height});
+        this._fontTexture.set_data( fontData.get_pixels(),
           fontData.has_alpha ? Cogl.PixelFormat.RGBA_8888 : Cogl.PixelFormat.RGB_888,
           fontData.width, fontData.height, fontData.rowstride);
       }
@@ -78,7 +78,7 @@ var Effect = class Effect {
       shader.connect('begin-animation', (shader, settings) => {
         const c1 =
           Clutter.Color.from_string(settings.getValue('matrix-trail-color'))[1];
-        const c2 = Clutter.Color.from_string(settings.get_string('matrix-tip-color'))[1];
+        const c2 = Clutter.Color.from_string(settings.getValue('matrix-tip-color'))[1];
 
         // clang-format off
         shader.set_uniform_float(shader._uTrailColor, 3, [c1.red / 255, c1.green / 255, c1.blue / 255]);
@@ -144,5 +144,14 @@ var Effect = class Effect {
   // bounds of the actor. This only works for GNOME 3.38+.
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0 + settings.getValue('matrix-overshoot')};
+  }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("matrix-open-sound");
+     } else {
+        return settings.getValue("matrix-close-sound");
+     }
   }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Mushroom.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Mushroom.js
@@ -215,6 +215,15 @@ var Effect = class Effect {
     return {x: 1.0, y: 1.0};
   }
 
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("mushroom-open-sound");
+     } else {
+        return settings.getValue("mushroom-close-sound");
+     }
+  }
+
   // ---------------------------------------------------------------- Presets
 
   // This function initializes the preset dropdown menu for configuring fire options.

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/PaintBrush.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/PaintBrush.js
@@ -59,7 +59,7 @@ var Effect = class Effect {
       if (!this._brushTexture) {
         const brushData = GdkPixbuf.Pixbuf.new_from_file( GLib.get_home_dir() +
            '/.local/share/cinnamon/extensions/' + UUID + '/resources/img/brush.png');
-        this._brushTexture = new Clutter.Image();
+        this._brushTexture = new St.ImageContent({preferred_width: brushData.width, preferred_height: brushData.height});
         this._brushTexture.set_data(brushData.get_pixels(),
                                     Cogl.PixelFormat.RGBA_8888_PRE, brushData.width,
                                     brushData.height, brushData.rowstride);
@@ -130,5 +130,14 @@ var Effect = class Effect {
   // bounds of the actor. This only works for GNOME 3.38+.
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
+  }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("paint-brush-open-sound");
+     } else {
+        return settings.getValue("paint-brush-close-sound");
+     }
   }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/PixelWheel.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/PixelWheel.js
@@ -106,4 +106,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("pixel-wheel-open-sound");
+     } else {
+        return settings.getValue("pixel-wheel-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/PixelWipe.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/PixelWipe.js
@@ -131,4 +131,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("pixel-wipe-open-sound");
+     } else {
+        return settings.getValue("pixel-wipe-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Pixelate.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Pixelate.js
@@ -106,4 +106,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("pixelate-open-sound");
+     } else {
+        return settings.getValue("pixelate-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Portal.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Portal.js
@@ -119,4 +119,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("portal-open-sound");
+     } else {
+        return settings.getValue("portal-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/RGBWarp.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/RGBWarp.js
@@ -111,4 +111,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("rgbwarp-open-sound");
+     } else {
+        return settings.getValue("rgbwarp-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/SnapOfDisintegration.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/SnapOfDisintegration.js
@@ -61,7 +61,7 @@ var Effect = class Effect {
       if (!this._dustTexture) {
         const dustData    = GdkPixbuf.Pixbuf.new_from_file( GLib.get_home_dir() +
            '/.local/share/cinnamon/extensions/' + UUID + '/resources/img/dust.png');
-        this._dustTexture = new Clutter.Image();
+        this._dustTexture = new St.ImageContent({preferred_width: dustData.width, preferred_height: dustData.height});
         this._dustTexture.set_data(dustData.get_pixels(), Cogl.PixelFormat.RGB_888,
                                    dustData.width, dustData.height, dustData.rowstride);
       }
@@ -141,5 +141,14 @@ var Effect = class Effect {
   // bounds of the actor. This only works for GNOME 3.38+.
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.2, y: 1.2};
+  }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("snap-open-sound");
+     } else {
+        return settings.getValue("snap-close-sound");
+     }
   }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/TRexAttack.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/TRexAttack.js
@@ -56,7 +56,7 @@ var Effect = class Effect {
       if (!this._clawTexture) {
         const clawData    = GdkPixbuf.Pixbuf.new_from_file( GLib.get_home_dir() +
            '/.local/share/cinnamon/extensions/' + UUID + '/resources/img/claws.png');
-        this._clawTexture = new Clutter.Image();
+        this._clawTexture = new St.ImageContent({preferred_width: clawData.width, preferred_height: clawData.height});
         this._clawTexture.set_data(clawData.get_pixels(), Cogl.PixelFormat.RGB_888,
                                    clawData.width, clawData.height, clawData.rowstride);
       }
@@ -71,7 +71,7 @@ var Effect = class Effect {
 
       // Write all uniform values at the start of each animation.
       shader.connect('begin-animation', (shader, settings, forOpening, testMode) => {
-        const c = Clutter.Color.from_string(settings.get_string('trex-scratch-color'))[1];
+        const c = Clutter.Color.from_string(settings.getValue('trex-scratch-color'))[1];
 
         // clang-format off
         shader.set_uniform_float(shader._uFlashColor,    4, [c.red / 255, c.green / 255, c.blue / 255, c.alpha / 255]);
@@ -139,7 +139,16 @@ var Effect = class Effect {
   // animation. This is useful if the effect requires drawing something beyond the usual
   // bounds of the actor. This only works for GNOME 3.38+.
   static getActorScale(settings, forOpening, actor) {
-    const scale = 1.0 + 0.5 * settings.get_double('trex-scratch-warp');
+    const scale = 1.0 + 0.5 * settings.getValue('trex-scratch-warp');
     return {x: scale, y: scale};
+  }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("trex-scratch-open-sound");
+     } else {
+        return settings.getValue("trex-scratch-close-sound");
+     }
   }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/TVEffect.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/TVEffect.js
@@ -107,4 +107,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("tv-open-sound");
+     } else {
+        return settings.getValue("tv-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/TVGlitch.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/TVGlitch.js
@@ -119,4 +119,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("tv-glitch-open-sound");
+     } else {
+        return settings.getValue("tv-glitch-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/TeamRocket.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/TeamRocket.js
@@ -125,4 +125,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("team-rocket-open-sound");
+     } else {
+        return settings.getValue("team-rocket-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Wisps.js
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/effects/Wisps.js
@@ -133,4 +133,13 @@ var Effect = class Effect {
   static getActorScale(settings, forOpening, actor) {
     return {x: 1.0, y: 1.0};
   }
+
+  // The getSFX() is called from extension.js to get the sound effect file for this effect
+  static getSFX(settings, forOpening) {
+     if (forOpening) {
+        return settings.getValue("wisps-open-sound");
+     } else {
+        return settings.getValue("wisps-close-sound");
+     }
+  }
 }

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/metadata.json
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/metadata.json
@@ -1,7 +1,7 @@
 {
   "uuid": "CinnamonBurnMyWindows@klangman",
   "name": "Burn My Windows",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Window open/close/minimize/unminimize effects based on the Burn-My-Windows Gnome extension by Schneegans",
   "url": "https://github.com/klangman/CinnamonBurnMyWindows",
   "website": "https://github.com/klangman/CinnamonBurnMyWindows",

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/CinnamonBurnMyWindows@klangman.pot
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/CinnamonBurnMyWindows@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: CinnamonBurnMyWindows@klangman 1.0.3\n"
+"Project-Id-Version: CinnamonBurnMyWindows@klangman 1.0.4\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-10-15 21:53-0400\n"
+"POT-Creation-Date: 2026-08-02 12:18-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,31 +17,31 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.2/extension.js:208 6.2/extension.js:286 6.2/extension.js:614
+#. 6.2/extension.js:210 6.2/extension.js:311 6.2/extension.js:678
 msgid "Error"
 msgstr ""
 
-#. 6.2/extension.js:208
+#. 6.2/extension.js:210
 msgid "was NOT enabled"
 msgstr ""
 
-#. 6.2/extension.js:209 6.2/extension.js:287
+#. 6.2/extension.js:211 6.2/extension.js:312
 msgid "The existing extension"
 msgstr ""
 
-#. 6.2/extension.js:209
+#. 6.2/extension.js:211
 msgid "conflicts with this extension."
 msgstr ""
 
-#. 6.2/extension.js:286
+#. 6.2/extension.js:311
 msgid "minimize/unminimize effects can not be enabled"
 msgstr ""
 
-#. 6.2/extension.js:287
+#. 6.2/extension.js:312
 msgid "already handles minimize/unminimize animation events."
 msgstr ""
 
-#. 6.2/extension.js:615
+#. 6.2/extension.js:679
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore application specific effects can not be applied to "
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Aura Glow"
 msgstr ""
 
-#. effects/BrokenGlass.js:152
+#. effects/BrokenGlass.js:153
 msgid "Broken Glass"
 msgstr ""
 
@@ -155,32 +155,32 @@ msgid "Fire"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:180
+#. effects/Fire.js:189
 msgid "Default Fire"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:190
+#. effects/Fire.js:199
 msgid "Hell Fire"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:200
+#. effects/Fire.js:209
 msgid "Dark and Smutty"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:210
+#. effects/Fire.js:219
 msgid "Cold Breeze"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:220
+#. effects/Fire.js:229
 msgid "Santa is Coming"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:230
+#. effects/Fire.js:239
 msgid "Nuclear"
 msgstr ""
 
@@ -291,42 +291,42 @@ msgid "Mushroom"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:227
+#. effects/Mushroom.js:236
 msgid "8Bit Plumber"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:244
+#. effects/Mushroom.js:253
 msgid "New Bros 2"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:262
+#. effects/Mushroom.js:271
 msgid "The True North"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:280
+#. effects/Mushroom.js:289
 msgid "Red White and Blue"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:297
+#. effects/Mushroom.js:306
 msgid "Rainbow"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:314
+#. effects/Mushroom.js:323
 msgid "Cattuccino"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:332
+#. effects/Mushroom.js:341
 msgid "Dracula"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:349
+#. effects/Mushroom.js:358
 msgid "Sparkle"
 msgstr ""
 
@@ -495,6 +495,18 @@ msgstr ""
 msgid "Wisps"
 msgstr ""
 
+#. 6.2/CustomWidgets.py:509
+msgid "_Cancel"
+msgstr ""
+
+#. 6.2/CustomWidgets.py:510
+msgid "_Open"
+msgstr ""
+
+#. 6.2/CustomWidgets.py:520
+msgid "Sound files"
+msgstr ""
+
 #. metadata.json->name
 msgid "Burn My Windows"
 msgstr ""
@@ -543,11 +555,6 @@ msgstr ""
 
 #. 6.2->settings-schema.json->effect-settings->title
 msgid "Effect Specific Settings"
-msgstr ""
-
-#. 6.2->settings-schema.json->fire-custom-section->title
-#. 6.2->settings-schema.json->mushroom-custom-section->title
-msgid "Setting for the custom preset:"
 msgstr ""
 
 #. 6.2->settings-schema.json->random-section->title
@@ -718,6 +725,20 @@ msgstr ""
 msgid "Close window effect"
 msgstr ""
 
+#. 6.2->settings-schema.json->enable-sound->description
+msgid "Allow Burn My Windows to override cinnamon sound effects"
+msgstr ""
+
+#. 6.2->settings-schema.json->enable-sound->tooltip
+msgid ""
+"Allow Burn My Windows to override Cinnamon's window open/close/minimize "
+"sound effects with unique ones defined in the Effect Settings tab for each "
+"Burn My Windows effect. Note: Sounds will only play when Cinnamon's open/"
+"close/minimize sound effects are enabled under Cinnamon sounds settings. The "
+"default cinnamon sounds will be used unless a sound effect file is chosen "
+"for the active Burn My Windows effect."
+msgstr ""
+
 #. 6.2->settings-schema.json->dialog-special->description
 #. 6.2->settings-schema.json->power-dialog-special->description
 msgid "Special handling for dialog windows"
@@ -839,6 +860,56 @@ msgstr ""
 msgid "Reset to default"
 msgstr ""
 
+#. 6.2->settings-schema.json->apparition-open-sound->description
+#. 6.2->settings-schema.json->aura-glow-open-sound->description
+#. 6.2->settings-schema.json->doom-open-sound->description
+#. 6.2->settings-schema.json->energize-a-open-sound->description
+#. 6.2->settings-schema.json->energize-b-open-sound->description
+#. 6.2->settings-schema.json->fire-open-sound->description
+#. 6.2->settings-schema.json->focus-open-sound->description
+#. 6.2->settings-schema.json->glide-open-sound->description
+#. 6.2->settings-schema.json->glitch-open-sound->description
+#. 6.2->settings-schema.json->hexagon-open-sound->description
+#. 6.2->settings-schema.json->incinerate-open-sound->description
+#. 6.2->settings-schema.json->magiclamp-open-sound->description
+#. 6.2->settings-schema.json->mushroom-open-sound->description
+#. 6.2->settings-schema.json->pixelate-open-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-open-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-open-sound->description
+#. 6.2->settings-schema.json->portal-open-sound->description
+#. 6.2->settings-schema.json->rgbwarp-open-sound->description
+#. 6.2->settings-schema.json->team-rocket-open-sound->description
+#. 6.2->settings-schema.json->tv-open-sound->description
+#. 6.2->settings-schema.json->tv-glitch-open-sound->description
+#. 6.2->settings-schema.json->wisps-open-sound->description
+msgid "Sound on window appear events"
+msgstr ""
+
+#. 6.2->settings-schema.json->apparition-close-sound->description
+#. 6.2->settings-schema.json->aura-glow-close-sound->description
+#. 6.2->settings-schema.json->doom-close-sound->description
+#. 6.2->settings-schema.json->energize-a-close-sound->description
+#. 6.2->settings-schema.json->energize-b-close-sound->description
+#. 6.2->settings-schema.json->fire-close-sound->description
+#. 6.2->settings-schema.json->focus-close-sound->description
+#. 6.2->settings-schema.json->glide-close-sound->description
+#. 6.2->settings-schema.json->glitch-close-sound->description
+#. 6.2->settings-schema.json->hexagon-close-sound->description
+#. 6.2->settings-schema.json->incinerate-close-sound->description
+#. 6.2->settings-schema.json->magiclamp-close-sound->description
+#. 6.2->settings-schema.json->mushroom-close-sound->description
+#. 6.2->settings-schema.json->pixelate-close-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-close-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-close-sound->description
+#. 6.2->settings-schema.json->portal-close-sound->description
+#. 6.2->settings-schema.json->rgbwarp-close-sound->description
+#. 6.2->settings-schema.json->team-rocket-close-sound->description
+#. 6.2->settings-schema.json->tv-close-sound->description
+#. 6.2->settings-schema.json->tv-glitch-close-sound->description
+#. 6.2->settings-schema.json->wisps-close-sound->description
+msgid "Sound on window disappear events"
+msgstr ""
+
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 msgid "Random Color"
 msgstr ""
@@ -924,7 +995,7 @@ msgid "Custom"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire Preset"
+msgid "Fire effect style"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
@@ -1105,7 +1176,7 @@ msgid "This effects the quality and the costs of the animation"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom Preset"
+msgid "Mushroom effect style"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/ca.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-10-15 21:53-0400\n"
+"POT-Creation-Date: 2026-08-02 12:18-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,31 +18,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.6\n"
 
-#. 6.2/extension.js:208 6.2/extension.js:286 6.2/extension.js:614
+#. 6.2/extension.js:210 6.2/extension.js:311 6.2/extension.js:678
 msgid "Error"
 msgstr "Error"
 
-#. 6.2/extension.js:208
+#. 6.2/extension.js:210
 msgid "was NOT enabled"
 msgstr "no s'ha activat"
 
-#. 6.2/extension.js:209 6.2/extension.js:287
+#. 6.2/extension.js:211 6.2/extension.js:312
 msgid "The existing extension"
 msgstr "L'extensió existent"
 
-#. 6.2/extension.js:209
+#. 6.2/extension.js:211
 msgid "conflicts with this extension."
 msgstr "conflictivitza amb aquesta extensió."
 
-#. 6.2/extension.js:286
+#. 6.2/extension.js:311
 msgid "minimize/unminimize effects can not be enabled"
 msgstr "no es poden activar els efectes de minimitza/desminimitza"
 
-#. 6.2/extension.js:287
+#. 6.2/extension.js:312
 msgid "already handles minimize/unminimize animation events."
 msgstr "ja gestiona esdeveniments de minimitzat/desminimitzat"
 
-#. 6.2/extension.js:615
+#. 6.2/extension.js:679
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore application specific effects can not be applied to "
@@ -85,7 +85,7 @@ msgstr "Aparició"
 msgid "Aura Glow"
 msgstr "Brillantor de l'aura"
 
-#. effects/BrokenGlass.js:152
+#. effects/BrokenGlass.js:153
 msgid "Broken Glass"
 msgstr "Vidre trencat"
 
@@ -158,32 +158,32 @@ msgid "Fire"
 msgstr "Foc"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:180
+#. effects/Fire.js:189
 msgid "Default Fire"
 msgstr "Foc per defecte"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:190
+#. effects/Fire.js:199
 msgid "Hell Fire"
 msgstr "Foc infernal"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:200
+#. effects/Fire.js:209
 msgid "Dark and Smutty"
 msgstr "Fosc i brut"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:210
+#. effects/Fire.js:219
 msgid "Cold Breeze"
 msgstr "Brisa freda"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:220
+#. effects/Fire.js:229
 msgid "Santa is Coming"
 msgstr "Ja arriba el Pare Noel"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:230
+#. effects/Fire.js:239
 msgid "Nuclear"
 msgstr "Nuclear"
 
@@ -294,42 +294,42 @@ msgid "Mushroom"
 msgstr "Bolet"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:227
+#. effects/Mushroom.js:236
 msgid "8Bit Plumber"
 msgstr "Fontaner de 8 bits"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:244
+#. effects/Mushroom.js:253
 msgid "New Bros 2"
 msgstr "New Bros 2"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:262
+#. effects/Mushroom.js:271
 msgid "The True North"
 msgstr "El veritable nord"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:280
+#. effects/Mushroom.js:289
 msgid "Red White and Blue"
 msgstr "Vermell, blanc i blau"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:297
+#. effects/Mushroom.js:306
 msgid "Rainbow"
 msgstr "Arc de Sant Martí"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:314
+#. effects/Mushroom.js:323
 msgid "Cattuccino"
 msgstr "Cattuccino"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:332
+#. effects/Mushroom.js:341
 msgid "Dracula"
 msgstr "Dràcula"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:349
+#. effects/Mushroom.js:358
 msgid "Sparkle"
 msgstr "Resplendor"
 
@@ -498,6 +498,19 @@ msgstr "Team Rocket"
 msgid "Wisps"
 msgstr "Motes"
 
+#. 6.2/CustomWidgets.py:509
+msgid "_Cancel"
+msgstr ""
+
+#. 6.2/CustomWidgets.py:510
+#, fuzzy
+msgid "_Open"
+msgstr "Obrir"
+
+#. 6.2/CustomWidgets.py:520
+msgid "Sound files"
+msgstr ""
+
 #. metadata.json->name
 msgid "Burn My Windows"
 msgstr "Crema les meves finestres (Burn My Windows)"
@@ -549,11 +562,6 @@ msgstr "Selector d'efecte"
 #. 6.2->settings-schema.json->effect-settings->title
 msgid "Effect Specific Settings"
 msgstr "Opcions específiques d'efectes"
-
-#. 6.2->settings-schema.json->fire-custom-section->title
-#. 6.2->settings-schema.json->mushroom-custom-section->title
-msgid "Setting for the custom preset:"
-msgstr "Configuració per l'ajust personalitzat"
 
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
@@ -747,6 +755,20 @@ msgstr "Efecte d'obertura de finestra"
 msgid "Close window effect"
 msgstr "Efecte de tancament de finestra"
 
+#. 6.2->settings-schema.json->enable-sound->description
+msgid "Allow Burn My Windows to override cinnamon sound effects"
+msgstr ""
+
+#. 6.2->settings-schema.json->enable-sound->tooltip
+msgid ""
+"Allow Burn My Windows to override Cinnamon's window open/close/minimize "
+"sound effects with unique ones defined in the Effect Settings tab for each "
+"Burn My Windows effect. Note: Sounds will only play when Cinnamon's open/"
+"close/minimize sound effects are enabled under Cinnamon sounds settings. The "
+"default cinnamon sounds will be used unless a sound effect file is chosen "
+"for the active Burn My Windows effect."
+msgstr ""
+
 #. 6.2->settings-schema.json->dialog-special->description
 #. 6.2->settings-schema.json->power-dialog-special->description
 msgid "Special handling for dialog windows"
@@ -875,6 +897,56 @@ msgstr "Duració de l'efecte (ms)"
 msgid "Reset to default"
 msgstr "Restablir a per defecte"
 
+#. 6.2->settings-schema.json->apparition-open-sound->description
+#. 6.2->settings-schema.json->aura-glow-open-sound->description
+#. 6.2->settings-schema.json->doom-open-sound->description
+#. 6.2->settings-schema.json->energize-a-open-sound->description
+#. 6.2->settings-schema.json->energize-b-open-sound->description
+#. 6.2->settings-schema.json->fire-open-sound->description
+#. 6.2->settings-schema.json->focus-open-sound->description
+#. 6.2->settings-schema.json->glide-open-sound->description
+#. 6.2->settings-schema.json->glitch-open-sound->description
+#. 6.2->settings-schema.json->hexagon-open-sound->description
+#. 6.2->settings-schema.json->incinerate-open-sound->description
+#. 6.2->settings-schema.json->magiclamp-open-sound->description
+#. 6.2->settings-schema.json->mushroom-open-sound->description
+#. 6.2->settings-schema.json->pixelate-open-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-open-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-open-sound->description
+#. 6.2->settings-schema.json->portal-open-sound->description
+#. 6.2->settings-schema.json->rgbwarp-open-sound->description
+#. 6.2->settings-schema.json->team-rocket-open-sound->description
+#. 6.2->settings-schema.json->tv-open-sound->description
+#. 6.2->settings-schema.json->tv-glitch-open-sound->description
+#. 6.2->settings-schema.json->wisps-open-sound->description
+msgid "Sound on window appear events"
+msgstr ""
+
+#. 6.2->settings-schema.json->apparition-close-sound->description
+#. 6.2->settings-schema.json->aura-glow-close-sound->description
+#. 6.2->settings-schema.json->doom-close-sound->description
+#. 6.2->settings-schema.json->energize-a-close-sound->description
+#. 6.2->settings-schema.json->energize-b-close-sound->description
+#. 6.2->settings-schema.json->fire-close-sound->description
+#. 6.2->settings-schema.json->focus-close-sound->description
+#. 6.2->settings-schema.json->glide-close-sound->description
+#. 6.2->settings-schema.json->glitch-close-sound->description
+#. 6.2->settings-schema.json->hexagon-close-sound->description
+#. 6.2->settings-schema.json->incinerate-close-sound->description
+#. 6.2->settings-schema.json->magiclamp-close-sound->description
+#. 6.2->settings-schema.json->mushroom-close-sound->description
+#. 6.2->settings-schema.json->pixelate-close-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-close-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-close-sound->description
+#. 6.2->settings-schema.json->portal-close-sound->description
+#. 6.2->settings-schema.json->rgbwarp-close-sound->description
+#. 6.2->settings-schema.json->team-rocket-close-sound->description
+#. 6.2->settings-schema.json->tv-close-sound->description
+#. 6.2->settings-schema.json->tv-glitch-close-sound->description
+#. 6.2->settings-schema.json->wisps-close-sound->description
+msgid "Sound on window disappear events"
+msgstr ""
+
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 msgid "Random Color"
 msgstr "Color aleatori"
@@ -963,8 +1035,8 @@ msgid "Custom"
 msgstr "Personalitzat"
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire Preset"
-msgstr "Foc predefinit"
+msgid "Fire effect style"
+msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
 msgid "Fire Movement Speed"
@@ -1160,7 +1232,8 @@ msgid "This effects the quality and the costs of the animation"
 msgstr "Això afecta a la qualitat i el cost de l'animació"
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom Preset"
+#, fuzzy
+msgid "Mushroom effect style"
 msgstr "Predefinició de Bolets"
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/da.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/da.po
@@ -6,9 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 1.0.3\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-extensions/"
-"issues\n"
-"POT-Creation-Date: 2025-10-15 21:53-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
+"extensions/issues\n"
+"POT-Creation-Date: 2026-08-02 12:18-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Alan Mortensen <over.tackiness223@passinbox.com>\n"
 "Language-Team: \n"
@@ -18,39 +18,40 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.2/extension.js:208 6.2/extension.js:286 6.2/extension.js:614
+#. 6.2/extension.js:210 6.2/extension.js:311 6.2/extension.js:678
 msgid "Error"
 msgstr "Fejl"
 
-#. 6.2/extension.js:208
+#. 6.2/extension.js:210
 msgid "was NOT enabled"
 msgstr "var ikke aktiveret"
 
-#. 6.2/extension.js:209 6.2/extension.js:287
+#. 6.2/extension.js:211 6.2/extension.js:312
 msgid "The existing extension"
 msgstr "Den eksisterende udvidelse"
 
-#. 6.2/extension.js:209
+#. 6.2/extension.js:211
 msgid "conflicts with this extension."
 msgstr "er i konflikt med denne udvidelse."
 
-#. 6.2/extension.js:286
+#. 6.2/extension.js:311
 msgid "minimize/unminimize effects can not be enabled"
 msgstr "effekter til minimering/gendan fra minimeret kan ikke aktiveres"
 
-#. 6.2/extension.js:287
+#. 6.2/extension.js:312
 msgid "already handles minimize/unminimize animation events."
 msgstr ""
 "håndterer allerede animationshændelser til minimering/gendan fra minimeret."
 
-#. 6.2/extension.js:615
+#. 6.2/extension.js:679
 msgid ""
-"Unable to determine the application or the WM_CLASS of the previously focused "
-"window, therefore application specific effects can not be applied to that window"
+"Unable to determine the application or the WM_CLASS of the previously "
+"focused window, therefore application specific effects can not be applied to "
+"that window"
 msgstr ""
 "Det er ikke muligt at bestemme programmet eller WM_CLASS for det vindue, der "
-"tidligere var i fokus, og derfor kan programspecifikke effekter ikke anvendes "
-"på dette vindue"
+"tidligere var i fokus, og derfor kan programspecifikke effekter ikke "
+"anvendes på dette vindue"
 
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
@@ -86,7 +87,7 @@ msgstr "Tilsynekomst"
 msgid "Aura Glow"
 msgstr "Auraglød"
 
-#. effects/BrokenGlass.js:152
+#. effects/BrokenGlass.js:153
 msgid "Broken Glass"
 msgstr "Ituslået glas"
 
@@ -159,32 +160,32 @@ msgid "Fire"
 msgstr "Ild"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:180
+#. effects/Fire.js:189
 msgid "Default Fire"
 msgstr "Ildstandard"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:190
+#. effects/Fire.js:199
 msgid "Hell Fire"
 msgstr "Helvedsild"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:200
+#. effects/Fire.js:209
 msgid "Dark and Smutty"
 msgstr "Mørk og smudsig"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:210
+#. effects/Fire.js:219
 msgid "Cold Breeze"
 msgstr "Kold brise"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:220
+#. effects/Fire.js:229
 msgid "Santa is Coming"
 msgstr "Julemanden er på vej"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:230
+#. effects/Fire.js:239
 msgid "Nuclear"
 msgstr "Kerne"
 
@@ -295,42 +296,42 @@ msgid "Mushroom"
 msgstr "Svamp"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:227
+#. effects/Mushroom.js:236
 msgid "8Bit Plumber"
 msgstr "8 bit-blikkenslager"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:244
+#. effects/Mushroom.js:253
 msgid "New Bros 2"
 msgstr "New Bros 2"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:262
+#. effects/Mushroom.js:271
 msgid "The True North"
 msgstr "Geografisk nord"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:280
+#. effects/Mushroom.js:289
 msgid "Red White and Blue"
 msgstr "Rød, hvid og blå"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:297
+#. effects/Mushroom.js:306
 msgid "Rainbow"
 msgstr "Regnbue"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:314
+#. effects/Mushroom.js:323
 msgid "Cattuccino"
 msgstr "Cattuccino"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:332
+#. effects/Mushroom.js:341
 msgid "Dracula"
 msgstr "Dracula"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:349
+#. effects/Mushroom.js:358
 msgid "Sparkle"
 msgstr "Stråle"
 
@@ -499,6 +500,19 @@ msgstr "Team Rocket"
 msgid "Wisps"
 msgstr "Lysglimt"
 
+#. 6.2/CustomWidgets.py:509
+msgid "_Cancel"
+msgstr ""
+
+#. 6.2/CustomWidgets.py:510
+#, fuzzy
+msgid "_Open"
+msgstr "Åbn"
+
+#. 6.2/CustomWidgets.py:520
+msgid "Sound files"
+msgstr ""
+
 #. metadata.json->name
 msgid "Burn My Windows"
 msgstr "Brænd mine vinduer"
@@ -508,8 +522,8 @@ msgid ""
 "Window open/close/minimize/unminimize effects based on the Burn-My-Windows "
 "Gnome extension by Schneegans"
 msgstr ""
-"Effekter til åbning/lukning/minimering/gendan fra minimeret af vinduer baseret "
-"på Gnome-udvidelsen Burn-My-Windows af Schneegans"
+"Effekter til åbning/lukning/minimering/gendan fra minimeret af vinduer "
+"baseret på Gnome-udvidelsen Burn-My-Windows af Schneegans"
 
 #. 6.2->settings-schema.json->general-page->title
 msgid "General"
@@ -551,11 +565,6 @@ msgstr "Effektvælger"
 msgid "Effect Specific Settings"
 msgstr "Effektspecifikke indstillinger"
 
-#. 6.2->settings-schema.json->fire-custom-section->title
-#. 6.2->settings-schema.json->mushroom-custom-section->title
-msgid "Setting for the custom preset:"
-msgstr "Indstillinger for den tilpassede forudindstilling:"
-
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
 msgstr "Effekter inkluderet i de randomiserede sæt:"
@@ -575,36 +584,36 @@ msgid ""
 "Version: ext-version\n"
 "\n"
 "Ported to Cinnamon by Kevin Langman\n"
-"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / <a "
-"href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/new\">Report an "
-"issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/"
-"view/103\">Website</a>\n"
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
+"new\">Report an issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/"
+"extensions/view/103\">Website</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
 "<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a> / <a "
 "href=\"https://ko-fi.com/schneegans\">Ko-fi</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
-"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-effect\">Github</"
-"a>"
+"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
+"effect\">Github</a>"
 msgstr ""
 "\n"
 "<b>Opløs din vinduer med stil.</b>\n"
 "Version: ext-version\n"
 "\n"
 "Porteret til Cinnamon af Kevin Langman\n"
-"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / <a "
-"href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/new\">Rapportér "
-"et problem</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/"
-"view/103\">Website</a>\n"
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
+"new\">Rapportér et problem</a> / <a href=\"https://cinnamon-"
+"spices.linuxmint.com/extensions/view/103\">Website</a>\n"
 "\n"
 "Baseret på Burn-My-Windows-koden af Schneegans og bidragydere\n"
 "<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a> / <a "
 "href=\"https://ko-fi.com/schneegans\">Ko-fi</a>\n"
 "\n"
 "The Magic Lamp Effect er porteret fra kode af hermes83\n"
-"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-effect\">Github</"
-"a>"
+"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
+"effect\">Github</a>"
 
 #. 6.2->settings-schema.json->app-rules->description
 msgid "Application Specific Rules"
@@ -648,11 +657,11 @@ msgstr "Tilføj indgang til programmet med det senest fokuserede vindue"
 
 #. 6.2->settings-schema.json->app-rules-button->tooltip
 msgid ""
-"Focus a window you want to enable application specific setting for then return "
-"here and press this button."
+"Focus a window you want to enable application specific setting for then "
+"return here and press this button."
 msgstr ""
-"Bring det vindue, du vil aktivere programspecifikke indstillinger for, i fokus "
-"og vend derefter tilbage hertil og tryk på denne knap."
+"Bring det vindue, du vil aktivere programspecifikke indstillinger for, i "
+"fokus og vend derefter tilbage hertil og tryk på denne knap."
 
 #. 6.2->settings-schema.json->random-include->description
 msgid "Effects included in the randomized sets"
@@ -660,9 +669,9 @@ msgstr "Effekter inkluderet i de randomiserede sæt"
 
 #. 6.2->settings-schema.json->random-include->tooltip
 msgid ""
-"Defines which effects are included in the randomized sets for each window event "
-"type. When 'Randomized' is selected for any event on the General tab these sets "
-"are used."
+"Defines which effects are included in the randomized sets for each window "
+"event type. When 'Randomized' is selected for any event on the General tab "
+"these sets are used."
 msgstr ""
 "Definerer, hvilke effekter der er inkluderet i de randomiserede sæt for hver "
 "vindueshændelsestype. Når “Randomiseret” er valgt for en begivenhed på "
@@ -748,6 +757,20 @@ msgstr "Åbn vindue-effekt"
 msgid "Close window effect"
 msgstr "Luk vindue-effekt"
 
+#. 6.2->settings-schema.json->enable-sound->description
+msgid "Allow Burn My Windows to override cinnamon sound effects"
+msgstr ""
+
+#. 6.2->settings-schema.json->enable-sound->tooltip
+msgid ""
+"Allow Burn My Windows to override Cinnamon's window open/close/minimize "
+"sound effects with unique ones defined in the Effect Settings tab for each "
+"Burn My Windows effect. Note: Sounds will only play when Cinnamon's open/"
+"close/minimize sound effects are enabled under Cinnamon sounds settings. The "
+"default cinnamon sounds will be used unless a sound effect file is chosen "
+"for the active Burn My Windows effect."
+msgstr ""
+
 #. 6.2->settings-schema.json->dialog-special->description
 #. 6.2->settings-schema.json->power-dialog-special->description
 msgid "Special handling for dialog windows"
@@ -760,9 +783,9 @@ msgid ""
 "specific settings that may have been defined."
 msgstr ""
 "Giver dig mulighed for at definere særlige indstillinger til håndtering af "
-"dialogvinduer (f.eks. dialogvinduer til åbning af filer). Disse indstillinger "
-"tilsidesætter eventuelle programspecifikke indstillinger, der måtte være "
-"defineret."
+"dialogvinduer (f.eks. dialogvinduer til åbning af filer). Disse "
+"indstillinger tilsidesætter eventuelle programspecifikke indstillinger, der "
+"måtte være defineret."
 
 #. 6.2->settings-schema.json->dialog-open-effect->description
 #. 6.2->settings-schema.json->power-dialog-open-effect->description
@@ -798,17 +821,18 @@ msgstr "Brug forskellige effekter, når der køres på batteriet"
 
 #. 6.2->settings-schema.json->power-onbattery->tooltip
 msgid ""
-"When enabled, a set of options will appear allowing you to define which effects "
-"(if any) will be used when running on battery power and the battery charge "
-"state is less than the set limit. These settings will take precedence over both "
-"the general settings and any application specific settings when the battery "
-"charge state condition is met."
+"When enabled, a set of options will appear allowing you to define which "
+"effects (if any) will be used when running on battery power and the battery "
+"charge state is less than the set limit. These settings will take precedence "
+"over both the general settings and any application specific settings when "
+"the battery charge state condition is met."
 msgstr ""
 "Når denne funktion er aktiveret, vises en række indstillinger, hvor du kan "
 "angive, hvilke effekter (hvis nogen) der skal anvendes, når enheden kører på "
 "batteri, og batteriniveauet er lavere end den indstillede grænse. Disse "
 "indstillinger har forrang for både de generelle indstillinger og eventuelle "
-"programspecifikke indstillinger, når betingelsen for batteriniveauet er opfyldt."
+"programspecifikke indstillinger, når betingelsen for batteriniveauet er "
+"opfyldt."
 
 #. 6.2->settings-schema.json->power-percent->description
 msgid "When battery is less than (percent)"
@@ -880,6 +904,56 @@ msgstr "Effektvarighed (ms)"
 msgid "Reset to default"
 msgstr "Gendan standardindstillinger"
 
+#. 6.2->settings-schema.json->apparition-open-sound->description
+#. 6.2->settings-schema.json->aura-glow-open-sound->description
+#. 6.2->settings-schema.json->doom-open-sound->description
+#. 6.2->settings-schema.json->energize-a-open-sound->description
+#. 6.2->settings-schema.json->energize-b-open-sound->description
+#. 6.2->settings-schema.json->fire-open-sound->description
+#. 6.2->settings-schema.json->focus-open-sound->description
+#. 6.2->settings-schema.json->glide-open-sound->description
+#. 6.2->settings-schema.json->glitch-open-sound->description
+#. 6.2->settings-schema.json->hexagon-open-sound->description
+#. 6.2->settings-schema.json->incinerate-open-sound->description
+#. 6.2->settings-schema.json->magiclamp-open-sound->description
+#. 6.2->settings-schema.json->mushroom-open-sound->description
+#. 6.2->settings-schema.json->pixelate-open-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-open-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-open-sound->description
+#. 6.2->settings-schema.json->portal-open-sound->description
+#. 6.2->settings-schema.json->rgbwarp-open-sound->description
+#. 6.2->settings-schema.json->team-rocket-open-sound->description
+#. 6.2->settings-schema.json->tv-open-sound->description
+#. 6.2->settings-schema.json->tv-glitch-open-sound->description
+#. 6.2->settings-schema.json->wisps-open-sound->description
+msgid "Sound on window appear events"
+msgstr ""
+
+#. 6.2->settings-schema.json->apparition-close-sound->description
+#. 6.2->settings-schema.json->aura-glow-close-sound->description
+#. 6.2->settings-schema.json->doom-close-sound->description
+#. 6.2->settings-schema.json->energize-a-close-sound->description
+#. 6.2->settings-schema.json->energize-b-close-sound->description
+#. 6.2->settings-schema.json->fire-close-sound->description
+#. 6.2->settings-schema.json->focus-close-sound->description
+#. 6.2->settings-schema.json->glide-close-sound->description
+#. 6.2->settings-schema.json->glitch-close-sound->description
+#. 6.2->settings-schema.json->hexagon-close-sound->description
+#. 6.2->settings-schema.json->incinerate-close-sound->description
+#. 6.2->settings-schema.json->magiclamp-close-sound->description
+#. 6.2->settings-schema.json->mushroom-close-sound->description
+#. 6.2->settings-schema.json->pixelate-close-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-close-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-close-sound->description
+#. 6.2->settings-schema.json->portal-close-sound->description
+#. 6.2->settings-schema.json->rgbwarp-close-sound->description
+#. 6.2->settings-schema.json->team-rocket-close-sound->description
+#. 6.2->settings-schema.json->tv-close-sound->description
+#. 6.2->settings-schema.json->tv-glitch-close-sound->description
+#. 6.2->settings-schema.json->wisps-close-sound->description
+msgid "Sound on window disappear events"
+msgstr ""
+
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 msgid "Random Color"
 msgstr "Tilfældig farve"
@@ -936,9 +1010,10 @@ msgid ""
 "unminimize animation completes at the right location. This is a hack fix for "
 "the Doom effect until I can find a proper fix"
 msgstr ""
-"Anvend en forskydning til y-aksen for vinduets målposition, så åbne/gendan fra "
-"minimeret-animationen afsluttes på det rigtige sted. Dette er en midlertidig "
-"løsning på Doom-effekten, indtil jeg kan finde en ordentlig løsning."
+"Anvend en forskydning til y-aksen for vinduets målposition, så åbne/gendan "
+"fra minimeret-animationen afsluttes på det rigtige sted. Dette er en "
+"midlertidig løsning på Doom-effekten, indtil jeg kan finde en ordentlig "
+"løsning."
 
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
@@ -968,8 +1043,8 @@ msgid "Custom"
 msgstr "Brugerdefineret"
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire Preset"
-msgstr "Forudindstilling"
+msgid "Fire effect style"
+msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
 msgid "Fire Movement Speed"
@@ -989,8 +1064,8 @@ msgstr "Anvend en tilfældig farve (tilsidesætter andre farveindstillinger)"
 
 #. 6.2->settings-schema.json->fire-random-color->tooltip
 msgid ""
-"Use a random fire color. This setting will override any preset or custom colors "
-"settings you select."
+"Use a random fire color. This setting will override any preset or custom "
+"colors settings you select."
 msgstr ""
 "Anvend en tilfældig farve til ilden. Denne indstilling tilsidesætter alle "
 "forudindstillede eller brugerdefinerede farveindstillinger, du vælger."
@@ -1005,8 +1080,8 @@ msgstr "Sløringskvalitet"
 
 #. 6.2->settings-schema.json->focus-blur-quality->tooltip
 msgid ""
-"The Quality of the Blur (Setting this too high may increase GPU load and affect "
-"performance)"
+"The Quality of the Blur (Setting this too high may increase GPU load and "
+"affect performance)"
 msgstr ""
 "Kvaliteten af sløringen (hvis denne indstilling er for høj, kan det øge GPU-"
 "belastningen og påvirke ydeevnen)."
@@ -1087,13 +1162,14 @@ msgstr "Effekttypen"
 #. 6.2->settings-schema.json->magiclamp-effect->tooltip
 msgid ""
 "The effect can be a smooth curve or a wavy animation. The random option will "
-"randomly choose between the two and the Appear/Disappear options use different "
-"effects whether a window is appearing or disappearing from the screen"
+"randomly choose between the two and the Appear/Disappear options use "
+"different effects whether a window is appearing or disappearing from the "
+"screen"
 msgstr ""
 "Effekten kan være en jævn kurve eller en bølget animation. Den tilfældige "
-"indstilling vælger tilfældigt mellem de to, og indstillingerne Komme til syne/"
-"Forsvinde bruger forskellige effekter, alt efter om et vindue kommer til syne "
-"eller forsvinder fra skærmen."
+"indstilling vælger tilfældigt mellem de to, og indstillingerne Komme til "
+"syne/Forsvinde bruger forskellige effekter, alt efter om et vindue kommer "
+"til syne eller forsvinder fra skærmen."
 
 #. 6.2->settings-schema.json->magiclamp-edge->options
 msgid "Top"
@@ -1134,10 +1210,11 @@ msgstr "Forskydning af åbne-/lukke-kant"
 
 #. 6.2->settings-schema.json->magiclamp-edge-offset->tooltip
 msgid ""
-"The offset from the top or left of the \"Open/Close Edge\" that the animation "
-"should use as the origin/target of the animation. This is a percentage of the "
-"monitors width/height and it does not apply to minimize/unminimize events or "
-"when the \"Open/Close Edge\" is set to \"Edge closest to mouse pointer\""
+"The offset from the top or left of the \"Open/Close Edge\" that the "
+"animation should use as the origin/target of the animation. This is a "
+"percentage of the monitors width/height and it does not apply to minimize/"
+"unminimize events or when the \"Open/Close Edge\" is set to \"Edge closest "
+"to mouse pointer\""
 msgstr ""
 "Forskydningen fra toppen eller venstre side af “Åbne-/lukke-kanten”, som "
 "animationen skal bruge som udgangspunkt/mål for animationen. Dette er en "
@@ -1162,7 +1239,8 @@ msgid "This effects the quality and the costs of the animation"
 msgstr "Påvirker animationens kvalitet og omkostning"
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom Preset"
+#, fuzzy
+msgid "Mushroom effect style"
 msgstr "Forudindstilling for Svamp"
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/es.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-10-15 21:53-0400\n"
+"POT-Creation-Date: 2026-08-02 12:18-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,31 +17,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.7\n"
 
-#. 6.2/extension.js:208 6.2/extension.js:286 6.2/extension.js:614
+#. 6.2/extension.js:210 6.2/extension.js:311 6.2/extension.js:678
 msgid "Error"
 msgstr "Error"
 
-#. 6.2/extension.js:208
+#. 6.2/extension.js:210
 msgid "was NOT enabled"
 msgstr "no estaba habilitado"
 
-#. 6.2/extension.js:209 6.2/extension.js:287
+#. 6.2/extension.js:211 6.2/extension.js:312
 msgid "The existing extension"
 msgstr "La extensión existente"
 
-#. 6.2/extension.js:209
+#. 6.2/extension.js:211
 msgid "conflicts with this extension."
 msgstr "entra en conflicto con esta extensión."
 
-#. 6.2/extension.js:286
+#. 6.2/extension.js:311
 msgid "minimize/unminimize effects can not be enabled"
 msgstr "no se pueden activar los efectos de minimizar/maximizar"
 
-#. 6.2/extension.js:287
+#. 6.2/extension.js:312
 msgid "already handles minimize/unminimize animation events."
 msgstr "ya maneja eventos de animación de minimizar/maximizar."
 
-#. 6.2/extension.js:615
+#. 6.2/extension.js:679
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore application specific effects can not be applied to "
@@ -85,7 +85,7 @@ msgstr "Aparición"
 msgid "Aura Glow"
 msgstr "Brillo del aura"
 
-#. effects/BrokenGlass.js:152
+#. effects/BrokenGlass.js:153
 msgid "Broken Glass"
 msgstr "Vidrio roto"
 
@@ -158,32 +158,32 @@ msgid "Fire"
 msgstr "Fuego"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:180
+#. effects/Fire.js:189
 msgid "Default Fire"
 msgstr "Fuego predeterminado"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:190
+#. effects/Fire.js:199
 msgid "Hell Fire"
 msgstr "Fuego infernal"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:200
+#. effects/Fire.js:209
 msgid "Dark and Smutty"
 msgstr "Oscuro y sucio"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:210
+#. effects/Fire.js:219
 msgid "Cold Breeze"
 msgstr "Brisa fría"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:220
+#. effects/Fire.js:229
 msgid "Santa is Coming"
 msgstr "Ya viene Papá Noel"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:230
+#. effects/Fire.js:239
 msgid "Nuclear"
 msgstr "Nuclear"
 
@@ -294,42 +294,42 @@ msgid "Mushroom"
 msgstr "Setas"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:227
+#. effects/Mushroom.js:236
 msgid "8Bit Plumber"
 msgstr "Fontanero de 8 bits"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:244
+#. effects/Mushroom.js:253
 msgid "New Bros 2"
 msgstr "New Bros 2"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:262
+#. effects/Mushroom.js:271
 msgid "The True North"
 msgstr "Verdadero norte"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:280
+#. effects/Mushroom.js:289
 msgid "Red White and Blue"
 msgstr "Rojo, blanco y azul"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:297
+#. effects/Mushroom.js:306
 msgid "Rainbow"
 msgstr "Arcoiris"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:314
+#. effects/Mushroom.js:323
 msgid "Cattuccino"
 msgstr "Cattuccino"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:332
+#. effects/Mushroom.js:341
 msgid "Dracula"
 msgstr "Drácula"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:349
+#. effects/Mushroom.js:358
 msgid "Sparkle"
 msgstr "Destello"
 
@@ -498,6 +498,19 @@ msgstr "Equipo Rocket"
 msgid "Wisps"
 msgstr "Motas"
 
+#. 6.2/CustomWidgets.py:509
+msgid "_Cancel"
+msgstr ""
+
+#. 6.2/CustomWidgets.py:510
+#, fuzzy
+msgid "_Open"
+msgstr "Abrir"
+
+#. 6.2/CustomWidgets.py:520
+msgid "Sound files"
+msgstr ""
+
 #. metadata.json->name
 msgid "Burn My Windows"
 msgstr "Burn My Windows"
@@ -549,11 +562,6 @@ msgstr "Selector de efecto"
 #. 6.2->settings-schema.json->effect-settings->title
 msgid "Effect Specific Settings"
 msgstr "Ajustes específicos del efecto"
-
-#. 6.2->settings-schema.json->fire-custom-section->title
-#. 6.2->settings-schema.json->mushroom-custom-section->title
-msgid "Setting for the custom preset:"
-msgstr "Configuración para el preajuste personalizado:"
 
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
@@ -748,6 +756,20 @@ msgstr "Efecto para abrir ventana"
 msgid "Close window effect"
 msgstr "Efecto para cerrar ventana"
 
+#. 6.2->settings-schema.json->enable-sound->description
+msgid "Allow Burn My Windows to override cinnamon sound effects"
+msgstr ""
+
+#. 6.2->settings-schema.json->enable-sound->tooltip
+msgid ""
+"Allow Burn My Windows to override Cinnamon's window open/close/minimize "
+"sound effects with unique ones defined in the Effect Settings tab for each "
+"Burn My Windows effect. Note: Sounds will only play when Cinnamon's open/"
+"close/minimize sound effects are enabled under Cinnamon sounds settings. The "
+"default cinnamon sounds will be used unless a sound effect file is chosen "
+"for the active Burn My Windows effect."
+msgstr ""
+
 #. 6.2->settings-schema.json->dialog-special->description
 #. 6.2->settings-schema.json->power-dialog-special->description
 msgid "Special handling for dialog windows"
@@ -881,6 +903,56 @@ msgstr "Duración del efecto (ms)"
 msgid "Reset to default"
 msgstr "Restablecer a valores por defecto"
 
+#. 6.2->settings-schema.json->apparition-open-sound->description
+#. 6.2->settings-schema.json->aura-glow-open-sound->description
+#. 6.2->settings-schema.json->doom-open-sound->description
+#. 6.2->settings-schema.json->energize-a-open-sound->description
+#. 6.2->settings-schema.json->energize-b-open-sound->description
+#. 6.2->settings-schema.json->fire-open-sound->description
+#. 6.2->settings-schema.json->focus-open-sound->description
+#. 6.2->settings-schema.json->glide-open-sound->description
+#. 6.2->settings-schema.json->glitch-open-sound->description
+#. 6.2->settings-schema.json->hexagon-open-sound->description
+#. 6.2->settings-schema.json->incinerate-open-sound->description
+#. 6.2->settings-schema.json->magiclamp-open-sound->description
+#. 6.2->settings-schema.json->mushroom-open-sound->description
+#. 6.2->settings-schema.json->pixelate-open-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-open-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-open-sound->description
+#. 6.2->settings-schema.json->portal-open-sound->description
+#. 6.2->settings-schema.json->rgbwarp-open-sound->description
+#. 6.2->settings-schema.json->team-rocket-open-sound->description
+#. 6.2->settings-schema.json->tv-open-sound->description
+#. 6.2->settings-schema.json->tv-glitch-open-sound->description
+#. 6.2->settings-schema.json->wisps-open-sound->description
+msgid "Sound on window appear events"
+msgstr ""
+
+#. 6.2->settings-schema.json->apparition-close-sound->description
+#. 6.2->settings-schema.json->aura-glow-close-sound->description
+#. 6.2->settings-schema.json->doom-close-sound->description
+#. 6.2->settings-schema.json->energize-a-close-sound->description
+#. 6.2->settings-schema.json->energize-b-close-sound->description
+#. 6.2->settings-schema.json->fire-close-sound->description
+#. 6.2->settings-schema.json->focus-close-sound->description
+#. 6.2->settings-schema.json->glide-close-sound->description
+#. 6.2->settings-schema.json->glitch-close-sound->description
+#. 6.2->settings-schema.json->hexagon-close-sound->description
+#. 6.2->settings-schema.json->incinerate-close-sound->description
+#. 6.2->settings-schema.json->magiclamp-close-sound->description
+#. 6.2->settings-schema.json->mushroom-close-sound->description
+#. 6.2->settings-schema.json->pixelate-close-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-close-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-close-sound->description
+#. 6.2->settings-schema.json->portal-close-sound->description
+#. 6.2->settings-schema.json->rgbwarp-close-sound->description
+#. 6.2->settings-schema.json->team-rocket-close-sound->description
+#. 6.2->settings-schema.json->tv-close-sound->description
+#. 6.2->settings-schema.json->tv-glitch-close-sound->description
+#. 6.2->settings-schema.json->wisps-close-sound->description
+msgid "Sound on window disappear events"
+msgstr ""
+
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 msgid "Random Color"
 msgstr "Color aleatorio"
@@ -970,8 +1042,8 @@ msgid "Custom"
 msgstr "Personalizar"
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire Preset"
-msgstr "Preajuste de fuego"
+msgid "Fire effect style"
+msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
 msgid "Fire Movement Speed"
@@ -1168,7 +1240,8 @@ msgid "This effects the quality and the costs of the animation"
 msgstr "Esto repercute en la calidad y el coste de la animación"
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom Preset"
+#, fuzzy
+msgid "Mushroom effect style"
 msgstr "Preajuste de setas"
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/fi.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/fi.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.5\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-10-15 21:53-0400\n"
+"POT-Creation-Date: 2026-08-02 12:18-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -18,31 +18,31 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.2/extension.js:208 6.2/extension.js:286 6.2/extension.js:614
+#. 6.2/extension.js:210 6.2/extension.js:311 6.2/extension.js:678
 msgid "Error"
 msgstr "Virhe"
 
-#. 6.2/extension.js:208
+#. 6.2/extension.js:210
 msgid "was NOT enabled"
 msgstr "eI ollut käytössä"
 
-#. 6.2/extension.js:209 6.2/extension.js:287
+#. 6.2/extension.js:211 6.2/extension.js:312
 msgid "The existing extension"
 msgstr "Nykyinen laajennus"
 
-#. 6.2/extension.js:209
+#. 6.2/extension.js:211
 msgid "conflicts with this extension."
 msgstr "on ristiriidassa tämän laajennuksen kanssa."
 
-#. 6.2/extension.js:286
+#. 6.2/extension.js:311
 msgid "minimize/unminimize effects can not be enabled"
 msgstr "tehosteita minimoi/palauta ei voi ottaa käyttöön"
 
-#. 6.2/extension.js:287
+#. 6.2/extension.js:312
 msgid "already handles minimize/unminimize animation events."
 msgstr "hoitaa jo animaatioiden minimoinnin/palauttamisen."
 
-#. 6.2/extension.js:615
+#. 6.2/extension.js:679
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore application specific effects can not be applied to "
@@ -86,7 +86,7 @@ msgstr "Ilmestyminen"
 msgid "Aura Glow"
 msgstr "Auran hehku"
 
-#. effects/BrokenGlass.js:152
+#. effects/BrokenGlass.js:153
 msgid "Broken Glass"
 msgstr "Särkynyt lasi"
 
@@ -159,32 +159,32 @@ msgid "Fire"
 msgstr "Tuli"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:180
+#. effects/Fire.js:189
 msgid "Default Fire"
 msgstr "Oletus tuli"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:190
+#. effects/Fire.js:199
 msgid "Hell Fire"
 msgstr "Helvetin tuli"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:200
+#. effects/Fire.js:209
 msgid "Dark and Smutty"
 msgstr "Tumma tahra"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:210
+#. effects/Fire.js:219
 msgid "Cold Breeze"
 msgstr "Kylmää tuulta"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:220
+#. effects/Fire.js:229
 msgid "Santa is Coming"
 msgstr "Joulupukki tulee"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:230
+#. effects/Fire.js:239
 msgid "Nuclear"
 msgstr "Ydinvoima"
 
@@ -295,42 +295,42 @@ msgid "Mushroom"
 msgstr "Pyörre"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:227
+#. effects/Mushroom.js:236
 msgid "8Bit Plumber"
 msgstr "Putkimies"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:244
+#. effects/Mushroom.js:253
 msgid "New Bros 2"
 msgstr "Putkimies 2"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:262
+#. effects/Mushroom.js:271
 msgid "The True North"
 msgstr "Aito pohjoinen"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:280
+#. effects/Mushroom.js:289
 msgid "Red White and Blue"
 msgstr "Puna-valko-sininen"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:297
+#. effects/Mushroom.js:306
 msgid "Rainbow"
 msgstr "Sateenkaari"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:314
+#. effects/Mushroom.js:323
 msgid "Cattuccino"
 msgstr "Cattuccino"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:332
+#. effects/Mushroom.js:341
 msgid "Dracula"
 msgstr "Dracula"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:349
+#. effects/Mushroom.js:358
 msgid "Sparkle"
 msgstr "Kimallus"
 
@@ -499,6 +499,19 @@ msgstr "Hyppyportti"
 msgid "Wisps"
 msgstr "Hiukkaset"
 
+#. 6.2/CustomWidgets.py:509
+msgid "_Cancel"
+msgstr ""
+
+#. 6.2/CustomWidgets.py:510
+#, fuzzy
+msgid "_Open"
+msgstr "Avaa"
+
+#. 6.2/CustomWidgets.py:520
+msgid "Sound files"
+msgstr ""
+
 #. metadata.json->name
 msgid "Burn My Windows"
 msgstr "Burn My Windows"
@@ -550,11 +563,6 @@ msgstr "Tehosteen valinta"
 #. 6.2->settings-schema.json->effect-settings->title
 msgid "Effect Specific Settings"
 msgstr "Tehostekohtaiset asetukset"
-
-#. 6.2->settings-schema.json->fire-custom-section->title
-#. 6.2->settings-schema.json->mushroom-custom-section->title
-msgid "Setting for the custom preset:"
-msgstr "Esiasetuksen asetus:"
 
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
@@ -747,6 +755,20 @@ msgstr "Tehoste Ikkunan avaamiselle"
 msgid "Close window effect"
 msgstr "Tehoste Ikkunan sulkemiselle"
 
+#. 6.2->settings-schema.json->enable-sound->description
+msgid "Allow Burn My Windows to override cinnamon sound effects"
+msgstr ""
+
+#. 6.2->settings-schema.json->enable-sound->tooltip
+msgid ""
+"Allow Burn My Windows to override Cinnamon's window open/close/minimize "
+"sound effects with unique ones defined in the Effect Settings tab for each "
+"Burn My Windows effect. Note: Sounds will only play when Cinnamon's open/"
+"close/minimize sound effects are enabled under Cinnamon sounds settings. The "
+"default cinnamon sounds will be used unless a sound effect file is chosen "
+"for the active Burn My Windows effect."
+msgstr ""
+
 #. 6.2->settings-schema.json->dialog-special->description
 #. 6.2->settings-schema.json->power-dialog-special->description
 msgid "Special handling for dialog windows"
@@ -875,6 +897,56 @@ msgstr "Tehosteen kesto (ms)"
 msgid "Reset to default"
 msgstr "Palauta oletuksiin"
 
+#. 6.2->settings-schema.json->apparition-open-sound->description
+#. 6.2->settings-schema.json->aura-glow-open-sound->description
+#. 6.2->settings-schema.json->doom-open-sound->description
+#. 6.2->settings-schema.json->energize-a-open-sound->description
+#. 6.2->settings-schema.json->energize-b-open-sound->description
+#. 6.2->settings-schema.json->fire-open-sound->description
+#. 6.2->settings-schema.json->focus-open-sound->description
+#. 6.2->settings-schema.json->glide-open-sound->description
+#. 6.2->settings-schema.json->glitch-open-sound->description
+#. 6.2->settings-schema.json->hexagon-open-sound->description
+#. 6.2->settings-schema.json->incinerate-open-sound->description
+#. 6.2->settings-schema.json->magiclamp-open-sound->description
+#. 6.2->settings-schema.json->mushroom-open-sound->description
+#. 6.2->settings-schema.json->pixelate-open-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-open-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-open-sound->description
+#. 6.2->settings-schema.json->portal-open-sound->description
+#. 6.2->settings-schema.json->rgbwarp-open-sound->description
+#. 6.2->settings-schema.json->team-rocket-open-sound->description
+#. 6.2->settings-schema.json->tv-open-sound->description
+#. 6.2->settings-schema.json->tv-glitch-open-sound->description
+#. 6.2->settings-schema.json->wisps-open-sound->description
+msgid "Sound on window appear events"
+msgstr ""
+
+#. 6.2->settings-schema.json->apparition-close-sound->description
+#. 6.2->settings-schema.json->aura-glow-close-sound->description
+#. 6.2->settings-schema.json->doom-close-sound->description
+#. 6.2->settings-schema.json->energize-a-close-sound->description
+#. 6.2->settings-schema.json->energize-b-close-sound->description
+#. 6.2->settings-schema.json->fire-close-sound->description
+#. 6.2->settings-schema.json->focus-close-sound->description
+#. 6.2->settings-schema.json->glide-close-sound->description
+#. 6.2->settings-schema.json->glitch-close-sound->description
+#. 6.2->settings-schema.json->hexagon-close-sound->description
+#. 6.2->settings-schema.json->incinerate-close-sound->description
+#. 6.2->settings-schema.json->magiclamp-close-sound->description
+#. 6.2->settings-schema.json->mushroom-close-sound->description
+#. 6.2->settings-schema.json->pixelate-close-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-close-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-close-sound->description
+#. 6.2->settings-schema.json->portal-close-sound->description
+#. 6.2->settings-schema.json->rgbwarp-close-sound->description
+#. 6.2->settings-schema.json->team-rocket-close-sound->description
+#. 6.2->settings-schema.json->tv-close-sound->description
+#. 6.2->settings-schema.json->tv-glitch-close-sound->description
+#. 6.2->settings-schema.json->wisps-close-sound->description
+msgid "Sound on window disappear events"
+msgstr ""
+
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 msgid "Random Color"
 msgstr "Satunnainen väri"
@@ -963,8 +1035,8 @@ msgid "Custom"
 msgstr "Mukautettu"
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire Preset"
-msgstr "Palon esiasetus"
+msgid "Fire effect style"
+msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
 msgid "Fire Movement Speed"
@@ -1150,7 +1222,8 @@ msgid "This effects the quality and the costs of the animation"
 msgstr "Vaikuttaa animaation laatuun ja aikaan"
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom Preset"
+#, fuzzy
+msgid "Mushroom effect style"
 msgstr "Pyörre esiasetus"
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/fr.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-10-15 21:53-0400\n"
+"POT-Creation-Date: 2026-08-02 12:18-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -18,31 +18,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.2/extension.js:208 6.2/extension.js:286 6.2/extension.js:614
+#. 6.2/extension.js:210 6.2/extension.js:311 6.2/extension.js:678
 msgid "Error"
 msgstr "Erreur"
 
-#. 6.2/extension.js:208
+#. 6.2/extension.js:210
 msgid "was NOT enabled"
 msgstr "n'a PAS été activée"
 
-#. 6.2/extension.js:209 6.2/extension.js:287
+#. 6.2/extension.js:211 6.2/extension.js:312
 msgid "The existing extension"
 msgstr "L'extension existante"
 
-#. 6.2/extension.js:209
+#. 6.2/extension.js:211
 msgid "conflicts with this extension."
 msgstr "est en conflit avec cette extension."
 
-#. 6.2/extension.js:286
+#. 6.2/extension.js:311
 msgid "minimize/unminimize effects can not be enabled"
 msgstr ""
 
-#. 6.2/extension.js:287
+#. 6.2/extension.js:312
 msgid "already handles minimize/unminimize animation events."
 msgstr ""
 
-#. 6.2/extension.js:615
+#. 6.2/extension.js:679
 #, fuzzy
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
@@ -87,7 +87,7 @@ msgstr "Apparition"
 msgid "Aura Glow"
 msgstr ""
 
-#. effects/BrokenGlass.js:152
+#. effects/BrokenGlass.js:153
 msgid "Broken Glass"
 msgstr "Broken Glass (Verre brisé)"
 
@@ -160,32 +160,32 @@ msgid "Fire"
 msgstr "Fire (Feu)"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:180
+#. effects/Fire.js:189
 msgid "Default Fire"
 msgstr "Default Fire (Feu par défaut)"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:190
+#. effects/Fire.js:199
 msgid "Hell Fire"
 msgstr "Hell Fire (Feu d'Enfer)"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:200
+#. effects/Fire.js:209
 msgid "Dark and Smutty"
 msgstr "Dark and Smutty (Sombre et coquin)"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:210
+#. effects/Fire.js:219
 msgid "Cold Breeze"
 msgstr "Cold Breeze (Brise fraîche)"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:220
+#. effects/Fire.js:229
 msgid "Santa is Coming"
 msgstr "Santa is Coming (Le Père Noël arrive)"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:230
+#. effects/Fire.js:239
 msgid "Nuclear"
 msgstr ""
 
@@ -296,42 +296,42 @@ msgid "Mushroom"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:227
+#. effects/Mushroom.js:236
 msgid "8Bit Plumber"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:244
+#. effects/Mushroom.js:253
 msgid "New Bros 2"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:262
+#. effects/Mushroom.js:271
 msgid "The True North"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:280
+#. effects/Mushroom.js:289
 msgid "Red White and Blue"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:297
+#. effects/Mushroom.js:306
 msgid "Rainbow"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:314
+#. effects/Mushroom.js:323
 msgid "Cattuccino"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:332
+#. effects/Mushroom.js:341
 msgid "Dracula"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:349
+#. effects/Mushroom.js:358
 msgid "Sparkle"
 msgstr ""
 
@@ -500,6 +500,18 @@ msgstr ""
 msgid "Wisps"
 msgstr "Wisps (Sillages de bulles)"
 
+#. 6.2/CustomWidgets.py:509
+msgid "_Cancel"
+msgstr ""
+
+#. 6.2/CustomWidgets.py:510
+msgid "_Open"
+msgstr ""
+
+#. 6.2/CustomWidgets.py:520
+msgid "Sound files"
+msgstr ""
+
 #. metadata.json->name
 msgid "Burn My Windows"
 msgstr "Brûle mes fenêtres"
@@ -553,11 +565,6 @@ msgstr "Sélecteur d'effet"
 #. 6.2->settings-schema.json->effect-settings->title
 msgid "Effect Specific Settings"
 msgstr "Paramètres propres à l'effet"
-
-#. 6.2->settings-schema.json->fire-custom-section->title
-#. 6.2->settings-schema.json->mushroom-custom-section->title
-msgid "Setting for the custom preset:"
-msgstr ""
 
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
@@ -734,6 +741,20 @@ msgstr "Effet d'ouverture"
 msgid "Close window effect"
 msgstr "Effet de fermeture"
 
+#. 6.2->settings-schema.json->enable-sound->description
+msgid "Allow Burn My Windows to override cinnamon sound effects"
+msgstr ""
+
+#. 6.2->settings-schema.json->enable-sound->tooltip
+msgid ""
+"Allow Burn My Windows to override Cinnamon's window open/close/minimize "
+"sound effects with unique ones defined in the Effect Settings tab for each "
+"Burn My Windows effect. Note: Sounds will only play when Cinnamon's open/"
+"close/minimize sound effects are enabled under Cinnamon sounds settings. The "
+"default cinnamon sounds will be used unless a sound effect file is chosen "
+"for the active Burn My Windows effect."
+msgstr ""
+
 #. 6.2->settings-schema.json->dialog-special->description
 #. 6.2->settings-schema.json->power-dialog-special->description
 msgid "Special handling for dialog windows"
@@ -868,6 +889,56 @@ msgstr "Durée de l'effet (millisecondes)"
 msgid "Reset to default"
 msgstr "Default Fire (Feu par défaut)"
 
+#. 6.2->settings-schema.json->apparition-open-sound->description
+#. 6.2->settings-schema.json->aura-glow-open-sound->description
+#. 6.2->settings-schema.json->doom-open-sound->description
+#. 6.2->settings-schema.json->energize-a-open-sound->description
+#. 6.2->settings-schema.json->energize-b-open-sound->description
+#. 6.2->settings-schema.json->fire-open-sound->description
+#. 6.2->settings-schema.json->focus-open-sound->description
+#. 6.2->settings-schema.json->glide-open-sound->description
+#. 6.2->settings-schema.json->glitch-open-sound->description
+#. 6.2->settings-schema.json->hexagon-open-sound->description
+#. 6.2->settings-schema.json->incinerate-open-sound->description
+#. 6.2->settings-schema.json->magiclamp-open-sound->description
+#. 6.2->settings-schema.json->mushroom-open-sound->description
+#. 6.2->settings-schema.json->pixelate-open-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-open-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-open-sound->description
+#. 6.2->settings-schema.json->portal-open-sound->description
+#. 6.2->settings-schema.json->rgbwarp-open-sound->description
+#. 6.2->settings-schema.json->team-rocket-open-sound->description
+#. 6.2->settings-schema.json->tv-open-sound->description
+#. 6.2->settings-schema.json->tv-glitch-open-sound->description
+#. 6.2->settings-schema.json->wisps-open-sound->description
+msgid "Sound on window appear events"
+msgstr ""
+
+#. 6.2->settings-schema.json->apparition-close-sound->description
+#. 6.2->settings-schema.json->aura-glow-close-sound->description
+#. 6.2->settings-schema.json->doom-close-sound->description
+#. 6.2->settings-schema.json->energize-a-close-sound->description
+#. 6.2->settings-schema.json->energize-b-close-sound->description
+#. 6.2->settings-schema.json->fire-close-sound->description
+#. 6.2->settings-schema.json->focus-close-sound->description
+#. 6.2->settings-schema.json->glide-close-sound->description
+#. 6.2->settings-schema.json->glitch-close-sound->description
+#. 6.2->settings-schema.json->hexagon-close-sound->description
+#. 6.2->settings-schema.json->incinerate-close-sound->description
+#. 6.2->settings-schema.json->magiclamp-close-sound->description
+#. 6.2->settings-schema.json->mushroom-close-sound->description
+#. 6.2->settings-schema.json->pixelate-close-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-close-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-close-sound->description
+#. 6.2->settings-schema.json->portal-close-sound->description
+#. 6.2->settings-schema.json->rgbwarp-close-sound->description
+#. 6.2->settings-schema.json->team-rocket-close-sound->description
+#. 6.2->settings-schema.json->tv-close-sound->description
+#. 6.2->settings-schema.json->tv-glitch-close-sound->description
+#. 6.2->settings-schema.json->wisps-close-sound->description
+msgid "Sound on window disappear events"
+msgstr ""
+
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 #, fuzzy
 msgid "Random Color"
@@ -956,7 +1027,7 @@ msgid "Custom"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire Preset"
+msgid "Fire effect style"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
@@ -1142,7 +1213,7 @@ msgid "This effects the quality and the costs of the animation"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom Preset"
+msgid "Mushroom effect style"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/hu.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-10-15 21:53-0400\n"
+"POT-Creation-Date: 2026-08-02 12:18-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,33 +18,33 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.8\n"
 
-#. 6.2/extension.js:208 6.2/extension.js:286 6.2/extension.js:614
+#. 6.2/extension.js:210 6.2/extension.js:311 6.2/extension.js:678
 msgid "Error"
 msgstr "Hiba"
 
-#. 6.2/extension.js:208
+#. 6.2/extension.js:210
 msgid "was NOT enabled"
 msgstr "NEM volt engedélyezve"
 
-#. 6.2/extension.js:209 6.2/extension.js:287
+#. 6.2/extension.js:211 6.2/extension.js:312
 msgid "The existing extension"
 msgstr "A meglévő bővítmény"
 
-#. 6.2/extension.js:209
+#. 6.2/extension.js:211
 msgid "conflicts with this extension."
 msgstr "ütközik ezzel a bővitménnyel."
 
-#. 6.2/extension.js:286
+#. 6.2/extension.js:311
 msgid "minimize/unminimize effects can not be enabled"
 msgstr "effektusok minimalizálása/minimalizálása nem engedélyezhető"
 
-#. 6.2/extension.js:287
+#. 6.2/extension.js:312
 msgid "already handles minimize/unminimize animation events."
 msgstr ""
 "már kezeli az animációs események minimalizálását/minimalizálásának "
 "megszüntetését."
 
-#. 6.2/extension.js:615
+#. 6.2/extension.js:679
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore application specific effects can not be applied to "
@@ -88,7 +88,7 @@ msgstr "Megjelenik"
 msgid "Aura Glow"
 msgstr "Aura ragyogás"
 
-#. effects/BrokenGlass.js:152
+#. effects/BrokenGlass.js:153
 msgid "Broken Glass"
 msgstr "Törött üveg"
 
@@ -161,32 +161,32 @@ msgid "Fire"
 msgstr "Tűz"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:180
+#. effects/Fire.js:189
 msgid "Default Fire"
 msgstr "Alapértelmezett Tűz"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:190
+#. effects/Fire.js:199
 msgid "Hell Fire"
 msgstr "Pokol Tüze"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:200
+#. effects/Fire.js:209
 msgid "Dark and Smutty"
 msgstr "Sötét és piszkos"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:210
+#. effects/Fire.js:219
 msgid "Cold Breeze"
 msgstr "Hideg szellő"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:220
+#. effects/Fire.js:229
 msgid "Santa is Coming"
 msgstr "Jön a Mikulás"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:230
+#. effects/Fire.js:239
 msgid "Nuclear"
 msgstr "Nukleáris"
 
@@ -297,42 +297,42 @@ msgid "Mushroom"
 msgstr "Gomba"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:227
+#. effects/Mushroom.js:236
 msgid "8Bit Plumber"
 msgstr "8 bites vízvezeték-szerelő"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:244
+#. effects/Mushroom.js:253
 msgid "New Bros 2"
 msgstr "New Bros 2"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:262
+#. effects/Mushroom.js:271
 msgid "The True North"
 msgstr "Az igazi észak"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:280
+#. effects/Mushroom.js:289
 msgid "Red White and Blue"
 msgstr "Piros Fehér és Kék"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:297
+#. effects/Mushroom.js:306
 msgid "Rainbow"
 msgstr "Szivárvány"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:314
+#. effects/Mushroom.js:323
 msgid "Cattuccino"
 msgstr "Cattuccino"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:332
+#. effects/Mushroom.js:341
 msgid "Dracula"
 msgstr "Drakula"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:349
+#. effects/Mushroom.js:358
 msgid "Sparkle"
 msgstr "Szikra"
 
@@ -501,6 +501,19 @@ msgstr "Team Rocket"
 msgid "Wisps"
 msgstr "Foszlányok"
 
+#. 6.2/CustomWidgets.py:509
+msgid "_Cancel"
+msgstr ""
+
+#. 6.2/CustomWidgets.py:510
+#, fuzzy
+msgid "_Open"
+msgstr "Megnyit"
+
+#. 6.2/CustomWidgets.py:520
+msgid "Sound files"
+msgstr ""
+
 #. metadata.json->name
 msgid "Burn My Windows"
 msgstr "Égjenek az Ablakaim"
@@ -552,11 +565,6 @@ msgstr "Effektus választó"
 #. 6.2->settings-schema.json->effect-settings->title
 msgid "Effect Specific Settings"
 msgstr "Effekt specifikus beállítások"
-
-#. 6.2->settings-schema.json->fire-custom-section->title
-#. 6.2->settings-schema.json->mushroom-custom-section->title
-msgid "Setting for the custom preset:"
-msgstr "Az egyéni előbeállítás beállítása:"
 
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
@@ -751,6 +759,20 @@ msgstr "Megnyitás ablak effektusa"
 msgid "Close window effect"
 msgstr "Bezárás ablak effektusa"
 
+#. 6.2->settings-schema.json->enable-sound->description
+msgid "Allow Burn My Windows to override cinnamon sound effects"
+msgstr ""
+
+#. 6.2->settings-schema.json->enable-sound->tooltip
+msgid ""
+"Allow Burn My Windows to override Cinnamon's window open/close/minimize "
+"sound effects with unique ones defined in the Effect Settings tab for each "
+"Burn My Windows effect. Note: Sounds will only play when Cinnamon's open/"
+"close/minimize sound effects are enabled under Cinnamon sounds settings. The "
+"default cinnamon sounds will be used unless a sound effect file is chosen "
+"for the active Burn My Windows effect."
+msgstr ""
+
 #. 6.2->settings-schema.json->dialog-special->description
 #. 6.2->settings-schema.json->power-dialog-special->description
 msgid "Special handling for dialog windows"
@@ -884,6 +906,56 @@ msgstr "Effektus időtartama (ezredmásodperc)"
 msgid "Reset to default"
 msgstr "Visszaállítás alapértelmezettre"
 
+#. 6.2->settings-schema.json->apparition-open-sound->description
+#. 6.2->settings-schema.json->aura-glow-open-sound->description
+#. 6.2->settings-schema.json->doom-open-sound->description
+#. 6.2->settings-schema.json->energize-a-open-sound->description
+#. 6.2->settings-schema.json->energize-b-open-sound->description
+#. 6.2->settings-schema.json->fire-open-sound->description
+#. 6.2->settings-schema.json->focus-open-sound->description
+#. 6.2->settings-schema.json->glide-open-sound->description
+#. 6.2->settings-schema.json->glitch-open-sound->description
+#. 6.2->settings-schema.json->hexagon-open-sound->description
+#. 6.2->settings-schema.json->incinerate-open-sound->description
+#. 6.2->settings-schema.json->magiclamp-open-sound->description
+#. 6.2->settings-schema.json->mushroom-open-sound->description
+#. 6.2->settings-schema.json->pixelate-open-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-open-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-open-sound->description
+#. 6.2->settings-schema.json->portal-open-sound->description
+#. 6.2->settings-schema.json->rgbwarp-open-sound->description
+#. 6.2->settings-schema.json->team-rocket-open-sound->description
+#. 6.2->settings-schema.json->tv-open-sound->description
+#. 6.2->settings-schema.json->tv-glitch-open-sound->description
+#. 6.2->settings-schema.json->wisps-open-sound->description
+msgid "Sound on window appear events"
+msgstr ""
+
+#. 6.2->settings-schema.json->apparition-close-sound->description
+#. 6.2->settings-schema.json->aura-glow-close-sound->description
+#. 6.2->settings-schema.json->doom-close-sound->description
+#. 6.2->settings-schema.json->energize-a-close-sound->description
+#. 6.2->settings-schema.json->energize-b-close-sound->description
+#. 6.2->settings-schema.json->fire-close-sound->description
+#. 6.2->settings-schema.json->focus-close-sound->description
+#. 6.2->settings-schema.json->glide-close-sound->description
+#. 6.2->settings-schema.json->glitch-close-sound->description
+#. 6.2->settings-schema.json->hexagon-close-sound->description
+#. 6.2->settings-schema.json->incinerate-close-sound->description
+#. 6.2->settings-schema.json->magiclamp-close-sound->description
+#. 6.2->settings-schema.json->mushroom-close-sound->description
+#. 6.2->settings-schema.json->pixelate-close-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-close-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-close-sound->description
+#. 6.2->settings-schema.json->portal-close-sound->description
+#. 6.2->settings-schema.json->rgbwarp-close-sound->description
+#. 6.2->settings-schema.json->team-rocket-close-sound->description
+#. 6.2->settings-schema.json->tv-close-sound->description
+#. 6.2->settings-schema.json->tv-glitch-close-sound->description
+#. 6.2->settings-schema.json->wisps-close-sound->description
+msgid "Sound on window disappear events"
+msgstr ""
+
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 msgid "Random Color"
 msgstr "Véletlenszerű szín"
@@ -974,8 +1046,8 @@ msgid "Custom"
 msgstr "Egyéni"
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire Preset"
-msgstr "Tűz előbeállítás"
+msgid "Fire effect style"
+msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
 msgid "Fire Movement Speed"
@@ -1172,7 +1244,8 @@ msgid "This effects the quality and the costs of the animation"
 msgstr "Ez befolyásolja az animáció minőségét és költségeit"
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom Preset"
+#, fuzzy
+msgid "Mushroom effect style"
 msgstr "Gomba előbeállítás"
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/it.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/it.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 1.0.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-10-15 21:53-0400\n"
+"POT-Creation-Date: 2026-08-02 12:18-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -17,32 +17,32 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.2/extension.js:208 6.2/extension.js:286 6.2/extension.js:614
+#. 6.2/extension.js:210 6.2/extension.js:311 6.2/extension.js:678
 msgid "Error"
 msgstr "Errore"
 
-#. 6.2/extension.js:208
+#. 6.2/extension.js:210
 msgid "was NOT enabled"
 msgstr "NON è stato abilitato"
 
-#. 6.2/extension.js:209 6.2/extension.js:287
+#. 6.2/extension.js:211 6.2/extension.js:312
 msgid "The existing extension"
 msgstr "L'estensione già esistente"
 
-#. 6.2/extension.js:209
+#. 6.2/extension.js:211
 msgid "conflicts with this extension."
 msgstr "è in conflitto con questa estensione."
 
-#. 6.2/extension.js:286
+#. 6.2/extension.js:311
 msgid "minimize/unminimize effects can not be enabled"
 msgstr ""
 "non è stato possibile abilitare gli effetti di minimizzazione/ripristino"
 
-#. 6.2/extension.js:287
+#. 6.2/extension.js:312
 msgid "already handles minimize/unminimize animation events."
 msgstr "gestisce già gli eventi di animazione di minimizzazione/ripristino."
 
-#. 6.2/extension.js:615
+#. 6.2/extension.js:679
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore application specific effects can not be applied to "
@@ -86,7 +86,7 @@ msgstr "Apparizione"
 msgid "Aura Glow"
 msgstr "Bagliore d'aura"
 
-#. effects/BrokenGlass.js:152
+#. effects/BrokenGlass.js:153
 msgid "Broken Glass"
 msgstr "Vetro infranto"
 
@@ -159,32 +159,32 @@ msgid "Fire"
 msgstr "Fuoco"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:180
+#. effects/Fire.js:189
 msgid "Default Fire"
 msgstr "Fuoco predefinito"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:190
+#. effects/Fire.js:199
 msgid "Hell Fire"
 msgstr "Fuoco infernale"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:200
+#. effects/Fire.js:209
 msgid "Dark and Smutty"
 msgstr "Oscuro e Fuligginoso"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:210
+#. effects/Fire.js:219
 msgid "Cold Breeze"
 msgstr "Brezza fredda"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:220
+#. effects/Fire.js:229
 msgid "Santa is Coming"
 msgstr "Arriva Babbo Natale"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:230
+#. effects/Fire.js:239
 msgid "Nuclear"
 msgstr "Nucleare"
 
@@ -295,42 +295,42 @@ msgid "Mushroom"
 msgstr "Fungo"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:227
+#. effects/Mushroom.js:236
 msgid "8Bit Plumber"
 msgstr "Idraulico 8Bit"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:244
+#. effects/Mushroom.js:253
 msgid "New Bros 2"
 msgstr "Nuovi Bros 2"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:262
+#. effects/Mushroom.js:271
 msgid "The True North"
 msgstr "Il vero Nord"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:280
+#. effects/Mushroom.js:289
 msgid "Red White and Blue"
 msgstr "Rosso bianco e blu"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:297
+#. effects/Mushroom.js:306
 msgid "Rainbow"
 msgstr "Arcobaleno"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:314
+#. effects/Mushroom.js:323
 msgid "Cattuccino"
 msgstr "Cattuccino"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:332
+#. effects/Mushroom.js:341
 msgid "Dracula"
 msgstr "Dracula"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:349
+#. effects/Mushroom.js:358
 msgid "Sparkle"
 msgstr "Scintilla"
 
@@ -499,6 +499,19 @@ msgstr "Team Rocket"
 msgid "Wisps"
 msgstr "Fili di fumo"
 
+#. 6.2/CustomWidgets.py:509
+msgid "_Cancel"
+msgstr ""
+
+#. 6.2/CustomWidgets.py:510
+#, fuzzy
+msgid "_Open"
+msgstr "Apri"
+
+#. 6.2/CustomWidgets.py:520
+msgid "Sound files"
+msgstr ""
+
 #. metadata.json->name
 msgid "Burn My Windows"
 msgstr "Brucia le mie finestre"
@@ -550,11 +563,6 @@ msgstr "Selettore effetti"
 #. 6.2->settings-schema.json->effect-settings->title
 msgid "Effect Specific Settings"
 msgstr "Impostazioni specifiche dell'effetto"
-
-#. 6.2->settings-schema.json->fire-custom-section->title
-#. 6.2->settings-schema.json->mushroom-custom-section->title
-msgid "Setting for the custom preset:"
-msgstr "Impostazioni per la preimpostazione personalizzata:"
 
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
@@ -750,6 +758,20 @@ msgstr "Effetto apertura finestra"
 msgid "Close window effect"
 msgstr "Effetto chiusura finestra"
 
+#. 6.2->settings-schema.json->enable-sound->description
+msgid "Allow Burn My Windows to override cinnamon sound effects"
+msgstr ""
+
+#. 6.2->settings-schema.json->enable-sound->tooltip
+msgid ""
+"Allow Burn My Windows to override Cinnamon's window open/close/minimize "
+"sound effects with unique ones defined in the Effect Settings tab for each "
+"Burn My Windows effect. Note: Sounds will only play when Cinnamon's open/"
+"close/minimize sound effects are enabled under Cinnamon sounds settings. The "
+"default cinnamon sounds will be used unless a sound effect file is chosen "
+"for the active Burn My Windows effect."
+msgstr ""
+
 #. 6.2->settings-schema.json->dialog-special->description
 #. 6.2->settings-schema.json->power-dialog-special->description
 msgid "Special handling for dialog windows"
@@ -878,6 +900,56 @@ msgstr "Durata effetto (ms)"
 msgid "Reset to default"
 msgstr "Ripristina ai valori predefiniti"
 
+#. 6.2->settings-schema.json->apparition-open-sound->description
+#. 6.2->settings-schema.json->aura-glow-open-sound->description
+#. 6.2->settings-schema.json->doom-open-sound->description
+#. 6.2->settings-schema.json->energize-a-open-sound->description
+#. 6.2->settings-schema.json->energize-b-open-sound->description
+#. 6.2->settings-schema.json->fire-open-sound->description
+#. 6.2->settings-schema.json->focus-open-sound->description
+#. 6.2->settings-schema.json->glide-open-sound->description
+#. 6.2->settings-schema.json->glitch-open-sound->description
+#. 6.2->settings-schema.json->hexagon-open-sound->description
+#. 6.2->settings-schema.json->incinerate-open-sound->description
+#. 6.2->settings-schema.json->magiclamp-open-sound->description
+#. 6.2->settings-schema.json->mushroom-open-sound->description
+#. 6.2->settings-schema.json->pixelate-open-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-open-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-open-sound->description
+#. 6.2->settings-schema.json->portal-open-sound->description
+#. 6.2->settings-schema.json->rgbwarp-open-sound->description
+#. 6.2->settings-schema.json->team-rocket-open-sound->description
+#. 6.2->settings-schema.json->tv-open-sound->description
+#. 6.2->settings-schema.json->tv-glitch-open-sound->description
+#. 6.2->settings-schema.json->wisps-open-sound->description
+msgid "Sound on window appear events"
+msgstr ""
+
+#. 6.2->settings-schema.json->apparition-close-sound->description
+#. 6.2->settings-schema.json->aura-glow-close-sound->description
+#. 6.2->settings-schema.json->doom-close-sound->description
+#. 6.2->settings-schema.json->energize-a-close-sound->description
+#. 6.2->settings-schema.json->energize-b-close-sound->description
+#. 6.2->settings-schema.json->fire-close-sound->description
+#. 6.2->settings-schema.json->focus-close-sound->description
+#. 6.2->settings-schema.json->glide-close-sound->description
+#. 6.2->settings-schema.json->glitch-close-sound->description
+#. 6.2->settings-schema.json->hexagon-close-sound->description
+#. 6.2->settings-schema.json->incinerate-close-sound->description
+#. 6.2->settings-schema.json->magiclamp-close-sound->description
+#. 6.2->settings-schema.json->mushroom-close-sound->description
+#. 6.2->settings-schema.json->pixelate-close-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-close-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-close-sound->description
+#. 6.2->settings-schema.json->portal-close-sound->description
+#. 6.2->settings-schema.json->rgbwarp-close-sound->description
+#. 6.2->settings-schema.json->team-rocket-close-sound->description
+#. 6.2->settings-schema.json->tv-close-sound->description
+#. 6.2->settings-schema.json->tv-glitch-close-sound->description
+#. 6.2->settings-schema.json->wisps-close-sound->description
+msgid "Sound on window disappear events"
+msgstr ""
+
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 msgid "Random Color"
 msgstr "Colore casuale"
@@ -967,8 +1039,8 @@ msgid "Custom"
 msgstr "Personalizzato"
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire Preset"
-msgstr "Preimpostazione Fuoco"
+msgid "Fire effect style"
+msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
 msgid "Fire Movement Speed"
@@ -1165,7 +1237,8 @@ msgid "This effects the quality and the costs of the animation"
 msgstr "Questo influisce sulla qualità e sul costo dell'animazione"
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom Preset"
+#, fuzzy
+msgid "Mushroom effect style"
 msgstr "Preimpostazione Mushroom"
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/nl.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-10-15 21:53-0400\n"
+"POT-Creation-Date: 2026-08-02 12:18-0400\n"
 "PO-Revision-Date: 2025-05-13 11:59+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,31 +16,31 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.2/extension.js:208 6.2/extension.js:286 6.2/extension.js:614
+#. 6.2/extension.js:210 6.2/extension.js:311 6.2/extension.js:678
 msgid "Error"
 msgstr "Fout"
 
-#. 6.2/extension.js:208
+#. 6.2/extension.js:210
 msgid "was NOT enabled"
 msgstr "was NIET ingeschakeld"
 
-#. 6.2/extension.js:209 6.2/extension.js:287
+#. 6.2/extension.js:211 6.2/extension.js:312
 msgid "The existing extension"
 msgstr "De bestaande extensie"
 
-#. 6.2/extension.js:209
+#. 6.2/extension.js:211
 msgid "conflicts with this extension."
 msgstr "conflicteert met deze extensie."
 
-#. 6.2/extension.js:286
+#. 6.2/extension.js:311
 msgid "minimize/unminimize effects can not be enabled"
 msgstr "minimaliseer-/onminimaliseer-effecten kunnen niet worden ingeschakeld"
 
-#. 6.2/extension.js:287
+#. 6.2/extension.js:312
 msgid "already handles minimize/unminimize animation events."
 msgstr "behandelt al minimaliseer-/onminimaliseer-animatiegebeurtenissen."
 
-#. 6.2/extension.js:615
+#. 6.2/extension.js:679
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore application specific effects can not be applied to "
@@ -84,7 +84,7 @@ msgstr "Verschijning"
 msgid "Aura Glow"
 msgstr "Aura Gloed"
 
-#. effects/BrokenGlass.js:152
+#. effects/BrokenGlass.js:153
 msgid "Broken Glass"
 msgstr "Gebroken Glas"
 
@@ -157,32 +157,32 @@ msgid "Fire"
 msgstr "Vuur"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:180
+#. effects/Fire.js:189
 msgid "Default Fire"
 msgstr "Standaard Vuur"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:190
+#. effects/Fire.js:199
 msgid "Hell Fire"
 msgstr "Hel Vuur"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:200
+#. effects/Fire.js:209
 msgid "Dark and Smutty"
 msgstr "Donker en Smerig"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:210
+#. effects/Fire.js:219
 msgid "Cold Breeze"
 msgstr "Koude Bries"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:220
+#. effects/Fire.js:229
 msgid "Santa is Coming"
 msgstr "Kerstman komt eraan"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:230
+#. effects/Fire.js:239
 msgid "Nuclear"
 msgstr "Nucleair"
 
@@ -293,42 +293,42 @@ msgid "Mushroom"
 msgstr "Paddenstoel"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:227
+#. effects/Mushroom.js:236
 msgid "8Bit Plumber"
 msgstr "8Bit Plumber"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:244
+#. effects/Mushroom.js:253
 msgid "New Bros 2"
 msgstr "New Bros 2"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:262
+#. effects/Mushroom.js:271
 msgid "The True North"
 msgstr "The True North"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:280
+#. effects/Mushroom.js:289
 msgid "Red White and Blue"
 msgstr "Rood Wit en Blauw"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:297
+#. effects/Mushroom.js:306
 msgid "Rainbow"
 msgstr "Regenboog"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:314
+#. effects/Mushroom.js:323
 msgid "Cattuccino"
 msgstr "Cattuccino"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:332
+#. effects/Mushroom.js:341
 msgid "Dracula"
 msgstr "Dracula"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:349
+#. effects/Mushroom.js:358
 msgid "Sparkle"
 msgstr "Schittering"
 
@@ -497,6 +497,19 @@ msgstr "Team Rocket"
 msgid "Wisps"
 msgstr "Slierten"
 
+#. 6.2/CustomWidgets.py:509
+msgid "_Cancel"
+msgstr ""
+
+#. 6.2/CustomWidgets.py:510
+#, fuzzy
+msgid "_Open"
+msgstr "Openen"
+
+#. 6.2/CustomWidgets.py:520
+msgid "Sound files"
+msgstr ""
+
 #. metadata.json->name
 msgid "Burn My Windows"
 msgstr "Verbrand Mijn Vensters"
@@ -548,11 +561,6 @@ msgstr "Effect Selector"
 #. 6.2->settings-schema.json->effect-settings->title
 msgid "Effect Specific Settings"
 msgstr "Effect Specifieke Instellingen"
-
-#. 6.2->settings-schema.json->fire-custom-section->title
-#. 6.2->settings-schema.json->mushroom-custom-section->title
-msgid "Setting for the custom preset:"
-msgstr "Instelling voor de aangepaste voorinstelling:"
 
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
@@ -747,6 +755,20 @@ msgstr "Open venster effect"
 msgid "Close window effect"
 msgstr "Sluit venster effect"
 
+#. 6.2->settings-schema.json->enable-sound->description
+msgid "Allow Burn My Windows to override cinnamon sound effects"
+msgstr ""
+
+#. 6.2->settings-schema.json->enable-sound->tooltip
+msgid ""
+"Allow Burn My Windows to override Cinnamon's window open/close/minimize "
+"sound effects with unique ones defined in the Effect Settings tab for each "
+"Burn My Windows effect. Note: Sounds will only play when Cinnamon's open/"
+"close/minimize sound effects are enabled under Cinnamon sounds settings. The "
+"default cinnamon sounds will be used unless a sound effect file is chosen "
+"for the active Burn My Windows effect."
+msgstr ""
+
 #. 6.2->settings-schema.json->dialog-special->description
 #. 6.2->settings-schema.json->power-dialog-special->description
 msgid "Special handling for dialog windows"
@@ -877,6 +899,56 @@ msgstr "Effect Duur (ms)"
 msgid "Reset to default"
 msgstr "Reset naar standaard"
 
+#. 6.2->settings-schema.json->apparition-open-sound->description
+#. 6.2->settings-schema.json->aura-glow-open-sound->description
+#. 6.2->settings-schema.json->doom-open-sound->description
+#. 6.2->settings-schema.json->energize-a-open-sound->description
+#. 6.2->settings-schema.json->energize-b-open-sound->description
+#. 6.2->settings-schema.json->fire-open-sound->description
+#. 6.2->settings-schema.json->focus-open-sound->description
+#. 6.2->settings-schema.json->glide-open-sound->description
+#. 6.2->settings-schema.json->glitch-open-sound->description
+#. 6.2->settings-schema.json->hexagon-open-sound->description
+#. 6.2->settings-schema.json->incinerate-open-sound->description
+#. 6.2->settings-schema.json->magiclamp-open-sound->description
+#. 6.2->settings-schema.json->mushroom-open-sound->description
+#. 6.2->settings-schema.json->pixelate-open-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-open-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-open-sound->description
+#. 6.2->settings-schema.json->portal-open-sound->description
+#. 6.2->settings-schema.json->rgbwarp-open-sound->description
+#. 6.2->settings-schema.json->team-rocket-open-sound->description
+#. 6.2->settings-schema.json->tv-open-sound->description
+#. 6.2->settings-schema.json->tv-glitch-open-sound->description
+#. 6.2->settings-schema.json->wisps-open-sound->description
+msgid "Sound on window appear events"
+msgstr ""
+
+#. 6.2->settings-schema.json->apparition-close-sound->description
+#. 6.2->settings-schema.json->aura-glow-close-sound->description
+#. 6.2->settings-schema.json->doom-close-sound->description
+#. 6.2->settings-schema.json->energize-a-close-sound->description
+#. 6.2->settings-schema.json->energize-b-close-sound->description
+#. 6.2->settings-schema.json->fire-close-sound->description
+#. 6.2->settings-schema.json->focus-close-sound->description
+#. 6.2->settings-schema.json->glide-close-sound->description
+#. 6.2->settings-schema.json->glitch-close-sound->description
+#. 6.2->settings-schema.json->hexagon-close-sound->description
+#. 6.2->settings-schema.json->incinerate-close-sound->description
+#. 6.2->settings-schema.json->magiclamp-close-sound->description
+#. 6.2->settings-schema.json->mushroom-close-sound->description
+#. 6.2->settings-schema.json->pixelate-close-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-close-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-close-sound->description
+#. 6.2->settings-schema.json->portal-close-sound->description
+#. 6.2->settings-schema.json->rgbwarp-close-sound->description
+#. 6.2->settings-schema.json->team-rocket-close-sound->description
+#. 6.2->settings-schema.json->tv-close-sound->description
+#. 6.2->settings-schema.json->tv-glitch-close-sound->description
+#. 6.2->settings-schema.json->wisps-close-sound->description
+msgid "Sound on window disappear events"
+msgstr ""
+
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 msgid "Random Color"
 msgstr "Willekeurige kleur"
@@ -966,8 +1038,8 @@ msgid "Custom"
 msgstr "Aangepast"
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire Preset"
-msgstr "Vuur-voorinstelling"
+msgid "Fire effect style"
+msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
 msgid "Fire Movement Speed"
@@ -1163,7 +1235,8 @@ msgid "This effects the quality and the costs of the animation"
 msgstr "Dit beïnvloedt de kwaliteit en de kosten van de animatie"
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom Preset"
+#, fuzzy
+msgid "Mushroom effect style"
 msgstr "Paddenstoel-voorinstelling"
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/pt.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/pt.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 0.9.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-10-15 21:53-0400\n"
+"POT-Creation-Date: 2026-08-02 12:18-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,31 +18,31 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.4\n"
 
-#. 6.2/extension.js:208 6.2/extension.js:286 6.2/extension.js:614
+#. 6.2/extension.js:210 6.2/extension.js:311 6.2/extension.js:678
 msgid "Error"
 msgstr "Erro"
 
-#. 6.2/extension.js:208
+#. 6.2/extension.js:210
 msgid "was NOT enabled"
 msgstr "não foi ativo"
 
-#. 6.2/extension.js:209 6.2/extension.js:287
+#. 6.2/extension.js:211 6.2/extension.js:312
 msgid "The existing extension"
 msgstr "A extensão existente"
 
-#. 6.2/extension.js:209
+#. 6.2/extension.js:211
 msgid "conflicts with this extension."
 msgstr "conflita com esta extensão."
 
-#. 6.2/extension.js:286
+#. 6.2/extension.js:311
 msgid "minimize/unminimize effects can not be enabled"
 msgstr ""
 
-#. 6.2/extension.js:287
+#. 6.2/extension.js:312
 msgid "already handles minimize/unminimize animation events."
 msgstr ""
 
-#. 6.2/extension.js:615
+#. 6.2/extension.js:679
 #, fuzzy
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
@@ -87,7 +87,7 @@ msgstr "Aparição"
 msgid "Aura Glow"
 msgstr ""
 
-#. effects/BrokenGlass.js:152
+#. effects/BrokenGlass.js:153
 msgid "Broken Glass"
 msgstr "Vidro Quebrado"
 
@@ -160,32 +160,32 @@ msgid "Fire"
 msgstr "Fogo"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:180
+#. effects/Fire.js:189
 msgid "Default Fire"
 msgstr "Fogo Padrão"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:190
+#. effects/Fire.js:199
 msgid "Hell Fire"
 msgstr "Fogo do Inferno"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:200
+#. effects/Fire.js:209
 msgid "Dark and Smutty"
 msgstr "Escuro e Sujo"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:210
+#. effects/Fire.js:219
 msgid "Cold Breeze"
 msgstr "Briza Fria"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:220
+#. effects/Fire.js:229
 msgid "Santa is Coming"
 msgstr "O Pai Natal está Vindo"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:230
+#. effects/Fire.js:239
 msgid "Nuclear"
 msgstr ""
 
@@ -296,42 +296,42 @@ msgid "Mushroom"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:227
+#. effects/Mushroom.js:236
 msgid "8Bit Plumber"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:244
+#. effects/Mushroom.js:253
 msgid "New Bros 2"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:262
+#. effects/Mushroom.js:271
 msgid "The True North"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:280
+#. effects/Mushroom.js:289
 msgid "Red White and Blue"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:297
+#. effects/Mushroom.js:306
 msgid "Rainbow"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:314
+#. effects/Mushroom.js:323
 msgid "Cattuccino"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:332
+#. effects/Mushroom.js:341
 msgid "Dracula"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:349
+#. effects/Mushroom.js:358
 msgid "Sparkle"
 msgstr ""
 
@@ -500,6 +500,18 @@ msgstr ""
 msgid "Wisps"
 msgstr "Fogos-Fátuos"
 
+#. 6.2/CustomWidgets.py:509
+msgid "_Cancel"
+msgstr ""
+
+#. 6.2/CustomWidgets.py:510
+msgid "_Open"
+msgstr ""
+
+#. 6.2/CustomWidgets.py:520
+msgid "Sound files"
+msgstr ""
+
 #. metadata.json->name
 msgid "Burn My Windows"
 msgstr "Queime Minha Janela"
@@ -553,11 +565,6 @@ msgstr "Selecionador de Efeitos"
 #. 6.2->settings-schema.json->effect-settings->title
 msgid "Effect Specific Settings"
 msgstr "Definições Específicas do Efeito"
-
-#. 6.2->settings-schema.json->fire-custom-section->title
-#. 6.2->settings-schema.json->mushroom-custom-section->title
-msgid "Setting for the custom preset:"
-msgstr ""
 
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
@@ -731,6 +738,20 @@ msgstr "Efeito de abertura da janela"
 msgid "Close window effect"
 msgstr "Efeito de fechamento da janela"
 
+#. 6.2->settings-schema.json->enable-sound->description
+msgid "Allow Burn My Windows to override cinnamon sound effects"
+msgstr ""
+
+#. 6.2->settings-schema.json->enable-sound->tooltip
+msgid ""
+"Allow Burn My Windows to override Cinnamon's window open/close/minimize "
+"sound effects with unique ones defined in the Effect Settings tab for each "
+"Burn My Windows effect. Note: Sounds will only play when Cinnamon's open/"
+"close/minimize sound effects are enabled under Cinnamon sounds settings. The "
+"default cinnamon sounds will be used unless a sound effect file is chosen "
+"for the active Burn My Windows effect."
+msgstr ""
+
 #. 6.2->settings-schema.json->dialog-special->description
 #. 6.2->settings-schema.json->power-dialog-special->description
 msgid "Special handling for dialog windows"
@@ -858,6 +879,56 @@ msgstr "Duração do Efeito (milissegundos)"
 msgid "Reset to default"
 msgstr "Fogo Padrão"
 
+#. 6.2->settings-schema.json->apparition-open-sound->description
+#. 6.2->settings-schema.json->aura-glow-open-sound->description
+#. 6.2->settings-schema.json->doom-open-sound->description
+#. 6.2->settings-schema.json->energize-a-open-sound->description
+#. 6.2->settings-schema.json->energize-b-open-sound->description
+#. 6.2->settings-schema.json->fire-open-sound->description
+#. 6.2->settings-schema.json->focus-open-sound->description
+#. 6.2->settings-schema.json->glide-open-sound->description
+#. 6.2->settings-schema.json->glitch-open-sound->description
+#. 6.2->settings-schema.json->hexagon-open-sound->description
+#. 6.2->settings-schema.json->incinerate-open-sound->description
+#. 6.2->settings-schema.json->magiclamp-open-sound->description
+#. 6.2->settings-schema.json->mushroom-open-sound->description
+#. 6.2->settings-schema.json->pixelate-open-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-open-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-open-sound->description
+#. 6.2->settings-schema.json->portal-open-sound->description
+#. 6.2->settings-schema.json->rgbwarp-open-sound->description
+#. 6.2->settings-schema.json->team-rocket-open-sound->description
+#. 6.2->settings-schema.json->tv-open-sound->description
+#. 6.2->settings-schema.json->tv-glitch-open-sound->description
+#. 6.2->settings-schema.json->wisps-open-sound->description
+msgid "Sound on window appear events"
+msgstr ""
+
+#. 6.2->settings-schema.json->apparition-close-sound->description
+#. 6.2->settings-schema.json->aura-glow-close-sound->description
+#. 6.2->settings-schema.json->doom-close-sound->description
+#. 6.2->settings-schema.json->energize-a-close-sound->description
+#. 6.2->settings-schema.json->energize-b-close-sound->description
+#. 6.2->settings-schema.json->fire-close-sound->description
+#. 6.2->settings-schema.json->focus-close-sound->description
+#. 6.2->settings-schema.json->glide-close-sound->description
+#. 6.2->settings-schema.json->glitch-close-sound->description
+#. 6.2->settings-schema.json->hexagon-close-sound->description
+#. 6.2->settings-schema.json->incinerate-close-sound->description
+#. 6.2->settings-schema.json->magiclamp-close-sound->description
+#. 6.2->settings-schema.json->mushroom-close-sound->description
+#. 6.2->settings-schema.json->pixelate-close-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-close-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-close-sound->description
+#. 6.2->settings-schema.json->portal-close-sound->description
+#. 6.2->settings-schema.json->rgbwarp-close-sound->description
+#. 6.2->settings-schema.json->team-rocket-close-sound->description
+#. 6.2->settings-schema.json->tv-close-sound->description
+#. 6.2->settings-schema.json->tv-glitch-close-sound->description
+#. 6.2->settings-schema.json->wisps-close-sound->description
+msgid "Sound on window disappear events"
+msgstr ""
+
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 #, fuzzy
 msgid "Random Color"
@@ -946,7 +1017,7 @@ msgid "Custom"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire Preset"
+msgid "Fire effect style"
 msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
@@ -1130,7 +1201,7 @@ msgid "This effects the quality and the costs of the animation"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom Preset"
+msgid "Mushroom effect style"
 msgstr ""
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/vi.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/vi.po
@@ -6,8 +6,9 @@
 msgid ""
 msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 1.0.3\n"
-"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-extensions/issues\n"
-"POT-Creation-Date: 2025-10-15 21:53-0400\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
+"extensions/issues\n"
+"POT-Creation-Date: 2026-08-02 12:18-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: loccun <huynhloc.contact@gmail.com>\n"
 "Language-Team: \n"
@@ -17,33 +18,38 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.2/extension.js:208 6.2/extension.js:286 6.2/extension.js:614
+#. 6.2/extension.js:210 6.2/extension.js:311 6.2/extension.js:678
 msgid "Error"
 msgstr "Lỗi"
 
-#. 6.2/extension.js:208
+#. 6.2/extension.js:210
 msgid "was NOT enabled"
 msgstr "đã KHÔNG được bật"
 
-#. 6.2/extension.js:209 6.2/extension.js:287
+#. 6.2/extension.js:211 6.2/extension.js:312
 msgid "The existing extension"
 msgstr "Tiện ích mở rộng hiện có"
 
-#. 6.2/extension.js:209
+#. 6.2/extension.js:211
 msgid "conflicts with this extension."
 msgstr "xung đột với tiện ích mở rộng này."
 
-#. 6.2/extension.js:286
+#. 6.2/extension.js:311
 msgid "minimize/unminimize effects can not be enabled"
 msgstr "hiệu ứng thu nhỏ/phục hồi không thể được bật"
 
-#. 6.2/extension.js:287
+#. 6.2/extension.js:312
 msgid "already handles minimize/unminimize animation events."
 msgstr "đã xử lý sự kiện hoạt ảnh thu nhỏ/phục hồi."
 
-#. 6.2/extension.js:615
-msgid "Unable to determine the application or the WM_CLASS of the previously focused window, therefore application specific effects can not be applied to that window"
-msgstr "Không thể xác định ứng dụng hoặc WM_CLASS của cửa sổ được tập trung trước đó, do đó hiệu ứng cụ thể cho ứng dụng không thể áp dụng cho cửa sổ đó"
+#. 6.2/extension.js:679
+msgid ""
+"Unable to determine the application or the WM_CLASS of the previously "
+"focused window, therefore application specific effects can not be applied to "
+"that window"
+msgstr ""
+"Không thể xác định ứng dụng hoặc WM_CLASS của cửa sổ được tập trung trước "
+"đó, do đó hiệu ứng cụ thể cho ứng dụng không thể áp dụng cho cửa sổ đó"
 
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
@@ -79,7 +85,7 @@ msgstr "Hiện hình"
 msgid "Aura Glow"
 msgstr "Hào quang"
 
-#. effects/BrokenGlass.js:152
+#. effects/BrokenGlass.js:153
 msgid "Broken Glass"
 msgstr "Kính vỡ"
 
@@ -152,32 +158,32 @@ msgid "Fire"
 msgstr "Lửa"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:180
+#. effects/Fire.js:189
 msgid "Default Fire"
 msgstr "Lửa mặc định"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:190
+#. effects/Fire.js:199
 msgid "Hell Fire"
 msgstr "Lửa địa ngục"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:200
+#. effects/Fire.js:209
 msgid "Dark and Smutty"
 msgstr "Tối và bẩn"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:210
+#. effects/Fire.js:219
 msgid "Cold Breeze"
 msgstr "Gió lạnh"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:220
+#. effects/Fire.js:229
 msgid "Santa is Coming"
 msgstr "Ông già Noel đang đến"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:230
+#. effects/Fire.js:239
 msgid "Nuclear"
 msgstr "Hạt nhân"
 
@@ -288,42 +294,42 @@ msgid "Mushroom"
 msgstr "Nấm"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:227
+#. effects/Mushroom.js:236
 msgid "8Bit Plumber"
 msgstr "Thợ sửa ống nước 8Bit"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:244
+#. effects/Mushroom.js:253
 msgid "New Bros 2"
 msgstr "Anh em mới 2"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:262
+#. effects/Mushroom.js:271
 msgid "The True North"
 msgstr "Phương Bắc thực sự"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:280
+#. effects/Mushroom.js:289
 msgid "Red White and Blue"
 msgstr "Đỏ Trắng và Xanh"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:297
+#. effects/Mushroom.js:306
 msgid "Rainbow"
 msgstr "Cầu vồng"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:314
+#. effects/Mushroom.js:323
 msgid "Cattuccino"
 msgstr "Cattuccino"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:332
+#. effects/Mushroom.js:341
 msgid "Dracula"
 msgstr "Dracula"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:349
+#. effects/Mushroom.js:358
 msgid "Sparkle"
 msgstr "Lấp lánh"
 
@@ -492,13 +498,30 @@ msgstr "Đội Rocket"
 msgid "Wisps"
 msgstr "Luồng sáng"
 
+#. 6.2/CustomWidgets.py:509
+msgid "_Cancel"
+msgstr ""
+
+#. 6.2/CustomWidgets.py:510
+#, fuzzy
+msgid "_Open"
+msgstr "Mở"
+
+#. 6.2/CustomWidgets.py:520
+msgid "Sound files"
+msgstr ""
+
 #. metadata.json->name
 msgid "Burn My Windows"
 msgstr "Burn My Windows"
 
 #. metadata.json->description
-msgid "Window open/close/minimize/unminimize effects based on the Burn-My-Windows Gnome extension by Schneegans"
-msgstr "Hiệu ứng mở/đóng/thu nhỏ/phục hồi cửa sổ dựa trên tiện ích mở rộng Burn-My-Windows Gnome của Schneegans"
+msgid ""
+"Window open/close/minimize/unminimize effects based on the Burn-My-Windows "
+"Gnome extension by Schneegans"
+msgstr ""
+"Hiệu ứng mở/đóng/thu nhỏ/phục hồi cửa sổ dựa trên tiện ích mở rộng Burn-My-"
+"Windows Gnome của Schneegans"
 
 #. 6.2->settings-schema.json->general-page->title
 msgid "General"
@@ -540,11 +563,6 @@ msgstr "Bộ chọn Hiệu ứng"
 msgid "Effect Specific Settings"
 msgstr "Cài đặt Cụ thể Hiệu ứng"
 
-#. 6.2->settings-schema.json->fire-custom-section->title
-#. 6.2->settings-schema.json->mushroom-custom-section->title
-msgid "Setting for the custom preset:"
-msgstr "Cài đặt cho thiết lập tùy chỉnh:"
-
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
 msgstr "Hiệu ứng được bao gồm trong các bộ ngẫu nhiên:"
@@ -564,26 +582,36 @@ msgid ""
 "Version: ext-version\n"
 "\n"
 "Ported to Cinnamon by Kevin Langman\n"
-"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / <a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/new\">Report an issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/103\">Website</a>\n"
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/"
+"new\">Report an issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/"
+"extensions/view/103\">Website</a>\n"
 "\n"
 "Based on the Burn-My-Windows code by Schneegans and contributors\n"
-"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a> / <a href=\"https://ko-fi.com/schneegans\">Ko-fi</a>\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a> / <a "
+"href=\"https://ko-fi.com/schneegans\">Ko-fi</a>\n"
 "\n"
 "The Magic Lamp Effect is ported from code by hermes83\n"
-"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-effect\">Github</a>"
+"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
+"effect\">Github</a>"
 msgstr ""
 "\n"
 "<b>Phân rã cửa sổ của bạn với phong cách.</b>\n"
 "Phiên bản: ext-version\n"
 "\n"
 "Chuyển sang Cinnamon bởi Kevin Langman\n"
-"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / <a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/new\">Báo cáo vấn đề</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/103\">Trang web</a>\n"
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">Github</a> / "
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/new\">Báo "
+"cáo vấn đề</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/"
+"view/103\">Trang web</a>\n"
 "\n"
 "Dựa trên mã Burn-My-Windows của Schneegans và những người đóng góp\n"
-"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a> / <a href=\"https://ko-fi.com/schneegans\">Ko-fi</a>\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">Github</a> / <a "
+"href=\"https://ko-fi.com/schneegans\">Ko-fi</a>\n"
 "\n"
 "Hiệu ứng Đèn Thần được chuyển từ mã của hermes83\n"
-"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-effect\">Github</a>"
+"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
+"effect\">Github</a>"
 
 #. 6.2->settings-schema.json->app-rules->description
 msgid "Application Specific Rules"
@@ -614,24 +642,38 @@ msgid "Application"
 msgstr "Ứng dụng"
 
 #. 6.2->settings-schema.json->app-rules->tooltip
-msgid "A list of applications with special effect rules. The application can be a desktop file name or a WM_CLASS name"
-msgstr "Danh sách các ứng dụng có quy tắc hiệu ứng đặc biệt. Ứng dụng có thể là tên tập tin desktop hoặc tên WM_CLASS"
+msgid ""
+"A list of applications with special effect rules. The application can be a "
+"desktop file name or a WM_CLASS name"
+msgstr ""
+"Danh sách các ứng dụng có quy tắc hiệu ứng đặc biệt. Ứng dụng có thể là tên "
+"tập tin desktop hoặc tên WM_CLASS"
 
 #. 6.2->settings-schema.json->app-rules-button->description
 msgid "Add entry for the application of the most recently focused window"
 msgstr "Thêm mục cho ứng dụng của cửa sổ được tập trung gần đây nhất"
 
 #. 6.2->settings-schema.json->app-rules-button->tooltip
-msgid "Focus a window you want to enable application specific setting for then return here and press this button."
-msgstr "Tập trung vào một cửa sổ bạn muốn bật cài đặt cụ thể cho ứng dụng, sau đó quay lại đây và nhấn nút này."
+msgid ""
+"Focus a window you want to enable application specific setting for then "
+"return here and press this button."
+msgstr ""
+"Tập trung vào một cửa sổ bạn muốn bật cài đặt cụ thể cho ứng dụng, sau đó "
+"quay lại đây và nhấn nút này."
 
 #. 6.2->settings-schema.json->random-include->description
 msgid "Effects included in the randomized sets"
 msgstr "Hiệu ứng được bao gồm trong các bộ ngẫu nhiên"
 
 #. 6.2->settings-schema.json->random-include->tooltip
-msgid "Defines which effects are included in the randomized sets for each window event type. When 'Randomized' is selected for any event on the General tab these sets are used."
-msgstr "Xác định hiệu ứng nào được bao gồm trong các bộ ngẫu nhiên cho mỗi loại sự kiện cửa sổ. Khi 'Ngẫu nhiên' được chọn cho bất kỳ sự kiện nào trên thẻ Chung, các bộ này sẽ được sử dụng."
+msgid ""
+"Defines which effects are included in the randomized sets for each window "
+"event type. When 'Randomized' is selected for any event on the General tab "
+"these sets are used."
+msgstr ""
+"Xác định hiệu ứng nào được bao gồm trong các bộ ngẫu nhiên cho mỗi loại sự "
+"kiện cửa sổ. Khi 'Ngẫu nhiên' được chọn cho bất kỳ sự kiện nào trên thẻ "
+"Chung, các bộ này sẽ được sử dụng."
 
 #. 6.2->settings-schema.json->random-include->columns->title
 msgid "Effect Name         "
@@ -713,14 +755,34 @@ msgstr "Hiệu ứng mở cửa sổ"
 msgid "Close window effect"
 msgstr "Hiệu ứng đóng cửa sổ"
 
+#. 6.2->settings-schema.json->enable-sound->description
+msgid "Allow Burn My Windows to override cinnamon sound effects"
+msgstr ""
+
+#. 6.2->settings-schema.json->enable-sound->tooltip
+msgid ""
+"Allow Burn My Windows to override Cinnamon's window open/close/minimize "
+"sound effects with unique ones defined in the Effect Settings tab for each "
+"Burn My Windows effect. Note: Sounds will only play when Cinnamon's open/"
+"close/minimize sound effects are enabled under Cinnamon sounds settings. The "
+"default cinnamon sounds will be used unless a sound effect file is chosen "
+"for the active Burn My Windows effect."
+msgstr ""
+
 #. 6.2->settings-schema.json->dialog-special->description
 #. 6.2->settings-schema.json->power-dialog-special->description
 msgid "Special handling for dialog windows"
 msgstr "Xử lý đặc biệt cho cửa sổ hộp thoại"
 
 #. 6.2->settings-schema.json->dialog-special->tooltip
-msgid "Allows you to define special settings for handling dialog window types (i.e. file open dialog windows). These settings will override any application specific settings that may have been defined."
-msgstr "Cho phép bạn xác định cài đặt đặc biệt để xử lý các loại cửa sổ hộp thoại (ví dụ: cửa sổ mở tập tin). Các cài đặt này sẽ ghi đè lên bất kỳ cài đặt cụ thể ứng dụng nào có thể đã được xác định."
+msgid ""
+"Allows you to define special settings for handling dialog window types (i.e. "
+"file open dialog windows). These settings will override any application "
+"specific settings that may have been defined."
+msgstr ""
+"Cho phép bạn xác định cài đặt đặc biệt để xử lý các loại cửa sổ hộp thoại "
+"(ví dụ: cửa sổ mở tập tin). Các cài đặt này sẽ ghi đè lên bất kỳ cài đặt cụ "
+"thể ứng dụng nào có thể đã được xác định."
 
 #. 6.2->settings-schema.json->dialog-open-effect->description
 #. 6.2->settings-schema.json->power-dialog-open-effect->description
@@ -743,8 +805,12 @@ msgid "Unminimize window effect"
 msgstr "Hiệu ứng phục hồi cửa sổ"
 
 #. 6.2->settings-schema.json->power-dialog-special->tooltip
-msgid "Allows you to define special settings for handling dialog window types (i.e. file open dialog windows)."
-msgstr "Cho phép bạn xác định cài đặt đặc biệt để xử lý các loại cửa sổ hộp thoại (ví dụ: cửa sổ mở tập tin)."
+msgid ""
+"Allows you to define special settings for handling dialog window types (i.e. "
+"file open dialog windows)."
+msgstr ""
+"Cho phép bạn xác định cài đặt đặc biệt để xử lý các loại cửa sổ hộp thoại "
+"(ví dụ: cửa sổ mở tập tin)."
 
 #. 6.2->settings-schema.json->power-onbattery->description
 msgid "Use different effects when running on battery power"
@@ -752,9 +818,17 @@ msgstr "Sử dụng hiệu ứng khác khi chạy bằng nguồn pin"
 
 #. 6.2->settings-schema.json->power-onbattery->tooltip
 msgid ""
-"When enabled, a set of options will appear allowing you to define which effects (if any) will be used when running on battery power and the battery charge state is less than the set limit. These settings will take precedence over both the general settings and any application specific settings when the battery charge "
-"state condition is met."
-msgstr "Khi được bật, một bộ tùy chọn sẽ xuất hiện cho phép bạn xác định hiệu ứng nào (nếu có) sẽ được sử dụng khi chạy bằng nguồn pin và trạng thái sạc pin thấp hơn giới hạn đã đặt. Các cài đặt này sẽ được ưu tiên hơn cả cài đặt chung và bất kỳ cài đặt cụ thể ứng dụng nào khi điều kiện trạng thái sạc pin được đáp ứng."
+"When enabled, a set of options will appear allowing you to define which "
+"effects (if any) will be used when running on battery power and the battery "
+"charge state is less than the set limit. These settings will take precedence "
+"over both the general settings and any application specific settings when "
+"the battery charge state condition is met."
+msgstr ""
+"Khi được bật, một bộ tùy chọn sẽ xuất hiện cho phép bạn xác định hiệu ứng "
+"nào (nếu có) sẽ được sử dụng khi chạy bằng nguồn pin và trạng thái sạc pin "
+"thấp hơn giới hạn đã đặt. Các cài đặt này sẽ được ưu tiên hơn cả cài đặt "
+"chung và bất kỳ cài đặt cụ thể ứng dụng nào khi điều kiện trạng thái sạc pin "
+"được đáp ứng."
 
 #. 6.2->settings-schema.json->power-percent->description
 msgid "When battery is less than (percent)"
@@ -826,6 +900,56 @@ msgstr "Thời lượng Hiệu ứng (ms)"
 msgid "Reset to default"
 msgstr "Đặt lại về mặc định"
 
+#. 6.2->settings-schema.json->apparition-open-sound->description
+#. 6.2->settings-schema.json->aura-glow-open-sound->description
+#. 6.2->settings-schema.json->doom-open-sound->description
+#. 6.2->settings-schema.json->energize-a-open-sound->description
+#. 6.2->settings-schema.json->energize-b-open-sound->description
+#. 6.2->settings-schema.json->fire-open-sound->description
+#. 6.2->settings-schema.json->focus-open-sound->description
+#. 6.2->settings-schema.json->glide-open-sound->description
+#. 6.2->settings-schema.json->glitch-open-sound->description
+#. 6.2->settings-schema.json->hexagon-open-sound->description
+#. 6.2->settings-schema.json->incinerate-open-sound->description
+#. 6.2->settings-schema.json->magiclamp-open-sound->description
+#. 6.2->settings-schema.json->mushroom-open-sound->description
+#. 6.2->settings-schema.json->pixelate-open-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-open-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-open-sound->description
+#. 6.2->settings-schema.json->portal-open-sound->description
+#. 6.2->settings-schema.json->rgbwarp-open-sound->description
+#. 6.2->settings-schema.json->team-rocket-open-sound->description
+#. 6.2->settings-schema.json->tv-open-sound->description
+#. 6.2->settings-schema.json->tv-glitch-open-sound->description
+#. 6.2->settings-schema.json->wisps-open-sound->description
+msgid "Sound on window appear events"
+msgstr ""
+
+#. 6.2->settings-schema.json->apparition-close-sound->description
+#. 6.2->settings-schema.json->aura-glow-close-sound->description
+#. 6.2->settings-schema.json->doom-close-sound->description
+#. 6.2->settings-schema.json->energize-a-close-sound->description
+#. 6.2->settings-schema.json->energize-b-close-sound->description
+#. 6.2->settings-schema.json->fire-close-sound->description
+#. 6.2->settings-schema.json->focus-close-sound->description
+#. 6.2->settings-schema.json->glide-close-sound->description
+#. 6.2->settings-schema.json->glitch-close-sound->description
+#. 6.2->settings-schema.json->hexagon-close-sound->description
+#. 6.2->settings-schema.json->incinerate-close-sound->description
+#. 6.2->settings-schema.json->magiclamp-close-sound->description
+#. 6.2->settings-schema.json->mushroom-close-sound->description
+#. 6.2->settings-schema.json->pixelate-close-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-close-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-close-sound->description
+#. 6.2->settings-schema.json->portal-close-sound->description
+#. 6.2->settings-schema.json->rgbwarp-close-sound->description
+#. 6.2->settings-schema.json->team-rocket-close-sound->description
+#. 6.2->settings-schema.json->tv-close-sound->description
+#. 6.2->settings-schema.json->tv-glitch-close-sound->description
+#. 6.2->settings-schema.json->wisps-close-sound->description
+msgid "Sound on window disappear events"
+msgstr ""
+
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 msgid "Random Color"
 msgstr "Màu Ngẫu nhiên"
@@ -877,8 +1001,14 @@ msgid "Y offset fix for open/unminimize events"
 msgstr "Sửa lỗi lệch Y cho sự kiện mở/phục hồi"
 
 #. 6.2->settings-schema.json->doom-y-hack->tooltip
-msgid "Apply an offset to the Y axis window target position so that the open/unminimize animation completes at the right location. This is a hack fix for the Doom effect until I can find a proper fix"
-msgstr "Áp dụng một độ lệch cho vị trí đích cửa sổ trên trục Y để hoạt ảnh mở/phục hồi hoàn thành ở đúng vị trí. Đây là một bản sửa tạm thời cho hiệu ứng Doom cho đến khi tôi có thể tìm thấy bản sửa chính xác"
+msgid ""
+"Apply an offset to the Y axis window target position so that the open/"
+"unminimize animation completes at the right location. This is a hack fix for "
+"the Doom effect until I can find a proper fix"
+msgstr ""
+"Áp dụng một độ lệch cho vị trí đích cửa sổ trên trục Y để hoạt ảnh mở/phục "
+"hồi hoàn thành ở đúng vị trí. Đây là một bản sửa tạm thời cho hiệu ứng Doom "
+"cho đến khi tôi có thể tìm thấy bản sửa chính xác"
 
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
@@ -908,8 +1038,8 @@ msgid "Custom"
 msgstr "Tùy chỉnh"
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire Preset"
-msgstr "Thiết lập Lửa"
+msgid "Fire effect style"
+msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
 msgid "Fire Movement Speed"
@@ -928,8 +1058,12 @@ msgid "Use a Random Color (overrides other color settings)"
 msgstr "Sử dụng Màu Ngẫu nhiên (ghi đè các cài đặt màu khác)"
 
 #. 6.2->settings-schema.json->fire-random-color->tooltip
-msgid "Use a random fire color. This setting will override any preset or custom colors settings you select."
-msgstr "Sử dụng màu lửa ngẫu nhiên. Cài đặt này sẽ ghi đè bất kỳ thiết lập màu tùy chỉnh hoặc đặt sẵn nào bạn chọn."
+msgid ""
+"Use a random fire color. This setting will override any preset or custom "
+"colors settings you select."
+msgstr ""
+"Sử dụng màu lửa ngẫu nhiên. Cài đặt này sẽ ghi đè bất kỳ thiết lập màu tùy "
+"chỉnh hoặc đặt sẵn nào bạn chọn."
 
 #. 6.2->settings-schema.json->fire-colors->description
 msgid "Colors 1-5"
@@ -940,8 +1074,12 @@ msgid "Blur Quality"
 msgstr "Chất lượng Làm mờ"
 
 #. 6.2->settings-schema.json->focus-blur-quality->tooltip
-msgid "The Quality of the Blur (Setting this too high may increase GPU load and affect performance)"
-msgstr "Chất lượng của Làm mờ (Đặt quá cao có thể tăng tải GPU và ảnh hưởng đến hiệu suất)"
+msgid ""
+"The Quality of the Blur (Setting this too high may increase GPU load and "
+"affect performance)"
+msgstr ""
+"Chất lượng của Làm mờ (Đặt quá cao có thể tăng tải GPU và ảnh hưởng đến hiệu "
+"suất)"
 
 #. 6.2->settings-schema.json->glide-squish->description
 msgid "Squish"
@@ -1017,8 +1155,16 @@ msgid "The type of effect"
 msgstr "Loại hiệu ứng"
 
 #. 6.2->settings-schema.json->magiclamp-effect->tooltip
-msgid "The effect can be a smooth curve or a wavy animation. The random option will randomly choose between the two and the Appear/Disappear options use different effects whether a window is appearing or disappearing from the screen"
-msgstr "Hiệu ứng có thể là một đường cong mượt mà hoặc một hoạt ảnh sóng. Tùy chọn ngẫu nhiên sẽ chọn ngẫu nhiên giữa hai loại và các tùy chọn Xuất hiện/Biến mất sử dụng các hiệu ứng khác nhau tùy thuộc vào việc cửa sổ đang xuất hiện hay biến mất khỏi màn hình"
+msgid ""
+"The effect can be a smooth curve or a wavy animation. The random option will "
+"randomly choose between the two and the Appear/Disappear options use "
+"different effects whether a window is appearing or disappearing from the "
+"screen"
+msgstr ""
+"Hiệu ứng có thể là một đường cong mượt mà hoặc một hoạt ảnh sóng. Tùy chọn "
+"ngẫu nhiên sẽ chọn ngẫu nhiên giữa hai loại và các tùy chọn Xuất hiện/Biến "
+"mất sử dụng các hiệu ứng khác nhau tùy thuộc vào việc cửa sổ đang xuất hiện "
+"hay biến mất khỏi màn hình"
 
 #. 6.2->settings-schema.json->magiclamp-edge->options
 msgid "Top"
@@ -1045,16 +1191,30 @@ msgid "Open/Close Edge"
 msgstr "Cạnh Mở/Đóng"
 
 #. 6.2->settings-schema.json->magiclamp-edge->tooltip
-msgid "The monitor edge where a window should originate from when opening, or disappear towards when closing. This setting is not used for minimize or unminimize events"
-msgstr "Cạnh màn hình nơi cửa sổ nên bắt nguồn khi mở, hoặc biến mất về phía đó khi đóng. Cài đặt này không được sử dụng cho sự kiện thu nhỏ hoặc phục hồi"
+msgid ""
+"The monitor edge where a window should originate from when opening, or "
+"disappear towards when closing. This setting is not used for minimize or "
+"unminimize events"
+msgstr ""
+"Cạnh màn hình nơi cửa sổ nên bắt nguồn khi mở, hoặc biến mất về phía đó khi "
+"đóng. Cài đặt này không được sử dụng cho sự kiện thu nhỏ hoặc phục hồi"
 
 #. 6.2->settings-schema.json->magiclamp-edge-offset->description
 msgid "Open/Close Edge Offset"
 msgstr "Độ lệch Cạnh Mở/Đóng"
 
 #. 6.2->settings-schema.json->magiclamp-edge-offset->tooltip
-msgid "The offset from the top or left of the \"Open/Close Edge\" that the animation should use as the origin/target of the animation. This is a percentage of the monitors width/height and it does not apply to minimize/unminimize events or when the \"Open/Close Edge\" is set to \"Edge closest to mouse pointer\""
-msgstr "Độ lệch từ trên cùng hoặc bên trái của \"Cạnh Mở/Đóng\" mà hoạt ảnh nên sử dụng làm điểm xuất phát/đích của hoạt ảnh. Đây là phần trăm chiều rộng/cao của màn hình và không áp dụng cho sự kiện thu nhỏ/phục hồi hoặc khi \"Cạnh Mở/Đóng\" được đặt thành \"Cạnh gần con trỏ chuột nhất\""
+msgid ""
+"The offset from the top or left of the \"Open/Close Edge\" that the "
+"animation should use as the origin/target of the animation. This is a "
+"percentage of the monitors width/height and it does not apply to minimize/"
+"unminimize events or when the \"Open/Close Edge\" is set to \"Edge closest "
+"to mouse pointer\""
+msgstr ""
+"Độ lệch từ trên cùng hoặc bên trái của \"Cạnh Mở/Đóng\" mà hoạt ảnh nên sử "
+"dụng làm điểm xuất phát/đích của hoạt ảnh. Đây là phần trăm chiều rộng/cao "
+"của màn hình và không áp dụng cho sự kiện thu nhỏ/phục hồi hoặc khi \"Cạnh "
+"Mở/Đóng\" được đặt thành \"Cạnh gần con trỏ chuột nhất\""
 
 #. 6.2->settings-schema.json->magiclamp-x-tiles->description
 msgid "X Tiles"
@@ -1073,7 +1233,8 @@ msgid "This effects the quality and the costs of the animation"
 msgstr "Điều này ảnh hưởng đến chất lượng và chi phí của hoạt ảnh"
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom Preset"
+#, fuzzy
+msgid "Mushroom effect style"
 msgstr "Thiết lập Nấm"
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description
@@ -1152,11 +1313,13 @@ msgstr "Tốc độ Xanh dương"
 msgid "Animation Split"
 msgstr "Chia tách Hoạt ảnh"
 
-#. 6.2->settings-schema.json->team-rocket-horizontal-sparkle-position->description
+#. 6.2->settings-schema.json->team-rocket-horizontal-sparkle-
+#. position->description
 msgid "Horizontal Sparkle Position"
 msgstr "Vị trí Lấp lánh Ngang"
 
-#. 6.2->settings-schema.json->team-rocket-vertical-sparkle-position->description
+#. 6.2->settings-schema.json->team-rocket-vertical-sparkle-
+#. position->description
 msgid "Vertical Sparkle Position"
 msgstr "Vị trí Lấp lánh Dọc"
 

--- a/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/zh_TW.po
+++ b/CinnamonBurnMyWindows@klangman/files/CinnamonBurnMyWindows@klangman/po/zh_TW.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: CinnamonBurnMyWindows@klangman 1.0.3\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2025-10-15 21:53-0400\n"
+"POT-Creation-Date: 2026-08-02 12:18-0400\n"
 "PO-Revision-Date: 2026-05-31 20:00+0800\n"
 "Last-Translator: Alang Hsu <alang.hsu@gmail.com>\n"
 "Language-Team: Chinese (Traditional) <zh_Lang@li.org>\n"
@@ -16,36 +16,38 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.2/extension.js:208 6.2/extension.js:286 6.2/extension.js:614
+#. 6.2/extension.js:210 6.2/extension.js:311 6.2/extension.js:678
 msgid "Error"
 msgstr "錯誤"
 
-#. 6.2/extension.js:208
+#. 6.2/extension.js:210
 msgid "was NOT enabled"
 msgstr "未啟用"
 
-#. 6.2/extension.js:209 6.2/extension.js:287
+#. 6.2/extension.js:211 6.2/extension.js:312
 msgid "The existing extension"
 msgstr "現有擴充套件"
 
-#. 6.2/extension.js:209
+#. 6.2/extension.js:211
 msgid "conflicts with this extension."
 msgstr "與此擴充套件衝突。"
 
-#. 6.2/extension.js:286
+#. 6.2/extension.js:311
 msgid "minimize/unminimize effects can not be enabled"
 msgstr "無法啟用最小化/還原效果"
 
-#. 6.2/extension.js:287
+#. 6.2/extension.js:312
 msgid "already handles minimize/unminimize animation events."
 msgstr "已處理最小化/還原動畫事件。"
 
-#. 6.2/extension.js:615
+#. 6.2/extension.js:679
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore application specific effects can not be applied to "
 "that window"
-msgstr "無法判定先前焦點視窗的應用程式或 WM_CLASS，因此無法對該視窗套用應用程式特定效果"
+msgstr ""
+"無法判定先前焦點視窗的應用程式或 WM_CLASS，因此無法對該視窗套用應用程式特定效"
+"果"
 
 #. 6.2->settings-schema.json->effect-selector->options
 #. 6.2->settings-schema.json->open-window-effect->options
@@ -81,7 +83,7 @@ msgstr "幽靈旋風"
 msgid "Aura Glow"
 msgstr "光暈光輝"
 
-#. effects/BrokenGlass.js:152
+#. effects/BrokenGlass.js:153
 msgid "Broken Glass"
 msgstr "玻璃碎裂"
 
@@ -154,32 +156,32 @@ msgid "Fire"
 msgstr "烈火燃燒"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:180
+#. effects/Fire.js:189
 msgid "Default Fire"
 msgstr "預設烈火燃燒效果"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:190
+#. effects/Fire.js:199
 msgid "Hell Fire"
 msgstr "地獄之火"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:200
+#. effects/Fire.js:209
 msgid "Dark and Smutty"
 msgstr "暗黑之火"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:210
+#. effects/Fire.js:219
 msgid "Cold Breeze"
 msgstr "冰火之舞"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:220
+#. effects/Fire.js:229
 msgid "Santa is Coming"
 msgstr "聖誕節來臨"
 
 #. 6.2->settings-schema.json->fire-presets->options
-#. effects/Fire.js:230
+#. effects/Fire.js:239
 msgid "Nuclear"
 msgstr "核子"
 
@@ -290,42 +292,42 @@ msgid "Mushroom"
 msgstr "蘑菇爆炸"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:227
+#. effects/Mushroom.js:236
 msgid "8Bit Plumber"
 msgstr "8位元水管工"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:244
+#. effects/Mushroom.js:253
 msgid "New Bros 2"
 msgstr "新超級兄弟2"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:262
+#. effects/Mushroom.js:271
 msgid "The True North"
 msgstr "極北之光"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:280
+#. effects/Mushroom.js:289
 msgid "Red White and Blue"
 msgstr "紅白藍"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:297
+#. effects/Mushroom.js:306
 msgid "Rainbow"
 msgstr "彩虹"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:314
+#. effects/Mushroom.js:323
 msgid "Cattuccino"
 msgstr "貓咪奇諾"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:332
+#. effects/Mushroom.js:341
 msgid "Dracula"
 msgstr "德古拉"
 
 #. 6.2->settings-schema.json->mushroom-presets->options
-#. effects/Mushroom.js:349
+#. effects/Mushroom.js:358
 msgid "Sparkle"
 msgstr "閃耀"
 
@@ -494,6 +496,19 @@ msgstr "火箭隊"
 msgid "Wisps"
 msgstr "精靈飛散"
 
+#. 6.2/CustomWidgets.py:509
+msgid "_Cancel"
+msgstr ""
+
+#. 6.2/CustomWidgets.py:510
+#, fuzzy
+msgid "_Open"
+msgstr "開啟"
+
+#. 6.2/CustomWidgets.py:520
+msgid "Sound files"
+msgstr ""
+
 #. metadata.json->name
 msgid "Burn My Windows"
 msgstr "Burn My Windows"
@@ -502,7 +517,9 @@ msgstr "Burn My Windows"
 msgid ""
 "Window open/close/minimize/unminimize effects based on the Burn-My-Windows "
 "Gnome extension by Schneegans"
-msgstr "基於 Schneegans 的 Burn-My-Windows GNOME 擴充套件，提供視窗開啟/關閉/最小化/還原效果"
+msgstr ""
+"基於 Schneegans 的 Burn-My-Windows GNOME 擴充套件，提供視窗開啟/關閉/最小化/"
+"還原效果"
 
 #. 6.2->settings-schema.json->general-page->title
 msgid "General"
@@ -544,11 +561,6 @@ msgstr "效果選擇器"
 msgid "Effect Specific Settings"
 msgstr "效果詳細設定"
 
-#. 6.2->settings-schema.json->fire-custom-section->title
-#. 6.2->settings-schema.json->mushroom-custom-section->title
-msgid "Setting for the custom preset:"
-msgstr "自訂預設集設定："
-
 #. 6.2->settings-schema.json->random-section->title
 msgid "Effects included in the randomized sets:"
 msgstr "隨機組合中包含的效果："
@@ -586,13 +598,18 @@ msgstr ""
 "版本：ext-version\n"
 "\n"
 "由 Kevin Langman 移植至 Cinnamon\n"
-"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">GitHub</a> / <a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/new\">回報問題</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/103\">網站</a>\n"
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows\">GitHub</a> / "
+"<a href=\"https://github.com/klangman/CinnamonBurnMyWindows/issues/new\">回報"
+"問題</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
+"103\">網站</a>\n"
 "\n"
 "基於 Schneegans 及貢獻者的 Burn-My-Windows 程式碼\n"
-"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">GitHub</a> / <a href=\"https://ko-fi.com/schneegans\">Ko-fi</a>\n"
+"<a href=\"https://github.com/Schneegans/Burn-My-Windows\">GitHub</a> / <a "
+"href=\"https://ko-fi.com/schneegans\">Ko-fi</a>\n"
 "\n"
 "Magic Lamp 效果移植自 hermes83 的程式碼\n"
-"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-effect\">GitHub</a>"
+"<a href=\"https://github.com/hermes83/compiz-alike-magic-lamp-"
+"effect\">GitHub</a>"
 
 #. 6.2->settings-schema.json->app-rules->description
 msgid "Application Specific Rules"
@@ -626,7 +643,8 @@ msgstr "應用程式"
 msgid ""
 "A list of applications with special effect rules. The application can be a "
 "desktop file name or a WM_CLASS name"
-msgstr "具有特殊效果規則的應用程式清單。應用程式可以為桌面檔案名稱或 WM_CLASS 名稱"
+msgstr ""
+"具有特殊效果規則的應用程式清單。應用程式可以為桌面檔案名稱或 WM_CLASS 名稱"
 
 #. 6.2->settings-schema.json->app-rules-button->description
 msgid "Add entry for the application of the most recently focused window"
@@ -647,7 +665,9 @@ msgid ""
 "Defines which effects are included in the randomized sets for each window "
 "event type. When 'Randomized' is selected for any event on the General tab "
 "these sets are used."
-msgstr "定義每個視窗事件類型的隨機組合中包含哪些效果。當在「一般」標籤中為任一事件選取了「隨機」時，將使用這些組合。"
+msgstr ""
+"定義每個視窗事件類型的隨機組合中包含哪些效果。當在「一般」標籤中為任一事件選"
+"取了「隨機」時，將使用這些組合。"
 
 #. 6.2->settings-schema.json->random-include->columns->title
 msgid "Effect Name         "
@@ -729,6 +749,20 @@ msgstr "開啟視窗效果"
 msgid "Close window effect"
 msgstr "關閉視窗效果"
 
+#. 6.2->settings-schema.json->enable-sound->description
+msgid "Allow Burn My Windows to override cinnamon sound effects"
+msgstr ""
+
+#. 6.2->settings-schema.json->enable-sound->tooltip
+msgid ""
+"Allow Burn My Windows to override Cinnamon's window open/close/minimize "
+"sound effects with unique ones defined in the Effect Settings tab for each "
+"Burn My Windows effect. Note: Sounds will only play when Cinnamon's open/"
+"close/minimize sound effects are enabled under Cinnamon sounds settings. The "
+"default cinnamon sounds will be used unless a sound effect file is chosen "
+"for the active Burn My Windows effect."
+msgstr ""
+
 #. 6.2->settings-schema.json->dialog-special->description
 #. 6.2->settings-schema.json->power-dialog-special->description
 msgid "Special handling for dialog windows"
@@ -739,7 +773,9 @@ msgid ""
 "Allows you to define special settings for handling dialog window types (i.e. "
 "file open dialog windows). These settings will override any application "
 "specific settings that may have been defined."
-msgstr "允許您定義處理對話視窗類型（例如開啟檔案對話框）的特殊設定。這些設定將覆蓋任何可能已定義的應用程式特定設定。"
+msgstr ""
+"允許您定義處理對話視窗類型（例如開啟檔案對話框）的特殊設定。這些設定將覆蓋任"
+"何可能已定義的應用程式特定設定。"
 
 #. 6.2->settings-schema.json->dialog-open-effect->description
 #. 6.2->settings-schema.json->power-dialog-open-effect->description
@@ -779,7 +815,9 @@ msgid ""
 "over both the general settings and any application specific settings when "
 "the battery charge state condition is met."
 msgstr ""
-"啟用後，將顯示一組選項，讓您定義在使用電池且電量低於設定閾值時要使用哪些效果（可選擇無效果）。當符合電池電量條件時，這些設定將優先於一般設定和應用程式特定設定。"
+"啟用後，將顯示一組選項，讓您定義在使用電池且電量低於設定閾值時要使用哪些效果"
+"（可選擇無效果）。當符合電池電量條件時，這些設定將優先於一般設定和應用程式特"
+"定設定。"
 
 #. 6.2->settings-schema.json->power-percent->description
 msgid "When battery is less than (percent)"
@@ -851,6 +889,56 @@ msgstr "效果持續時間（毫秒）"
 msgid "Reset to default"
 msgstr "重設為預設值"
 
+#. 6.2->settings-schema.json->apparition-open-sound->description
+#. 6.2->settings-schema.json->aura-glow-open-sound->description
+#. 6.2->settings-schema.json->doom-open-sound->description
+#. 6.2->settings-schema.json->energize-a-open-sound->description
+#. 6.2->settings-schema.json->energize-b-open-sound->description
+#. 6.2->settings-schema.json->fire-open-sound->description
+#. 6.2->settings-schema.json->focus-open-sound->description
+#. 6.2->settings-schema.json->glide-open-sound->description
+#. 6.2->settings-schema.json->glitch-open-sound->description
+#. 6.2->settings-schema.json->hexagon-open-sound->description
+#. 6.2->settings-schema.json->incinerate-open-sound->description
+#. 6.2->settings-schema.json->magiclamp-open-sound->description
+#. 6.2->settings-schema.json->mushroom-open-sound->description
+#. 6.2->settings-schema.json->pixelate-open-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-open-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-open-sound->description
+#. 6.2->settings-schema.json->portal-open-sound->description
+#. 6.2->settings-schema.json->rgbwarp-open-sound->description
+#. 6.2->settings-schema.json->team-rocket-open-sound->description
+#. 6.2->settings-schema.json->tv-open-sound->description
+#. 6.2->settings-schema.json->tv-glitch-open-sound->description
+#. 6.2->settings-schema.json->wisps-open-sound->description
+msgid "Sound on window appear events"
+msgstr ""
+
+#. 6.2->settings-schema.json->apparition-close-sound->description
+#. 6.2->settings-schema.json->aura-glow-close-sound->description
+#. 6.2->settings-schema.json->doom-close-sound->description
+#. 6.2->settings-schema.json->energize-a-close-sound->description
+#. 6.2->settings-schema.json->energize-b-close-sound->description
+#. 6.2->settings-schema.json->fire-close-sound->description
+#. 6.2->settings-schema.json->focus-close-sound->description
+#. 6.2->settings-schema.json->glide-close-sound->description
+#. 6.2->settings-schema.json->glitch-close-sound->description
+#. 6.2->settings-schema.json->hexagon-close-sound->description
+#. 6.2->settings-schema.json->incinerate-close-sound->description
+#. 6.2->settings-schema.json->magiclamp-close-sound->description
+#. 6.2->settings-schema.json->mushroom-close-sound->description
+#. 6.2->settings-schema.json->pixelate-close-sound->description
+#. 6.2->settings-schema.json->pixel-wheel-close-sound->description
+#. 6.2->settings-schema.json->pixel-wipe-close-sound->description
+#. 6.2->settings-schema.json->portal-close-sound->description
+#. 6.2->settings-schema.json->rgbwarp-close-sound->description
+#. 6.2->settings-schema.json->team-rocket-close-sound->description
+#. 6.2->settings-schema.json->tv-close-sound->description
+#. 6.2->settings-schema.json->tv-glitch-close-sound->description
+#. 6.2->settings-schema.json->wisps-close-sound->description
+msgid "Sound on window disappear events"
+msgstr ""
+
 #. 6.2->settings-schema.json->aura-glow-random-color->description
 msgid "Random Color"
 msgstr "隨機顏色"
@@ -906,7 +994,9 @@ msgid ""
 "Apply an offset to the Y axis window target position so that the open/"
 "unminimize animation completes at the right location. This is a hack fix for "
 "the Doom effect until I can find a proper fix"
-msgstr "對視窗目標位置的 Y 軸套用偏移，使開啟/還原動畫在正確位置完成。這是 Doom 效果的臨時修正，直到找到正式解決方案"
+msgstr ""
+"對視窗目標位置的 Y 軸套用偏移，使開啟/還原動畫在正確位置完成。這是 Doom 效果"
+"的臨時修正，直到找到正式解決方案"
 
 #. 6.2->settings-schema.json->energize-a-scale->description
 #. 6.2->settings-schema.json->energize-b-scale->description
@@ -936,8 +1026,8 @@ msgid "Custom"
 msgstr "自訂"
 
 #. 6.2->settings-schema.json->fire-presets->description
-msgid "Fire Preset"
-msgstr "火焰預設集"
+msgid "Fire effect style"
+msgstr ""
 
 #. 6.2->settings-schema.json->fire-custom-movement-speed->description
 msgid "Fire Movement Speed"
@@ -1054,7 +1144,9 @@ msgid ""
 "randomly choose between the two and the Appear/Disappear options use "
 "different effects whether a window is appearing or disappearing from the "
 "screen"
-msgstr "效果可以為平滑曲線或波浪動畫。隨機選項將隨機選擇兩者之一；「出現/消失」選項則分別使用不同的效果來處理視窗的出現與消失。"
+msgstr ""
+"效果可以為平滑曲線或波浪動畫。隨機選項將隨機選擇兩者之一；「出現/消失」選項則"
+"分別使用不同的效果來處理視窗的出現與消失。"
 
 #. 6.2->settings-schema.json->magiclamp-edge->options
 msgid "Top"
@@ -1085,7 +1177,9 @@ msgid ""
 "The monitor edge where a window should originate from when opening, or "
 "disappear towards when closing. This setting is not used for minimize or "
 "unminimize events"
-msgstr "視窗開啟時應從哪個螢幕邊緣出現，或關閉時消失至哪個邊緣。此設定不適用於最小化或還原事件。"
+msgstr ""
+"視窗開啟時應從哪個螢幕邊緣出現，或關閉時消失至哪個邊緣。此設定不適用於最小化"
+"或還原事件。"
 
 #. 6.2->settings-schema.json->magiclamp-edge-offset->description
 msgid "Open/Close Edge Offset"
@@ -1099,7 +1193,9 @@ msgid ""
 "unminimize events or when the \"Open/Close Edge\" is set to \"Edge closest "
 "to mouse pointer\""
 msgstr ""
-"動畫應使用的「開啟/關閉邊緣」從頂部或左側的偏移量，作為動畫的起點/終點。此為螢幕寬度/高度的百分比，不適用於最小化/還原事件，也不適用於「開啟/關閉邊緣」設為「最接近滑鼠游標的邊緣」的情況。"
+"動畫應使用的「開啟/關閉邊緣」從頂部或左側的偏移量，作為動畫的起點/終點。此為"
+"螢幕寬度/高度的百分比，不適用於最小化/還原事件，也不適用於「開啟/關閉邊緣」設"
+"為「最接近滑鼠游標的邊緣」的情況。"
 
 #. 6.2->settings-schema.json->magiclamp-x-tiles->description
 msgid "X Tiles"
@@ -1118,7 +1214,8 @@ msgid "This effects the quality and the costs of the animation"
 msgstr "這會影響動畫的品質和效能成本"
 
 #. 6.2->settings-schema.json->mushroom-presets->description
-msgid "Mushroom Preset"
+#, fuzzy
+msgid "Mushroom effect style"
 msgstr "蘑菇預設集"
 
 #. 6.2->settings-schema.json->mushroom-custom-scale-style->description


### PR DESCRIPTION
- Improved the Fire and Mushroom effect settings to be more clean, the custom settings now only show when "custom" is selected in the drop-down list.
- Added Effect settings sound options for each effect, allowing you to setup custom sounds for each effect open/unminimize and close/minimize events.. There are no default effects but you can download sound files and add them to BurnMyWindows.