### PR TITLE
active-window-indicator@fabiodamio - Add Spanish translation

### DIFF
--- a/active-window-indicator@fabiodamio/files/active-window-indicator@fabiodamio/po/es.po
+++ b/active-window-indicator@fabiodamio/files/active-window-indicator@fabiodamio/po/es.po
@@ -1,0 +1,71 @@
+# ACTIVE WINDOW INDICATOR
+# This file is put in the public domain.
+# fabiodamio, 2017
+#
+#, fuzzy
+msgid ""
+msgstr ""
+"Project-Id-Version: active-window-indicator@fabiodamio 1.0.0\n"
+"Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
+"extensions/issues\n"
+"POT-Creation-Date: 2026-08-04 18:18+0200\n"
+"PO-Revision-Date: \n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: Poedit 3.9\n"
+
+#. metadata.json->name
+msgid "Active Window Indicator"
+msgstr "Indicador de ventana activa"
+
+#. metadata.json->description
+msgid "Highlights the active window with a customizable top bar."
+msgstr ""
+"Resalta la ventana activa con una barra superior personalizable."
+
+#. settings-schema.json->line-height->units
+#. settings-schema.json->slant-percent->units
+msgid "px"
+msgstr "px"
+
+#. settings-schema.json->line-height->description
+msgid "Line height"
+msgstr "Altura de línea"
+
+#. settings-schema.json->line-height->tooltip
+msgid "Set the height of the indicator line"
+msgstr "Establecer la altura de la línea indicadora"
+
+#. settings-schema.json->width-percent->units
+#. settings-schema.json->alpha-percent->units
+msgid "%"
+msgstr "%"
+
+#. settings-schema.json->width-percent->description
+msgid "Width relative to window"
+msgstr "Ancho respecto a la ventana"
+
+#. settings-schema.json->slant-percent->description
+msgid "End slant"
+msgstr "Inclinación de los extremos"
+
+#. settings-schema.json->alpha-percent->description
+msgid "Opacity / Transparency"
+msgstr "Opacidad / Transparencia"
+
+#. settings-schema.json->anim-speed->description
+msgid "Gradient animation speed (1 = slow, 20 = fast)"
+msgstr ""
+"Velocidad de animación con gradiente (1 = lenta, 20 = rápida)"
+
+#. settings-schema.json->color-start->description
+msgid "Start color"
+msgstr "Color inicial"
+
+#. settings-schema.json->color-end->description
+msgid "End color"
+msgstr "Color final"


### PR DESCRIPTION
I don't know if it's just me or if it's a bug, but when I use “hot corners,” the bar is visible.

<img width="1366" height="768" alt="Screenshot from 2026-08-06 12-31-01" src="https://github.com/user-attachments/assets/2e1674f6-fbe6-4803-9256-544bfacca921" />

P.S. I'm using Mint 22.3, Cinnamon 6.6.9, X11 session
