### PR TITLE
[BlurCinnamon@klangman] v2.6.0 Dual Kawase blur, title bar blur, fixes

### DIFF
--- a/BlurCinnamon@klangman/CHANGELOG.md
+++ b/BlurCinnamon@klangman/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+## 2.6.0
+
+* Added a new Dual Kawase Blur algorithm written by Lucas-X-A which gives a Gaussian like smooth blur that is faster (better for low end GPUs) and produces better results in many cases as compared to the Gaussian blur algorithm. This is the new default algorithm for new installs, but people upgrading to this version will need to manually switch to Dual Kawase if they want to take advantage of this new algorithm.
+* Added an option to blur window title bars. This feature requires changes to your theme's CSS code, see the website for instruction (GTK3 and Mint-Y only)
+* Fix an Cinnamon crash when closing a non-focused blurred application window when the focused window is also a blurred application window.
+* Fix an issue where the desktop icons were not showing up the the Dynamic blur backgrounds
+* Fix a small delay before Dynamic blur effects appear when using the show desklets (Super+S) Cinnamon feature.
+* Fix some issues around UI scaling
+* Fix a memory leak due to not removing some listeners
+* Fix for window blurring not resizing properly when windows are "shaded"
+* Add an blur algorithm information guide to the "Generic effect settings" tab
+
+Special thanks to <a href=\"https://github.com/Lucas-X-A\">Lucas-X-A</a> for his many contributions to this release!
+
 ## 2.5.2
 
 * Fix a 2.5.1 regression with handling fullscreen windows
@@ -11,9 +25,9 @@
 * Fix for the blurred background of panels disappearing after closing the active workspace
 * Fix for the standard Alt-Tab switcher effects not disabling after unchecking the Alt-Tab effect on the General Setup tab
 * Simplified tracking of visible windows for dynamic blurring, hopefully fixing some cases of sticky clones
-* Fixes cases were new windows added while showing desklets (Super+S) would not get added to the clones for Desklets
+* Fixes cases were new windows added while showing desklets (Super+S) would not get added to the clones for Desklet dynamic blurring
 * Fixed the Standard Alt-Tab switcher effects so that it respects the app switcher "Override" option
-* Fixed performance issue casued failing to disconnect a signal for the Classic Alt-Tab switcher
+* Fixed a performance issue caused by failing to disconnect a signal for the Classic Alt-Tab switcher
 * Fixed some cases where the blurred background was placed in the wrong location for the standards Alt-Tab switcher
 * Fixed a "flash" of the desktop image in the blurred standard Alt-Tab switcher when using Dynamic effects
 
@@ -27,7 +41,7 @@
 * Added option to allow theme setting to remain for Notifications and Tooltips
 * Improved how window stacking is tracked for dynamic blurring (fixes issues with showing incorrect background windows)
 * Fixed a number of issues to allow proper support for video wallpapers (i.e. Hidamari)
-* Fixes some most cases where Application Window Dynamic blurring would cause issue with moving/resizing windows
+* Fixes most cases where Application Window Dynamic blurring would cause issue with moving/resizing windows
 * Fix some issues that occur after changing the UI scale and/or screen resolution
 * Better window tracking for the focused window backlight effect
 * A bunch of other fixes that I didn't remember to document

--- a/BlurCinnamon@klangman/README.md
+++ b/BlurCinnamon@klangman/README.md
@@ -29,10 +29,13 @@ Cinnamon components you can apply effects to (currently):
 | Gaussian dynamic blur           | Panels, Menu, Notifications, Tooltips, Windows, Desklets | Uses a Gaussian blur effect on top of a full desktop clone with windows and the desktop wallpaper                     |
 | Monte Carlo static blur         | Panels, Menu, Notifications, Tooltips, Windows, Desklets | Uses a Monte Carlo blur effect on top of the desktop wallpaper                                                        |
 | Monte Carlo dynamic blur        | Panels, Menu, Notifications, Tooltips, Windows, Desklets | Uses a Monte Carlo blur effect on top of a full desktop clone with windows and the desktop wallpaper                  |
+| Dual Kawase static blur         | Panels, Menu, Notifications, Tooltips, Windows, Desklets | Uses a Dual Kawase blur effect on top of the desktop wallpaper                                                        |
+| Dual Kawase dynamic blur        | Panels, Menu, Notifications, Tooltips, Windows, Desklets | Uses a Dual Kawase blur effect on top of a full desktop clone with windows and the desktop wallpaper                  |
 | Simple / Gaussian / Monte Carlo | Desktop, Expo, Overview                                  | These components can't benefit from anything other than static blurring (blur effect on top of the desktop wallpaper) |
 
 ## Features
 
+- A Dual Kawase blur algorithm which is efficient on low end GPUs/CPUs.
 - Gaussian and Monte Carlo blur algorithms (borrowed from the Gnome extension Blur-my-Shell) with a user configurable intensity
 - Simple blur algorithm (the Cinnamon built-in algorithm) which I would only recommend for very old computers
 - Dimming overlay with user configurable color and intensity (fully-transparent to a solid color)
@@ -76,9 +79,9 @@ Using any of the above with Blur Cinnamon may have some odd side effects that wo
 
 Blur Cinnamon can apply a blurred background to just about any window, but no application windows will have effects applied unless the "Application windows" support is enabled on the "General setup" tab of the Blur Cinnamon configuration window **<u>and</u>** the table under the "Component specific settings" for "windows" has been setup to allow specific windows to have effects enabled. 
 
-Even then the effects will only be visible when the application window (i.e Terminal) is configured to be transparent.  Many Terminal programs have options in their preferences that allows the Terminal to be transparent.
+Even then the **effects will only be visible when the application window (i.e Terminal) is configured to be transparent**.  Many Terminal programs have options in their preferences that allows the Terminal to be transparent.
 
-For windows that can't be configured to have transparent elements, you have the option of reducing the "Opacity" in Blur Cinnamon setting for the window, or by using the "Opacity Slider" extension. With a windows Opacity set to less than 100% you will see the Blur Cinnamon effects behind the window.
+For windows that can't be configured to have transparent elements, you have the option of **reducing the "Opacity" in Blur Cinnamon setting** for the window, or by using the "Opacity Slider" extension. With a windows Opacity set to less than 100% you will see the Blur Cinnamon effects behind the window.
 
 There is also a "Default window settings" entry in the Blur Cinnamon Windows setting page. With this entry enabled all normal windows will have effects applied. Specific windows can still be excluded by adding table entries for the windows you what to exclude and making sure the Enabled setting for the entry is **NOT** checked.
 
@@ -107,6 +110,37 @@ padding-left: 10px; padding-right: 10px; border-radius: 20px; border-width: 1px;
 
 The border radius rounds the corners, the padding adds space on each end of the panel to accommodate the rounded corners better, and the margins shrink the panel so that it does not fill the width of the screen resulting in a centered panel. 
 
+## Window Title Bar Blurring
+
+To enable application window title bar blurring for GTK3 windows when using the Mint-Y theme:
+
+1. Enable the "Blur window title bars" option under the "Component specific settings" tab with the "Windows" component selected.
+
+2. Add the following CSS code into the `~/.config/gtk-3.0/gtk.css` file. Create the file if it does not exist, which will likely be the case.
+   
+   ```
+   /* Make the titlebars semi-transparent, Opacity 0.5 */
+   headerbar, .titlebar {
+      background-color: rgba(0, 0, 0, 0.5);
+      border: none;
+      box-shadow: none;
+   }
+   ```
+
+3. Restart Cinnamon: ALT-F2, type r, press Enter
+
+You can modify the `rgba` values to achieve different colors (i.e. a blue glass look) and/or change the opacity of the title bar. But don't reduce the opacity to `0` or the window title bar controls will also disappear.
+
+Limitations:
+
+1. This only works for GTK3 windows, GTK4 windows will not be effected, and as I understand it they can not be changed to have transparent title bars.
+
+2. The title bar controls (close, minimize, maximize, etc.) will also be made semi-transparent, I was unable to find a way to have solid controls, but maybe someone that knows Cinnamon/GTK3 CSS better than I can make it solid?
+
+3. Applications that draw their own title bars (ie. Firefox, Chrome, Discord, etc.) will not be effected. In fact chrome will have a transparent title bar, but Blur Cinnamon is unable to determine the height of the title bar and therefore it is left without blurring effects. For Chrome you can enable the "Use system title bar and borders" option.
+
+4. The CSS code here only works for Mint-Y Application themes. The Mint-X theme does not work, but maybe it could be made to work with different CSS code.
+
 ## Feedback
 
 Please leave a comment here on cinnamon-spices.linuxmint.com or you can create an issue on my [Github](https://github.com/klangman/BlurCinnamon) to give me feedback, make a suggestion or to report any issues you find.
@@ -118,5 +152,7 @@ If you like this Cinnamon extension, please give it a "star" here any maybe on m
 Some code was borrowed from the [BlurOverview](https://cinnamon-spices.linuxmint.com/extensions/view/72) Extension by nailfarmer.
 
 The Gaussian, Monte Carlo and rounded corner effects code was borrowed from the Gnome [Blur my shell](https://github.com/aunetx/blur-my-shell) extension by [Aurélien Hamy](https://github.com/aunetx).
+
+The Dual Kawase algorithm effect code was written by <a href=\"https://github.com/Lucas-X-A\">Lucas-X-A</a>.
 
 The Blur Cinnamon icon was generated by Google Gemini

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/CustomWidgets.py
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/CustomWidgets.py
@@ -148,7 +148,7 @@ class LabelWithTooltip(SettingsWidget):
       self.label.set_line_wrap(True)
       self.pack_start(self.label, True, True, 0)
       if "tooltip" in info:
-         self.label.set_tooltip_text(info["tooltip"])
+         self.label.set_tooltip_markup(info["tooltip"])
 
 
 # An About page Widget with an image and a centered label that supports markup
@@ -160,7 +160,7 @@ class About(SettingsWidget):
       self.info = info
 
       UUID = "BlurCinnamon@klangman"
-      extensions_path  = GLib.get_home_dir() + "/.local/share/cinnamon/extensions/"
+      extensions_path  = GLib.get_user_data_dir() + "/cinnamon/extensions/"
 
       self.box = Gtk.Box(spacing=10,orientation=Gtk.Orientation.VERTICAL,margin_start=20, margin_end=20, margin_top=20, margin_left=20, margin_right=20)
       self.label = Gtk.Label("", xalign=0.5, justify=Gtk.Justification.CENTER, expand=True)

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/corner.js
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/corner.js
@@ -19,7 +19,7 @@ const DEFAULT_PARAMS = {
 // code from "common.glsl" is prepended automatically.
 function loadShaderResource(uuid, file_name) {
     let file;
-    file = Gio.File.new_for_path( GLib.get_home_dir() + '/.local/share/cinnamon/extensions/' + uuid  + "/6.0/" + file_name );
+    file = Gio.File.new_for_path( GLib.get_user_data_dir() + '/cinnamon/extensions/' + uuid  + "/6.0/" + file_name );
     let [data, etag] = file.load_bytes(null);
     let code = new TextDecoder().decode(data.get_data());
 
@@ -102,9 +102,8 @@ var CornerEffect = (typeof global === 'undefined') ?
             if (this._source)
                 this.set_shader_source(this._source);
 
-            //TODO: Get this code working in Cinnamon
-            //const theme_context = St.ThemeContext.get_for_stage(global.stage);
-            //theme_context.connectObject('notify::scale-factor', _ => this.update_radius(), this);
+            // Safe fetch of the current scale factor 
+            this.update_radius();
         }
 
         static get default_params() {
@@ -203,9 +202,15 @@ var CornerEffect = (typeof global === 'undefined') ?
                 let old_actor = this.get_actor();
                 old_actor?.disconnect(this._actor_connection_size_id);
             }
+
             if (this._actor_connection_clip_rect_id) {
                 let old_actor = this.get_actor();
                 old_actor?.disconnect(this._actor_connection_clip_rect_id);
+            }
+
+            if (this._scale_connection_id) {
+                St.ThemeContext.get_for_stage(global.stage).disconnect(this._scale_connection_id);
+                this._scale_connection_id = null;
             }
 
             if (actor) {
@@ -220,8 +225,11 @@ var CornerEffect = (typeof global === 'undefined') ?
                 this._actor_connection_clip_rect_id = actor.connect('notify::clip-rect', _ => {
                     this.clip = actor.has_clip ? actor.get_clip() : [0, 0, -10, -10];
                 });
-            }
-            else {
+
+                this._scale_connection_id = St.ThemeContext.get_for_stage(global.stage).connect('notify::scale-factor', () => {
+                    this.update_radius();
+                });
+            } else {
                 this._actor_connection_size_id = null;
                 this._actor_connection_clip_rect_id = null;
             }

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/dual_filtering_down.glsl
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/dual_filtering_down.glsl
@@ -1,0 +1,22 @@
+uniform sampler2D tex;
+uniform float offset;
+uniform float width;
+uniform float height;
+
+vec4 sampleBoundary(vec2 uv, vec2 uv_offset, vec2 pixel_step) {
+    vec2 pos = clamp(uv + uv_offset * pixel_step, vec2(3.0 / width, 3.0 / height), vec2(1.0 - 3.0 / width, 1.0 - 3.0 / height));
+    return texture2D(tex, pos);
+}
+
+void main() {
+    vec2 uv = cogl_tex_coord_in[0].xy;
+    vec2 pixel_step = vec2(1.0 / width, 1.0 / height);
+
+    vec4 sum = texture2D(tex, uv) * 4.0;
+    sum += sampleBoundary(uv, vec2(-offset * 0.5, -offset * 0.5), pixel_step);
+    sum += sampleBoundary(uv, vec2( offset * 0.5, -offset * 0.5), pixel_step);
+    sum += sampleBoundary(uv, vec2(-offset * 0.5,  offset * 0.5), pixel_step);
+    sum += sampleBoundary(uv, vec2( offset * 0.5,  offset * 0.5), pixel_step);
+
+    cogl_color_out = sum / 8.0;
+}

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/dual_filtering_up.glsl
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/dual_filtering_up.glsl
@@ -1,0 +1,34 @@
+uniform sampler2D tex;
+uniform float offset;
+uniform float brightness;
+uniform float width;
+uniform float height;
+uniform int is_last_pass;
+
+vec4 sampleBoundary(vec2 uv, vec2 uv_offset, vec2 pixel_step) {
+    vec2 pos = clamp(uv + uv_offset * pixel_step, vec2(3.0 / width, 3.0 / height), vec2(1.0 - 3.0 / width, 1.0 - 3.0 / height));
+    return texture2D(tex, pos);
+}
+
+void main() {
+    vec2 uv = cogl_tex_coord_in[0].xy;
+    vec2 pixel_step = vec2(1.0 / width, 1.0 / height);
+
+    // Cross at a distance of 1.5 | Diagonals at a distance of 0.5
+    vec4 sum = sampleBoundary(uv, vec2(-offset * 1.5, 0.0), pixel_step);
+    sum += sampleBoundary(uv, vec2(-offset * 0.5, offset * 0.5), pixel_step) * 2.0;
+    sum += sampleBoundary(uv, vec2(0.0, offset * 1.5), pixel_step);
+    sum += sampleBoundary(uv, vec2(offset * 0.5, offset * 0.5), pixel_step) * 2.0;
+    sum += sampleBoundary(uv, vec2(offset * 1.5, 0.0), pixel_step);
+    sum += sampleBoundary(uv, vec2(offset * 0.5, -offset * 0.5), pixel_step) * 2.0;
+    sum += sampleBoundary(uv, vec2(0.0, -offset * 1.5), pixel_step);
+    sum += sampleBoundary(uv, vec2(-offset * 0.5, -offset * 0.5), pixel_step) * 2.0;
+
+    sum /= 12.0;
+
+    if (is_last_pass == 1) {
+        sum.rgb *= brightness;
+    }
+
+    cogl_color_out = sum;
+}

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/dual_kawase_blur.js
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/dual_kawase_blur.js
@@ -1,0 +1,297 @@
+// Implemented based on the Dual Kawase Blur method described in SIGGRAPH 2015 by Marius Bjørge
+// Optimized for Cinnamon by stacking progressive multi-pass shader effects
+
+const GObject  = imports.gi.GObject;
+const St       = imports.gi.St;
+const Clutter  = imports.gi.Clutter;
+const GLib     = imports.gi.GLib;
+
+const UUID = "BlurCinnamon@klangman";
+
+const DEFAULT_PARAMS = {
+    radius: 0, brightness: 1,
+    width: 0, height: 0, 
+    pass_index: 0, total_passes: 1, chained_effect: null
+};
+
+var DualFilteringBlurEffect =
+    new GObject.registerClass({
+        GTypeName: `DualFilteringBlurEffect_${Math.floor(Math.random() * 100000) + 1}`,
+        Properties: {
+            'radius': GObject.ParamSpec.double(
+                `radius`,
+                `Radius`,
+                `Blur radius`,
+                GObject.ParamFlags.READWRITE,
+                0.0, 2000.0,
+                0.0,
+            ),
+            'brightness': GObject.ParamSpec.double(
+                `brightness`,
+                `Brightness`,
+                `Blur brightness`,
+                GObject.ParamFlags.READWRITE,
+                0.0, 1.0,
+                1.0,
+            ),
+            'width': GObject.ParamSpec.double(
+                `width`,
+                `Width`,
+                `Width`,
+                GObject.ParamFlags.READWRITE,
+                0.0, Number.MAX_SAFE_INTEGER,
+                0.0,
+            ),
+            'height': GObject.ParamSpec.double(
+                `height`,
+                `Height`,
+                `Height`,
+                GObject.ParamFlags.READWRITE,
+                0.0, Number.MAX_SAFE_INTEGER,
+                0.0,
+            ),
+            'pass_index': GObject.ParamSpec.int(
+                `pass_index`,
+                `Pass Index`,
+                `Current step in pipeline`,
+                GObject.ParamFlags.READWRITE,
+                0, 16,
+                0,
+            ),
+            'total_passes': GObject.ParamSpec.int(
+                `total_passes`,
+                `Total Passes`,
+                `Total depth of the blur pyramid`,
+                GObject.ParamFlags.READWRITE,
+                1, 16,
+                1,
+            ),
+            'chained_effect': GObject.ParamSpec.object(
+                `chained_effect`,
+                `Chained Effect`,
+                `Chained Effect`,
+                GObject.ParamFlags.READWRITE,
+                GObject.Object,
+            ),
+        }
+    }, class DualFilteringBlurEffect extends Clutter.ShaderEffect {
+        constructor(params) {
+            super(params);
+
+            this.pass_index = params?.pass_index ?? 0;
+            this.total_passes = params?.total_passes ?? 1;
+            this._sub_effects = []; 
+
+            // Determines Downsample vs Upsample based on the midpoint of the pyramid
+            let is_downsample = (this.pass_index <= Math.floor(this.total_passes / 2));
+            let shader_file = is_downsample ? 'dual_filtering_down.glsl' : 'dual_filtering_up.glsl';
+
+            this._source = this.get_shader_source(shader_file);
+            if (this._source)
+                this.set_shader_source(this._source);
+
+            this.radius = params?.radius ?? 0;
+            this.brightness = params?.brightness ?? 1;
+            this.width = params?.width ?? 0;
+            this.height = params?.height ?? 0;
+            this.chained_effect = params?.chained_effect ?? null;
+
+            // Fetches the scale factor safely
+            const theme_context = St.ThemeContext.get_for_stage(global.stage);
+            this._update_uniforms(theme_context.scale_factor);
+            this.set_enabled(this.radius > 0.);
+            this.set_uniform_value('brightness', parseFloat(this.brightness - 1e-6));
+            this.set_uniform_value('width', parseFloat(this.width + 3.0 - 1e-6));
+            this.set_uniform_value('height', parseFloat(this.height + 3.0 - 1e-6));
+        }
+
+        get_shader_source(shader_filename) {
+            let file_name = GLib.get_user_data_dir() + '/cinnamon/extensions/' + UUID + "/6.0/" + shader_filename;
+            let [ok, content] = GLib.file_get_contents(file_name);
+            return (new TextDecoder().decode(content));
+        }
+
+        static get default_params() {
+            return DEFAULT_PARAMS;
+        }
+
+        get radius() {
+            return this._radius;
+        }
+
+        set radius(value) {
+            if (this._radius !== value) {
+                this._radius = value;
+
+                if (this._sub_effects) {
+                    const scale_factor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
+                    this._update_uniforms(scale_factor);
+                    this.set_enabled(this.radius > 0.);
+
+                    this._sub_effects.forEach(effect => { effect.radius = value; });
+                }
+            }
+        }
+
+        get brightness() {
+            return this._brightness;
+        }
+
+        set brightness(value) {
+            if (this._brightness !== value) {
+                this._brightness = value;
+
+                if (this._sub_effects) {
+                    this.set_uniform_value('brightness', parseFloat(this._brightness - 1e-6));
+                    this._sub_effects.forEach(effect => { effect.brightness = value; });
+                }
+            }
+        }
+
+        get width() {
+            return this._width;
+        }
+
+        set width(value) {
+            if (this._width !== value) {
+                this._width = value;
+
+                if (this._sub_effects) {
+                    this.set_uniform_value('width', parseFloat(this._width + 3.0 - 1e-6));
+                    this._sub_effects.forEach(effect => { effect.width = value; });
+                }
+            }
+        }
+
+        get height() {
+            return this._height;
+        }
+
+        set height(value) {
+            if (this._height !== value) {
+                this._height = value;
+
+                if (this._sub_effects) {
+                    this.set_uniform_value('height', parseFloat(this._height + 3.0 - 1e-6));
+                    this._sub_effects.forEach(effect => { effect.height = value; });
+                }
+            }
+        }
+
+        get pass_index() {
+            return this._pass_index;
+        }
+
+        set pass_index(value) {
+            this._pass_index = value;
+        }
+
+        get total_passes() {
+            return this._total_passes;
+        }
+
+        set total_passes(value) {
+            this._total_passes = value;
+        }
+
+        get chained_effect() {
+            return this._chained_effect;
+        }
+
+        set chained_effect(value) {
+            this._chained_effect = value;
+        }
+
+        _update_uniforms(scale_factor) {
+            // Treat the UI radius as an intensity percentage 
+            let effective_radius = Math.min(this.radius, 100.0); 
+            let base_offset = effective_radius * 0.08;
+
+            // Calculate spatial spread mathematically
+            let midpoint = Math.floor(this.total_passes / 2);
+            let step_multiplier = 1.0;
+
+            if (this.pass_index <= midpoint) {
+                // Downsample: spread increases as we go deeper
+                step_multiplier = Math.pow(2.0, this.pass_index);
+            } else {
+                // Upsample: spread decreases as we come back up
+                let up_index = (this.total_passes - 1) - this.pass_index;
+                step_multiplier = Math.pow(2.0, up_index);
+            }
+
+            let calculated_offset = base_offset * scale_factor * step_multiplier;
+            this.set_uniform_value('offset', parseFloat(calculated_offset - 1e-6));
+        }
+
+        vfunc_set_actor(actor) {
+            if (this._actor_connection_size_id) {
+                let old_actor = this.get_actor();
+                old_actor?.disconnect(this._actor_connection_size_id);
+            }
+
+            if (this._scale_connection_id) {
+                St.ThemeContext.get_for_stage(global.stage).disconnect(this._scale_connection_id);
+                this._scale_connection_id = null;
+            }
+
+            if (actor) {
+                this.width = actor.width;
+                this.height = actor.height;
+                this._actor_connection_size_id = actor.connect('notify::size', _ => {
+                    this.width = actor.width;
+                    this.height = actor.height;
+                });
+
+                this._scale_connection_id = St.ThemeContext.get_for_stage(global.stage).connect('notify::scale-factor', () => {
+                    this._update_uniforms(St.ThemeContext.get_for_stage(global.stage).scale_factor);
+                });
+            } else {
+                this._actor_connection_size_id = null;
+            }
+
+            super.vfunc_set_actor(actor);
+
+            if (this.pass_index === 0) {
+                if (this._sub_effects) {
+                    this._sub_effects.forEach(effect => {
+                        try {
+                            let current_actor = effect.get_actor();
+                            if (current_actor) current_actor.remove_effect(effect);
+                        } catch (e) {
+                            // Ignores silently if the actor has already been cleaned up by the Cinnamon engine
+                        }
+                    });
+                }
+                this._sub_effects = [];
+
+                if (actor !== null && actor !== undefined) {
+                    let total_depth = 7;
+
+                    this.total_passes = total_depth;
+                    this.chained_effect = this; 
+
+                    for (let i = 1; i < total_depth; i++) {
+                        let new_pass = new DualFilteringBlurEffect({ 
+                            radius: this.radius, 
+                            brightness: this.brightness, 
+                            width: this.width, 
+                            height: this.height, 
+                            pass_index: i,
+                            total_passes: total_depth 
+                        });
+
+                        this._sub_effects.push(new_pass);
+                        actor.add_effect(new_pass);
+                    }
+                }
+            }
+        }
+
+        vfunc_paint_target(...params) {
+            // Identifies the last pass in the pyramid to apply final color grading
+            let is_last = (this._sub_effects && this.pass_index === this.total_passes - 1) ? 1 : 0;
+            this.set_uniform_value("is_last_pass", is_last);
+            super.vfunc_paint_target(...params);
+        }
+    });

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/extension.js
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/extension.js
@@ -58,6 +58,7 @@ const PopupMenu = imports.ui.popupMenu;
 
 const GaussianBlur = require("./gaussian_blur");
 const MonteCarloBlur = require("./monte_carlo_blur");
+const DualKawaseBlur = require("./dual_kawase_blur");
 const CornerEffect = require("./corner");
 
 const ANIMATION_TIME = 0.25;
@@ -104,7 +105,9 @@ const BlurType = {
    Transparent: 3,
    DynamicBlur: 4,    // Dynamic blur using Gaussian
    MonteCarlo: 5,
-   DynamicMC: 6       // Dynamic blur using Monte-Carlo
+   DynamicMC: 6,      // Dynamic blur using Monte-Carlo
+   DualKawase: 7,
+   DynamicDK: 8,      // Dynamic blur using Dual-Kawase
 }
 
 const PanelLoc = {
@@ -161,11 +164,13 @@ function _animateVisibleOverview() {
    if (blurType > BlurType.None) {
       let fx;
       if (blurType === BlurType.Simple) {
-         fx =  new Clutter.BlurEffect();
+         fx = new Clutter.BlurEffect();
       } else if (blurType === BlurType.Gaussian || blurType === BlurType.DynamicBlur) {
          fx = new GaussianBlur.GaussianBlurEffect( { radius: radius, brightness: 1, width: 0, height: 0 } );
-      } else { // Monte-Carlo
+      } else if (blurType === BlurType.MonteCarlo || blurType === BlurType.DynamicMC) {
          fx = new MonteCarloBlur.MonteCarloBlurEffect( { radius: radius, iterations: settings.montecarloIterations, prefer_closer_pixels: settings.montecarloPerferCloserPixels, use_base_pixel: settings.montecarloUseBasePixel, brightness: 1, width: 0, height: 0 } );
+      } else { // Dual-Kawase
+         fx = new DualKawaseBlur.DualFilteringBlurEffect( { radius: radius, brightness: 1, width: 0, height: 0 } );
       }
       desktopBackground.add_effect_with_name( BLUR_EFFECT_NAME, fx );
    }
@@ -204,8 +209,10 @@ function _animateVisibleExpo() {
          fx =  new Clutter.BlurEffect();
       } else if (blurType === BlurType.Gaussian || blurType === BlurType.DynamicBlur) {
          fx = new GaussianBlur.GaussianBlurEffect( {radius: radius, brightness: 1, width: 0, height: 0} );
-      } else { // Monte-Carlo
+      } else if (blurType === BlurType.MonteCarlo || blurType === BlurType.DynamicMC) {
          fx = new MonteCarloBlur.MonteCarloBlurEffect( { radius: radius, iterations: settings.montecarloIterations, prefer_closer_pixels: settings.montecarloPerferCloserPixels, use_base_pixel: settings.montecarloUseBasePixel, brightness: 1, width: 0, height: 0 } );
+      } else { // Dual-Kawase
+         fx = new DualKawaseBlur.DualFilteringBlurEffect( { radius: radius, brightness: 1, width: 0, height: 0 } );
       }
       desktopBackground.add_effect_with_name( BLUR_EFFECT_NAME, fx );
    }
@@ -243,8 +250,10 @@ function _showAppSwitcher3D(...params) {
             fx =  new Clutter.BlurEffect();
          } else if (blurType === BlurType.Gaussian || blurType === BlurType.DynamicBlur) {
             fx = new GaussianBlur.GaussianBlurEffect( {radius: radius, brightness: 1, width: 0, height: 0} );
-         } else { // Monte-Carlo
+         } else if (blurType === BlurType.MonteCarlo || blurType === BlurType.DynamicMC) {
             fx = new MonteCarloBlur.MonteCarloBlurEffect( { radius: radius, iterations: settings.montecarloIterations, prefer_closer_pixels: settings.montecarloPerferCloserPixels, use_base_pixel: settings.montecarloUseBasePixel, brightness: 1, width: 0, height: 0 } );
+         } else { // Dual-Kawase
+            fx = new DualKawaseBlur.DualFilteringBlurEffect( { radius: radius, brightness: 1, width: 0, height: 0 } );
          }
          desktopBackground.add_effect_with_name( BLUR_EFFECT_NAME, fx );
          this._blurCinnamonBlurEffect = fx;
@@ -257,7 +266,7 @@ function _showAppSwitcher3D(...params) {
 
       let [ret,color] = Clutter.Color.from_string( blendColor );
       if (!ret) { [ret,color] = Clutter.Color.from_string( "rgba(0,0,0,0)" ); }
-      color.alpha = opacity*2.55;
+      color.alpha = Math.round(opacity*2.55);
       this.actor.set_background_color(color);
    }
 
@@ -348,8 +357,9 @@ function clonePainted(background, actor) {
 }
 
 function createWindowClone(metaWindow, background, desktopOnly) {
-   if (background.is_mapped() && background._blurCinnamonMetaWindowOwner !== metaWindow && (!desktopOnly || metaWindow.get_window_type() === Meta.WindowType.DESKTOP) &&
-      (!background._blurCinnamonMetaWindowOwner || background._blurCinnamonMetaWindowOwner.get_window_type() !== Meta.WindowType.DESKTOP || metaWindow.get_window_type() === Meta.WindowType.DESKTOP) ) {
+   let owner = background._blurCinnamonMetaWindowOwner;
+   if (background.is_mapped() && owner !== metaWindow && (!desktopOnly || metaWindow.get_window_type() === Meta.WindowType.DESKTOP) &&
+      (!owner || owner.get_window_type() !== Meta.WindowType.DESKTOP || metaWindow.get_window_type() === Meta.WindowType.DESKTOP) ) {
       // Debugging check
       if( background._blurCinnamonWinClones.find( (element) => element._metaWindow === metaWindow) ) {
          log( `Warning! Tried to add a window clone to a background that already has a clone for that window.` );
@@ -357,8 +367,24 @@ function createWindowClone(metaWindow, background, desktopOnly) {
       }
       let rect = metaWindow.get_buffer_rect();
       let compositor = metaWindow.get_compositor_private();
+      // Remove any clones of the backgrounds window in metaWindow's clones. Required to avoid a recurrsion during painting.
+      if (owner && compositor) {
+         let blurData = compositor._blurCinnamonDataWindow;
+         if (blurData && blurData.background &&  blurData.background._blurCinnamonWinClones) {
+            blurData.background._blurCinnamonWinClones.forEach( (clone) => {
+               if (clone._metaWindow === owner) {
+                  debugMsg( `Destroying clone of background's window from metaWindow's clones` );
+                  destroyWindowClone(clone, blurData.background)
+               }
+            });
+         }
+      }
       let windowClone = new Clutter.Clone({source: compositor, reactive: false, x: rect.x, y: rect.y });
-      debugMsg( `Created clone ${windowClone} of ${metaWindow.get_title()}/${metaWindow.get_id()} for background ${background._blurCinnamonName}` );
+      if (owner) {
+         debugMsg( `Created clone ${windowClone} of ${metaWindow.get_title()}/${metaWindow.get_id()} for background ${background._blurCinnamonName} "${owner.get_title()}"/"${owner.get_wm_class()}"` );
+      } else {
+         debugMsg( `Created clone ${windowClone} of ${metaWindow.get_title()}/${metaWindow.get_id()} for background ${background._blurCinnamonName}` );
+      }
       if (metaWindow.get_window_type() === Meta.WindowType.DESKTOP && background._blurCinnamonDeskletClone) {
          background._blurCinnamonGroup.insert_child_below(windowClone, background._blurCinnamonDeskletClone);
       } else {
@@ -366,7 +392,7 @@ function createWindowClone(metaWindow, background, desktopOnly) {
       }
       background._blurCinnamonWinClones.push(windowClone);
       windowClone._metaWindow = metaWindow;
-      if (settings.windowArtifactMitigation && background._blurCinnamonMetaWindowOwner) {
+      if (settings.windowArtifactMitigation && owner) {
          windowClone._paintEventId = windowClone.connect( "paint", (actor) => clonePainted(background, actor));
       }
       return windowClone;
@@ -478,8 +504,8 @@ function cloneWindowsForBackgroundNow(background, desktopOnly) {
    windows.forEach( (window) => {
       let metaWindow = window.get_meta_window();
       let compositor = metaWindow.get_compositor_private();
-      if (metaWindow && compositor && compositor.visible && (!desktopOnly || metaWindow.get_window_type() === Meta.WindowType.DESKTOP) && 
-          metaWindow.get_window_type() !== Meta.WindowType.OVERRIDE_OTHER && metaWindow.get_wm_class() !== "Nemo-desktop")
+      if (metaWindow && compositor && compositor.visible && (!desktopOnly || metaWindow.get_window_type() === Meta.WindowType.DESKTOP) &&
+          metaWindow.get_window_type() !== Meta.WindowType.OVERRIDE_OTHER /*&& metaWindow.get_wm_class() !== "Nemo-desktop"*/)
       {
          let winRect = metaWindow.get_buffer_rect();
          let winX = winRect.x;
@@ -564,6 +590,7 @@ class CloneManager {
    }
 
    backgroundClipChanged(background) {
+      debugMsg( "Clip Changed" );
       let idx = this._backgrounds.indexOf(background);
       if (idx!==-1) {
          cloneWindowsForBackground(background, background._blurCinnamonDesktopOnly);
@@ -645,7 +672,7 @@ class CloneManager {
          }
       });
       background._blurCinnamonDesktopOnly = false;
-      cloneWindowsForBackground(background, false);
+      cloneWindowsForBackgroundNow(background, false);
    }
 
    lowerDeskletBackground(background) {
@@ -873,7 +900,7 @@ class BlurBase {
    }
 
    _getGenericSettings() {
-      if (!this._supportsDynamicBlur() && (settings.blurType === BlurType.DynamicBlur || settings.blurType === BlurType.DynamicMC))
+      if (!this._supportsDynamicBlur() && (settings.blurType === BlurType.DynamicBlur || settings.blurType === BlurType.DynamicMC || settings.blurType === BlurType.DynamicDK))
          return [settings.opacity, settings.blendColor, BlurType.Gaussian, settings.radius, settings.saturation];
       return [settings.opacity, settings.blendColor, settings.blurType, settings.radius, settings.saturation];
    }
@@ -889,7 +916,7 @@ class BlurBase {
    _getColor(colorString, opacity) {
       let [ret,color] = Clutter.Color.from_string( colorString );
       if (!ret) { [ret,color] = Clutter.Color.from_string( "rgba(0,0,0,0)" ); }
-      color.alpha = opacity*2.55;
+      color.alpha = Math.round(opacity*2.55);
       return color;
    }
 
@@ -949,9 +976,11 @@ class BlurBase {
          blurEffect =  new Clutter.BlurEffect();
       else if (blurType === BlurType.Gaussian || blurType === BlurType.DynamicBlur)
          blurEffect = new GaussianBlur.GaussianBlurEffect( {radius: radius, brightness: 1 , width: 0, height: 0} );
-      else // Monte-Carlo
+      else if (blurType === BlurType.MonteCarlo || blurType === BlurType.DynamicMC)
          blurEffect = new MonteCarloBlur.MonteCarloBlurEffect( { radius: radius, iterations: settings.montecarloIterations, prefer_closer_pixels: settings.montecarloPerferCloserPixels, use_base_pixel: settings.montecarloUseBasePixel, brightness: 1, width: 0, height: 0 } );
-      if (saturation<100)
+      else if (blurType === BlurType.DualKawase || blurType === BlurType.DynamicDK)
+         blurEffect = new DualKawaseBlur.DualFilteringBlurEffect( { radius: radius, brightness: 1, width: 0, height: 0 } );
+      if (saturation < 100)
          desatEffect = new Clutter.DesaturateEffect({factor: (100-saturation)/100});
       if (cornerRadius>0)
          cornerEffect = new CornerEffect.CornerEffect( metaData.uuid, {radius: cornerRadius, corners_top: top, corners_bottom: bottom} );
@@ -1061,6 +1090,12 @@ class BlurBase {
          }
          let blurEffect = new MonteCarloBlur.MonteCarloBlurEffect( { radius: radius, iterations: settings.montecarloIterations, prefer_closer_pixels: settings.montecarloPerferCloserPixels, use_base_pixel: settings.montecarloUseBasePixel, brightness: 1, width: 0, height: 0 } );
          background.add_effect_with_name( BLUR_EFFECT_NAME, blurEffect );
+      } else if ((blurType === BlurType.DualKawase || blurType === BlurType.DynamicDK) && !(curEffect instanceof DualKawaseBlur.DualFilteringBlurEffect)) {
+         if (curEffect) {
+            background.remove_effect(curEffect);
+         }
+         let blurEffect = new DualKawaseBlur.DualFilteringBlurEffect( { radius: radius, brightness: 1, width: 0, height: 0 } );
+         background.add_effect_with_name( BLUR_EFFECT_NAME, blurEffect );
       } else if (blurType === BlurType.Transparent && background instanceof Meta.X11BackgroundActor) {
          if (curEffect) {
             background.remove_effect(curEffect);
@@ -1081,7 +1116,7 @@ class BlurBase {
          this.parent.add_actor(background);
       }
       // Adjust the blur effects
-      if ((curEffect instanceof GaussianBlur.GaussianBlurEffect || curEffect instanceof MonteCarloBlur.MonteCarloBlurEffect) && curEffect.radius != radius) {
+      if ((curEffect instanceof GaussianBlur.GaussianBlurEffect || curEffect instanceof MonteCarloBlur.MonteCarloBlurEffect || curEffect instanceof DualKawaseBlur.DualFilteringBlurEffect) && curEffect.radius != radius) {
          curEffect.radius = radius;
       }
       // If Monte Carlo, update it's settings
@@ -1263,7 +1298,7 @@ class BlurOSD extends BlurBase {
          osd._blurCinnamonBackground = this._background;
 
          // If Dynamic Blurring is enabled, create a workspace clone and add the clone to the background
-         if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) {
+         if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC || blurType === BlurType.DynamicDK) {
             debugMsg( "Creating dynamic effect for classic app switcher" );
             this._createDynamicEffect(this._background);
          }
@@ -1302,7 +1337,7 @@ class BlurOSD extends BlurBase {
 
    _hideBackground(osd, actor) {
       if (!this._background) return;
-      if (this._blurType === BlurType.DynamicBlur || this._blurType === BlurType.DynamicMC) {
+      if (this._blurType === BlurType.DynamicBlur || this._blurType === BlurType.DynamicMC || this._blurType === BlurType.DynamicDK) {
          debugMsg( "Removing dynamic effect for classic app switcher" );
          this._destroyDynamicEffect(this._background);
       }
@@ -1408,7 +1443,7 @@ class BlurClassicSwitcher extends BlurBase {
 
          this._setClip(actor)
          // If Dynamic Blurring is enabled, create a workspace clone and add the clone to the background
-         if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) {
+         if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC || blurType === BlurType.DynamicDK) {
             debugMsg( "Creating dynamic effect for classic app switcher" );
             this._createDynamicEffect(this._background);
          }
@@ -1425,7 +1460,7 @@ class BlurClassicSwitcher extends BlurBase {
    }
 
    _hideBackground() {
-      if (this._blurType === BlurType.DynamicBlur || this._blurType === BlurType.DynamicMC) {
+      if (this._blurType === BlurType.DynamicBlur || this._blurType === BlurType.DynamicMC || this._blurType === BlurType.DynamicDK) {
          debugMsg( "Removing dynamic effect for classic app switcher" );
          this._destroyDynamicEffect(this._background);
       }
@@ -1776,7 +1811,7 @@ class BlurPanels extends BlurBase {
       blurredPanel.background = background;
       this._setClip(panel);
 
-      if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) {
+      if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC || blurType === BlurType.DynamicDK) {
          this._createDynamicEffect(background);
       }
 
@@ -1953,7 +1988,7 @@ class BlurPanels extends BlurBase {
                } else {
                   this._blurPanel(panels[i]);
                }
-               if ((blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) && !this._isDynamicEffectActive(blurredPanel.background)) {
+               if ((blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC || blurType === BlurType.DynamicDK) && !this._isDynamicEffectActive(blurredPanel.background)) {
                   this._createDynamicEffect(blurredPanel.background);
                }
             } else if (panels[i].__blurredPanel) {
@@ -2189,7 +2224,7 @@ class BlurPopupMenus extends BlurBase {
          debugMsg( "Blurred actor is now visible" );
 
          // If Dynamic Blurring is enabled, create window clones and add them to the background
-         if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) {
+         if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC || blurType === BlurType.DynamicDK) {
             this._createDynamicEffect(this._background);
          }
 
@@ -2362,7 +2397,7 @@ class BlurPopupMenus extends BlurBase {
       // Update the accent dimming color
       this._accentColor = this._getColor( blendColor, accentOpacity );
 
-      if ((blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) && !this._isDynamicEffectActive(this._background)) {
+      if ((blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC || blurType === BlurType.DynamicDK) && !this._isDynamicEffectActive(this._background)) {
          this._createDynamicEffect(this._background);
       }
 
@@ -2416,7 +2451,9 @@ class BlurDesktop extends BlurBase {
          this._blurEffect = new GaussianBlur.GaussianBlurEffect( {radius: radius, brightness: 1, width: 0, height: 0} );
       else if (blurType === BlurType.MonteCarlo)
          this._blurEffect = new MonteCarloBlur.MonteCarloBlurEffect( { radius: radius, iterations: settings.montecarloIterations, prefer_closer_pixels: settings.montecarloPerferCloserPixels, use_base_pixel: settings.montecarloUseBasePixel, brightness: 1, width: 0, height: 0 } );
-      this._desatEffect = new Clutter.DesaturateEffect({factor: (100-saturation)/100});
+      else if (blurType === BlurType.DualKawase)
+         this._blurEffect = new DualKawaseBlur.DualFilteringBlurEffect( { radius: radius, brightness: 1, width: 0, height: 0 } );
+      this._desatEffect = new Clutter.DesaturateEffect({ factor: (100 - saturation) / 100 });
       if (this._blurEffect)
          global.background_actor.add_effect_with_name( BLUR_EFFECT_NAME, this._blurEffect );
       global.background_actor.add_effect_with_name( DESAT_EFFECT_NAME, this._desatEffect );
@@ -2469,11 +2506,17 @@ class BlurDesktop extends BlurBase {
          }
          this._blurEffect = new MonteCarloBlur.MonteCarloBlurEffect( { radius: radius, iterations: settings.montecarloIterations, prefer_closer_pixels: settings.montecarloPerferCloserPixels, use_base_pixel: settings.montecarloUseBasePixel, brightness: 1, width: 0, height: 0 } );
          global.background_actor.add_effect_with_name( BLUR_EFFECT_NAME, this._blurEffect );
+      } else if (blurType === BlurType.DualKawase && !(this._blurEffect instanceof DualKawaseBlur.DualFilteringBlurEffect)) {
+         if (curEffect) {
+            global.background_actor.remove_effect(curEffect);
+         }
+         this._blurEffect = new DualKawaseBlur.DualFilteringBlurEffect( { radius: radius, brightness: 1, width: 0, height: 0 } );
+         global.background_actor.add_effect_with_name( BLUR_EFFECT_NAME, this._blurEffect );
       } else if (blurType !== BlurType.None && curEffect === null) {
          global.background_actor.add_effect_with_name( BLUR_EFFECT_NAME, this._blurEffect );
       }
       // Adjust the effects
-      if ((this._blurEffect instanceof GaussianBlur.GaussianBlurEffect || this._blurEffect instanceof MonteCarloBlur.MonteCarloBlurEffect) && this._blurEffect.radius != radius) {
+      if ((this._blurEffect instanceof GaussianBlur.GaussianBlurEffect || this._blurEffect instanceof MonteCarloBlur.MonteCarloBlurEffect || this._blurEffect instanceof DualKawaseBlur.DualFilteringBlurEffect) && this._blurEffect.radius != radius) {
          this._blurEffect.radius = radius;
       }
       // If Monte Carlo, update it's settings
@@ -2495,7 +2538,7 @@ class BlurDesktop extends BlurBase {
    _onFocusChanged(){
       let window = global.display.get_focus_window();
       if (!window || window.get_window_type() === Meta.WindowType.DESKTOP) {
-         if ((this._blurEffect instanceof GaussianBlur.GaussianBlurEffect || this._blurEffect instanceof MonteCarloBlur.MonteCarloBlurEffect) && this._blurEffect.radius != this._withFocusSettings.radius)
+         if ((this._blurEffect instanceof GaussianBlur.GaussianBlurEffect || this._blurEffect instanceof MonteCarloBlur.MonteCarloBlurEffect || this._blurEffect instanceof DualKawaseBlur.DualFilteringBlurEffect) && this._blurEffect.radius != this._withFocusSettings.radius)
             this._blurEffect.radius = this._withFocusSettings.radius;
          let dimmerColor = this._getColor( this._withFocusSettings.blendColor, this._withFocusSettings.opacity );
          this._dimmer.set_background_color(dimmerColor);
@@ -2505,7 +2548,7 @@ class BlurDesktop extends BlurBase {
          return;
       }
       if (this._currentlyWithFocus) {
-         if ((this._blurEffect instanceof GaussianBlur.GaussianBlurEffect || this._blurEffect instanceof MonteCarloBlur.MonteCarloBlurEffect) && this._blurEffect.radius != this._withoutFocusSettings.radius)
+         if ((this._blurEffect instanceof GaussianBlur.GaussianBlurEffect || this._blurEffect instanceof MonteCarloBlur.MonteCarloBlurEffect || this._blurEffect instanceof DualKawaseBlur.DualFilteringBlurEffect) && this._blurEffect.radius != this._withoutFocusSettings.radius)
             this._blurEffect.radius = this._withoutFocusSettings.radius;
          let dimmerColor = this._getColor( this._withoutFocusSettings.blendColor, this._withoutFocusSettings.opacity );
          this._dimmer.set_background_color(dimmerColor);
@@ -2597,7 +2640,7 @@ class BlurNotifications extends BlurBase {
             table.set_style( this._activeNotificationData.original_table_style );
          }
          this._setClip(actor, this._background, table);
-         if ((this._blurType === BlurType.DynamicBlur || this._blurType === BlurType.DynamicMC) && !this._isDynamicEffectActive(this._background)) {
+         if ((this._blurType === BlurType.DynamicBlur || this._blurType === BlurType.DynamicMC || this._blurType === BlurType.DynamicDK) && !this._isDynamicEffectActive(this._background)) {
             this._createDynamicEffect(this._background);
          }
       } else {
@@ -2648,7 +2691,7 @@ class BlurNotifications extends BlurBase {
       // Resize the background to match the size of the notification window
       this._setClip(actor, this._background, table);
       // If Dynamic Blurring is enabled, create a workspace clone and add the clone to the background
-      if (this._blurType === BlurType.DynamicBlur || this._blurType === BlurType.DynamicMC) {
+      if (this._blurType === BlurType.DynamicBlur || this._blurType === BlurType.DynamicMC || this._blurType === BlurType.DynamicDK) {
          this._createDynamicEffect(this._background);
       }
       // The notification window size can change after being shown, so we need to adjust the background when that happens
@@ -2753,7 +2796,7 @@ class BlurTooltips extends BlurBase {
       this._setClip(actor, this._background, actor);
       this._background.show();
       // If Dynamic Blurring is enabled, create a workspace clone and add the clone to the background
-      if ((blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) && !this._isDynamicEffectActive(this._background)) {
+      if ((blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC || blurType === BlurType.DynamicDK) && !this._isDynamicEffectActive(this._background)) {
          this._createDynamicEffect(this._background);
       }
       // Adapt to any future tooltip size changes
@@ -2819,7 +2862,7 @@ class BlurApplications extends BlurBase {
       let element = settings.windowInclusionList.find( (element) => {if (element.application == _("Default window settings")) {return true;}} );
       if (!element) {
          let windowList = settings.settings.getValue("windows-inclusion-list");
-         windowList.splice( 0, 0, {enabled:false, application:_("Default window settings"), override: false, opacity:0, color:"rgb(0,0,0)", blurtype:BlurType.Gaussian, radius:10, saturation:100, corner_radius: 10, corner_top: true, corner_bottom: false  } );
+         windowList.splice( 0, 0, {enabled:false, application:_("Default window settings"), override: false, opacity:0, color:"rgb(0,0,0)", blurtype:BlurType.Gaussian, radius:10, saturation:100, corner_radius: 8, corner_top: true, corner_bottom: false  } );
          settings.settings.setValue("windows-inclusion-list", windowList);
       }
 
@@ -2867,7 +2910,7 @@ class BlurApplications extends BlurBase {
       let compositor = metaWindow.get_compositor_private();
 
       // Get the effect setting that should apply to Application windows
-      let [enabled, window_opacity, opacity, blendColor, blurType, radius, saturation, corner_radius, top, bottom] = this._getSettings(metaWindow);
+      let [enabled, window_opacity, opacity, blendColor, blurType, radius, saturation, corner_radius, top, bottom, titlebarsOnly] = this._getSettings(metaWindow);
       if (enabled) {
          // A signal manager for this window
          let signalManager = new SignalManager.SignalManager(null);
@@ -2875,7 +2918,7 @@ class BlurApplications extends BlurBase {
          // Setup the window opacity
          if (!window_opacity || window_opacity < 10 || window_opacity > 100 )
             window_opacity = 100;
-         metaWindow.set_opacity(window_opacity*2.55);
+         metaWindow.set_opacity(Math.round(window_opacity*2.55));
 
          // Create the effect and add it to the window
          let background = this._createBackgroundAndEffects(opacity, blendColor, blurType, radius, saturation, null, corner_radius, top, bottom);
@@ -2883,25 +2926,20 @@ class BlurApplications extends BlurBase {
          compositor.insert_child_at_index(background, 0);
 
          // Add blur data to the compositor while blurring is in effect
-         compositor._blurCinnamonDataWindow = { effectThis: this, background: background, metaWindow: metaWindow, signalManager: signalManager };
+         compositor._blurCinnamonDataWindow = { effectThis: this, background: background, metaWindow: metaWindow, signalManager: signalManager, titlebarsOnly: titlebarsOnly };
 
          // Add listeners for this window's compositor
-         //signalManager.connect(metaWindow, "notify::maximized-horizontally", () => this._maximized(metaWindow) );
-         //signalManager.connect(metaWindow, "notify::maximized-vertically ",  () => this._maximized(metaWindow) );
-         //signalManager.connect(metaWindow, "unmanaged"/*"unmanaging"*/, () => this._unblurWindow(compositor) );
          signalManager.connect(compositor, "destroy", () => this._unblurWindow(compositor) );
-         signalManager.connect(compositor, "notify::allocation", () => this._setClip(compositor) );
          // Some windows are positioned after their first allocation, so keep the blur aligned
          // when either the compositor actor or the MetaWindow reports a position update.
+         signalManager.connect(compositor, "notify::allocation", () => this._setClip(compositor) );
          signalManager.connect(metaWindow, "position-changed", () => this._setClip(compositor) );
-         //signalManager.connect(metaWindow, "notify::maximized-horizontally", () => this._setClip(compositor) );
-         //signalManager.connect(metaWindow, "notify::maximized-vertically", () => this._setClip(compositor) );
-
          // Resize / reposition the blurred actor
          this._setClip(compositor);
          // Make the background visible
          background.show();
-         if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) {
+
+         if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC || blurType === BlurType.DynamicDK) {
             this._createDynamicEffect(background, metaWindow);
          }
       }
@@ -2921,24 +2959,36 @@ class BlurApplications extends BlurBase {
 
    // Get the window specific effect settings, or a disabled set of value when no settings exist
    _getSettings(metaWindow) {
+      let titlebarsOnly = false;
+      let enabled;
       let wmclass = metaWindow.get_wm_class();
       let winType = metaWindow.get_window_type();
       // We want to allow blurring for normal window, docks (i.e Plank) and desktop windows (i.e Conky)
-      if ((winType === Meta.WindowType.NORMAL || winType === Meta.WindowType.DOCK || winType === Meta.WindowType.DESKTOP) && wmclass !== "Nemo-desktop") {
+      if ((winType === Meta.WindowType.NORMAL || (settings.windowsTitlebarBlur && (winType === Meta.WindowType.DIALOG || winType === Meta.WindowType.MODAL_DIALOG)) ||
+           winType === Meta.WindowType.DOCK || winType === Meta.WindowType.DESKTOP) && wmclass !== "Nemo-desktop") 
+      {
          let app = this._getAppForWindow(metaWindow);
          let appId = app ? app.get_id() : null;
          let element = settings.windowInclusionList.find( (element) => {if (element.application == appId || element.application == wmclass) {return true;}} );
          if (!element) {
             element = settings.windowInclusionList.find( (element) => {if (element.application == _("Default window settings")) {return true;}} );
+            if (!element.enabled && settings.windowsTitlebarBlur) {
+               titlebarsOnly = true;
+               enabled = true;
+            } else {
+               enabled = element.enabled;
+            }
+         } else {
+            enabled = element.enabled;
          }
          if (element) {
             if (element.override) {
-               return [element.enabled, element.window_opacity, element.opacity, element.color, element.blurtype, element.radius, element.saturation, element.corner_radius, element.corner_top, element.corner_bottom];
+               return [enabled, element.window_opacity, element.opacity, element.color, element.blurtype, element.radius, element.saturation, element.corner_radius, element.corner_top, element.corner_bottom, titlebarsOnly];
             }
-            return [element.enabled, element.window_opacity, ...super._getSettings(false), element.corner_radius, element.corner_top, element.corner_bottom ];
+            return [enabled, element.window_opacity, ...super._getSettings(false), element.corner_radius, element.corner_top, element.corner_bottom, titlebarsOnly ];
          }
       }
-      return [false, 100, 0, undefined, BlurType.None, 0, 100, 0, false, false]
+      return [false, 100, 0, undefined, BlurType.None, 0, 100, 0, false, false, false]
    }
 
    _setClip(compositor) {
@@ -2950,8 +3000,17 @@ class BlurApplications extends BlurBase {
          } else {
             data.background.show();
          }
-
          let rect = data.metaWindow.get_frame_rect();
+
+         // If the window is shaded or the blur is for the titlebar only, then we only want to blur under the title bar.
+         if (data.metaWindow.is_shaded() || data.titlebarsOnly) {
+            let clientRect = data.metaWindow.frame_rect_to_client_rect(rect);
+            rect.height = clientRect.y - rect.y;
+            if (rect.height <= 0) {
+               rect.height = 3; // Hack, bad things happen if we set the height to 0 or less
+               data.background.hide();
+            }
+         }
          // Set the background position to the displays 0,0 based on the compositor's position and the shadow size
          //let windowShadowSizeX = (compositor.get_width() - rect.width) / 2;
          //let windowShadowSizeY = (compositor.get_height() - rect.height) / 2;
@@ -3023,11 +3082,12 @@ class BlurApplications extends BlurBase {
       for (let i = 0; i < windows.length; i++) {
          let compositor = windows[i].get_compositor_private();
          let data = compositor._blurCinnamonDataWindow;
-         let [enabled, window_opacity, opacity, blendColor, blurType, radius, saturation, corner_radius, top, bottom] = this._getSettings(windows[i]);
+         let [enabled, window_opacity, opacity, blendColor, blurType, radius, saturation, corner_radius, top, bottom, titlebarsOnly] = this._getSettings(windows[i]);
          if (compositor._blurCinnamonDataWindow) {
             if (!enabled) {
                this._unblurWindow(compositor);
             } else {
+               data.titlebarsOnly = titlebarsOnly;
                this._updateEffects(data.background, opacity, blendColor, blurType, radius, saturation);
                let cornerEffect = this._getCornerEffect(data.background);
                if (cornerEffect) {
@@ -3037,8 +3097,8 @@ class BlurApplications extends BlurBase {
                this._updateCornerRadius(data.background, corner_radius, top, bottom);
                if (!window_opacity || window_opacity < 10 || window_opacity > 100 )
                   window_opacity = 100;
-               windows[i].set_opacity(window_opacity*2.55);
-               if ((blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) && !this._isDynamicEffectActive(data.background)) {
+               windows[i].set_opacity(Math.round(window_opacity*2.55));
+               if ((blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC || blurType === BlurType.DynamicDK) && !this._isDynamicEffectActive(data.background)) {
                   this._createDynamicEffect(data.background, data.metaWindow);
                }
             }
@@ -3287,7 +3347,7 @@ class BlurDesklets extends BlurBase {
          let desklet = desklets[i].desklet;
          if (desklet && desklet._blurCinnamonBackground) {
             let blurSettings = desklet._blurCinnamonBackground._blurCinnamonSettings;
-            if(blurSettings[3] === BlurType.DynamicBlur || blurSettings[3] === BlurType.DynamicMC) {
+            if(blurSettings[3] === BlurType.DynamicBlur || blurSettings[3] === BlurType.DynamicMC || blurSettings[3] === BlurType.DynamicDK) {
                this._raiseDeskletDynamicBackground(desklet._blurCinnamonBackground);
             }
          }
@@ -3307,7 +3367,7 @@ class BlurDesklets extends BlurBase {
          let desklet = desklets[i].desklet;
          if (desklet && desklet._blurCinnamonBackground) {
             let blurSettings = desklet._blurCinnamonBackground._blurCinnamonSettings;
-            if(blurSettings[3] === BlurType.DynamicBlur || blurSettings[3] === BlurType.DynamicMC) {
+            if(blurSettings[3] === BlurType.DynamicBlur || blurSettings[3] === BlurType.DynamicMC || blurSettings[3] === BlurType.DynamicDK) {
                this._lowerDeskletDynamicBackground(desklet._blurCinnamonBackground);
             }
          }
@@ -3342,7 +3402,7 @@ class BlurDesklets extends BlurBase {
          desklet._blurCinnamonSignalManager = new SignalManager.SignalManager(null);
          desklet._blurCinnamonSignalManager.connect(desklet.actor, "notify::allocation", () => this._setClip(desklet) );
          //desklet._blurCinnamonSignalManager.connect(desklet, "destroy", () => this._deskletRemoved(desklet) );
-         if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) {
+         if (blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC || blurType === BlurType.DynamicDK) {
             this._createDynamicEffect(background, global.desklet_container, true);
          }
       }
@@ -3403,7 +3463,6 @@ class BlurDesklets extends BlurBase {
          if (cloneManager)
             cloneManager.backgroundClipChanged(background);
       }
-
    }
 
    updateEffects() {
@@ -3420,7 +3479,7 @@ class BlurDesklets extends BlurBase {
                   if (enabled) {
                      this._updateEffects( desklet._blurCinnamonBackground, opacity, blendColor, blurType, radius, saturation );
                      desklet._blurCinnamonBackground._blurCinnamonSettings = deskletSettings;
-                     if ((blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC) && !this._isDynamicEffectActive(desklet._blurCinnamonBackground)) {
+                     if ((blurType === BlurType.DynamicBlur || blurType === BlurType.DynamicMC || blurType === BlurType.DynamicDK) && !this._isDynamicEffectActive(desklet._blurCinnamonBackground)) {
                         this._createDynamicEffect(desklet._blurCinnamonBackground, global.desklet_container, true);
                      }
                   } else {
@@ -3593,6 +3652,7 @@ class BlurSettings {
 
       this.bind('windows-inclusion-list', 'windowInclusionList', updateWindowEffects);
       this.bind('windows-atrifact-mitigation', 'windowArtifactMitigation', updateArtifactMitigation);
+      this.bind('windows-titlebar-blur', `windowsTitlebarBlur`, updateWindowEffects);
 
       this.bind('focused-window-backlight', 'focusedWindowEffect', updateFocusedWindowEffect);
 

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/gaussian_blur.js
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/gaussian_blur.js
@@ -108,15 +108,12 @@ const GaussianBlurEffect =
                 this.set_shader_source(this._source);
 
             const theme_context = St.ThemeContext.get_for_stage(global.stage);
-            theme_context.connect(
-                'notify::scale-factor', () => {
-                this.set_uniform_value('sigma', parseFloat(this.radius * theme_context.scale_factor / 2 - 1e-6) );
-                }
-            );
+            this.set_uniform_value('sigma', parseFloat(this.radius * theme_context.scale_factor / 2 - 1e-6));
+            this.set_enabled(this.radius > 0.);
         }
 
         get_shader_source(shader_filename) {
-            let file_name = GLib.get_home_dir() + '/.local/share/cinnamon/extensions/' + UUID + "/6.0/" + shader_filename;
+            let file_name = GLib.get_user_data_dir() + '/cinnamon/extensions/' + UUID + "/6.0/" + shader_filename;
             let [ok, content] = GLib.file_get_contents(file_name);
             return (new TextDecoder().decode(content));
         }
@@ -211,6 +208,12 @@ const GaussianBlurEffect =
                 let old_actor = this.get_actor();
                 old_actor?.disconnect(this._actor_connection_size_id);
             }
+
+            if (this._scale_connection_id) {
+                St.ThemeContext.get_for_stage(global.stage).disconnect(this._scale_connection_id);
+                this._scale_connection_id = null;
+            }
+
             if (actor) {
                 this.width = actor.width;
                 this.height = actor.height;
@@ -218,16 +221,30 @@ const GaussianBlurEffect =
                     this.width = actor.width;
                     this.height = actor.height;
                 });
-            }
-            else
+
+                this._scale_connection_id = St.ThemeContext.get_for_stage(global.stage).connect('notify::scale-factor', () => {
+                    const scale_factor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
+                    this.set_uniform_value('sigma', parseFloat(this._radius * scale_factor / 2 - 1e-6));
+                });
+            } else {
                 this._actor_connection_size_id = null;
+            }
 
             super.vfunc_set_actor(actor);
 
             if (this.direction == 0) {
-                if (this.chained_effect)
-                    this.chained_effect.get_actor()?.remove_effect(this.chained_effect);
-                else
+                // Clear the old effect, if it exists
+                if (this.chained_effect) {
+                    try {
+                        let current_actor = this.chained_effect.get_actor();
+                        if (current_actor) current_actor.remove_effect(this.chained_effect);
+                    } catch (e) {}
+
+                    this.chained_effect = null; 
+                }
+
+                // If there is a valid actor, recreate the effect and add it
+                if (actor !== null && actor !== undefined) {
                     this.chained_effect = new GaussianBlurEffect({
                         radius: this.radius,
                         brightness: this.brightness,
@@ -235,8 +252,8 @@ const GaussianBlurEffect =
                         height: this.height,
                         direction: 1
                     });
-                if (actor !== null)
                     actor.add_effect(this.chained_effect);
+                }
             }
         }
 

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/monte_carlo_blur.js
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/monte_carlo_blur.js
@@ -121,16 +121,11 @@ const MonteCarloBlurEffect =
                 this.set_shader_source(this._source);
 
             const theme_context = St.ThemeContext.get_for_stage(global.stage);
-            theme_context.connect(
-                'notify::scale-factor',
-                _ => this.set_uniform_value('radius',
-                    parseFloat(this._radius * theme_context.scale_factor - 1e-6)
-                )
-            );
+            this.set_uniform_value('radius', parseFloat(this._radius * theme_context.scale_factor - 1e-6));
         }
 
         get_shader_source(shader_filename) {
-            let file_name = GLib.get_home_dir() + '/.local/share/cinnamon/extensions/' + UUID + "/6.0/" + shader_filename;
+            let file_name = GLib.get_user_data_dir() + '/cinnamon/extensions/' + UUID + "/6.0/" + shader_filename;
             let [ok, content] = GLib.file_get_contents(file_name);
             return (new TextDecoder().decode(content));
         }
@@ -232,6 +227,12 @@ const MonteCarloBlurEffect =
                 let old_actor = this.get_actor();
                 old_actor?.disconnect(this._actor_connection_size_id);
             }
+
+            if (this._scale_connection_id) {
+                St.ThemeContext.get_for_stage(global.stage).disconnect(this._scale_connection_id);
+                this._scale_connection_id = null;
+            }
+
             if (actor) {
                 this.width = actor.width;
                 this.height = actor.height;
@@ -239,9 +240,14 @@ const MonteCarloBlurEffect =
                     this.width = actor.width;
                     this.height = actor.height;
                 });
-            }
-            else
+
+                this._scale_connection_id = St.ThemeContext.get_for_stage(global.stage).connect('notify::scale-factor', () => {
+                    const scale_factor = St.ThemeContext.get_for_stage(global.stage).scale_factor;
+                    this.set_uniform_value('radius', parseFloat(this._radius * scale_factor - 1e-6));
+                });
+            } else {
                 this._actor_connection_size_id = null;
+            }
 
             super.vfunc_set_actor(actor);
         }

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/settings-schema.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/6.0/settings-schema.json
@@ -33,12 +33,12 @@
       "generic-effect-settings" : {
          "type" : "section",
          "title" : "Generic effect settings",
-         "keys" : ["opacity", "blendColor", "blurType", "radius", "saturation"]
+         "keys" : ["opacity", "blendColor", "blurType", "show-blur-info", "radius", "saturation"]
       },
 
       "monte-carlo-settings" : {
          "type" : "section",
-         "title" : "Monte Carlo specific settings",
+         "title" : "Additional Monte Carlo specific settings",
          "keys" : ["monte-carlo-iterations", "monte-carlo-use-base-pixel", "monte-carlo-prefer-closer-pixels", "monte-carlo-label"]
       },
 
@@ -60,7 +60,7 @@
                     "notification-warning", "enable-notification-override", "allow-transparent-color-notifications", "notification-opacity", "notification-blendColor", "notification-blurType", "notification-radius", "notification-saturation", "notification-test-button",
                     "appswitcher-warning", "enable-appswitcher-override", "appswitcher-disable-3d-panels", "appswitcher-allow-classic", "allow-transparent-color-switcher", "appswitcher-allow-3d", "window-settings-button", "appswitcher-opacity", "appswitcher-blendColor", "appswitcher-blurType", "appswitcher-radius", "appswitcher-saturation",
                     "tooltips-warning", "enable-tooltips-override", "allow-transparent-color-tooltips", "tooltips-opacity", "tooltips-blendColor", "tooltips-blurType", "tooltips-radius", "tooltips-saturation",
-                    "windows-warning", "windows-inclusion-list", "windows-label", "windows-add-button", "windows-atrifact-mitigation", "windows-compiz-mitigation",
+                    "windows-warning", "windows-inclusion-list", "windows-label", "windows-add-button", "windows-titlebar-blur", "windows-atrifact-mitigation", "windows-compiz-mitigation",
                     "desklets-warning", "enable-desklets-override", "enable-desklets-unique-settings", "desklets-opacity", "desklets-blendColor", "desklets-blurType", "desklets-radius", "desklets-saturation", "desklets-list", "desklets-auto", "desklets-label",
                     "info-label"
                   ]
@@ -75,57 +75,57 @@
 
    "appswitcher-warning": {
       "type" : "label",
-      "description" : "Note: The Alt-Tab effects are currently disabled under the \"General setup\" tab.",
+      "description" : "💡 The Alt-Tab effects are currently disabled under the \"General setup\" tab.",
       "dependency" : "!enable-appswitcher-effects & component-selector=0"
    },
    "desklets-warning": {
       "type" : "label",
-      "description" : "Note: The Desklet effects are currently disabled under the \"General setup\" tab.",
+      "description" : "💡 The Desklet effects are currently disabled under the \"General setup\" tab.",
       "dependency" : "!enable-desklet-effects & component-selector=1"
    },
    "desktop-warning": {
       "type" : "label",
-      "description" : "Note: The Desktop effects are currently disabled under the \"General setup\" tab.",
+      "description" : "💡 The Desktop effects are currently disabled under the \"General setup\" tab.",
       "dependency" : "!enable-desktop-effects & component-selector=2"
    },
    "expo-warning": {
       "type" : "label",
-      "description" : "Note: The Expo effects are currently disabled under the \"General setup\" tab.",
+      "description" : "💡 The Expo effects are currently disabled under the \"General setup\" tab.",
       "dependency" : "!enable-expo-effects & component-selector=3"
    },
    "popup-warning": {
       "type" : "label",
-      "description" : "Note: The Menu effects are currently disabled under the \"General setup\" tab.",
+      "description" : "💡 The Menu effects are currently disabled under the \"General setup\" tab.",
       "dependency" : "!enable-popup-effects & component-selector=4"
    },
    "notification-warning": {
       "type" : "label",
-      "description" : "Note: The Notification effects are currently disabled under the \"General setup\" tab.",
+      "description" : "💡 The Notification effects are currently disabled under the \"General setup\" tab.",
       "dependency" : "!enable-notification-effects & component-selector=5"
    },
    "osd-warning": {
       "type" : "label",
-      "description" : "Note: The On-Screen-Display effects are currently disabled under the \"General setup\" tab.",
+      "description" : "💡 The On-Screen-Display effects are currently disabled under the \"General setup\" tab.",
       "dependency" : "!enable-osd-effects & component-selector=10"
    },
    "overview-warning": {
       "type" : "label",
-      "description" : "Note: The Overview effects are currently disabled under the \"General setup\" tab.",
+      "description" : "💡 The Overview effects are currently disabled under the \"General setup\" tab.",
       "dependency" : "!enable-overview-effects & component-selector=6"
    },
    "panel-warning": {
       "type" : "label",
-      "description" : "Note: The Panel effects are currently disabled under the \"General setup\" tab.",
+      "description" : "💡 The Panel effects are currently disabled under the \"General setup\" tab.",
       "dependency" : "!enable-panels-effects & component-selector=7"
    },
    "tooltips-warning": {
       "type" : "label",
-      "description" : "Note: The Tooltip effects are currently disabled under the \"General setup\" tab.",
+      "description" : "💡 The Tooltip effects are currently disabled under the \"General setup\" tab.",
       "dependency" : "!enable-tooltips-effects & component-selector=8"
    },
    "windows-warning": {
       "type" : "label",
-      "description" : "Note: The Window effects are currently disabled under the \"General setup\" tab.",
+      "description" : "💡 The Window effects are currently disabled under the \"General setup\" tab.",
       "dependency" : "!enable-window-effects & component-selector=9"
    },
 
@@ -133,7 +133,7 @@
       "type" : "custom",
       "file" : "CustomWidgets.py",
       "widget" : "LabelWithTooltip",
-      "description" : "<b>Note:</b> You must configure your Desklets to be transparent! (see tooltip)",
+      "description" : "💡 You must configure your Desklets to be transparent! (see tooltip)",
       "tooltip": "In order for Blur Cinnamon Desklet effects to be visible, a Desklets background must be transparent. This allows the blur effect to be visible below the Desklet. Most Desklets can be configured to have transparent backgrounds. On the Desktop, right-click on a Desklet, select the \"Configure...\" menu item to open a Desklet's configuration window.",
       "dependency" : "enable-desklet-effects & component-selector=1"
    },
@@ -142,7 +142,7 @@
       "type" : "custom",
       "file" : "CustomWidgets.py",
       "widget" : "LabelWithTooltip",
-      "description" : "<b>Note:</b> Read tooltip for information about the \"Default window settings\"",
+      "description" : "💡 Read tooltip for information about the \"Default window settings\"",
       "tooltip": "If the special \"Default window settings\" table entry is enabled then all windows will have effects applied. If it is disabled then only the applications defined in the table will have effects applied. If the \"Enabled\" option is unchecked for a particular application then effects will be disabled even if the \"Default window settings\" row is enabled.",
       "dependency" : "enable-window-effects & component-selector=9"
    },
@@ -174,7 +174,7 @@
       "type" : "custom",
       "file" : "CustomWidgets.py",
       "widget" : "About",
-      "description" : "\n<b>Bringing your style into focus</b>\nVersion: ext-version\n\nDeveloped by: Kevin Langman\n<a href=\"https://github.com/klangman/BlurCinnamon\">Github</a> / <a href=\"https://github.com/klangman/BlurCinnamon/issues/new\">Report an issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/104\">Website</a>\n\nThe rounded corners, Gaussian and Monte Carlo effects\nare based on code by aunetx (Blur-my-shell)\n<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n\nThe Overview effect is partially based on the BlurOverview extension by nailfarmer",
+      "description" : "\n<b>Bringing your style into focus</b>\nVersion: ext-version\n\nDeveloped by: Kevin Langman\n<a href=\"https://github.com/klangman/BlurCinnamon\">Github</a> / <a href=\"https://github.com/klangman/BlurCinnamon/issues/new\">Report an issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/104\">Website</a>\n\nThe rounded corners, Gaussian and Monte Carlo effects are\nbased on code by aunetx (Blur-my-shell <a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</a>)\n\nThe Dual Kawase effect was written by <a href=\"https://github.com/Lucas-X-A\">Lucas-X-A</a>\n\nThe Overview effect is partially based on the BlurOverview extension by nailfarmer",
       "icon" : "/icon.png"
    },
 
@@ -405,7 +405,7 @@
             {"id": "override",  "title": "Custom",    "type": "boolean", "default": true},
             {"id": "opacity",   "title": "Dim",       "type": "integer", "default": 40,  "min": 0, "max": 100},
             {"id": "color",     "title": "Color",     "type": "string",  "default": "rgb(0,0,0)"},
-            {"id": "blurtype",  "title": "Background","type": "integer", "default": 4, "options": { "Transparent": 3, "Transparent to wallpaper": 0, "Simple static blur": 1, "Gaussian static blur": 2, "Gaussian dynamic blur": 4, "Monte Carlo static blur": 5, "Monte Carlo dynamic blur": 6 } },
+            {"id": "blurtype",  "title": "Background","type": "integer", "default": 8, "options": { "Transparent": 3, "Transparent to wallpaper": 0, "Simple static blur": 1, "Gaussian static blur": 2, "Gaussian dynamic blur": 4, "Monte Carlo static blur": 5, "Monte Carlo dynamic blur": 6, "Dual Kawase static blur": 7, "Dual Kawase dynamic blur": 8 } },
             {"id": "radius",    "title": "Intensity", "type": "integer", "default": 10,  "min": 0, "max": 100},
             {"id": "saturation","title": "Saturation","type": "integer", "default": 100, "min": 0, "max": 100},
             {"id": "customCSS", "title": "Custom CSS","type": "string",  "default": ""}
@@ -455,17 +455,27 @@
 
     "blurType": {
         "type": "combobox",
-        "default": 4,
+        "default": 8,
         "options": {
             "None / Transparent to wallpaper": 0,
             "Simple static blur": 1,
             "Gaussian static blur": 2,
             "Gaussian dynamic blur (if applicable)": 4,
             "Monte Carlo static blur": 5,
-            "Monte Carlo dynamic blur (if applicable)": 6
+            "Monte Carlo dynamic blur (if applicable)": 6,
+            "Dual Kawase static blur": 7,
+            "Dual Kawase dynamic blur (if applicable)": 8
         },
         "description": "Type of blur effect",
         "tooltip": "What type of blur algorithm should be used to blur the background"
+    },
+
+    "show-blur-info": {
+        "type" : "custom",
+        "file" : "CustomWidgets.py",
+        "widget" : "LabelWithTooltip",
+        "description": "💡 Blur Algorithm Guide (see tooltip)",
+        "tooltip": "<b>Blur Algorithm Guide:</b>\n <b>• Gaussian:</b> Good quality smooth blur, can be GPU intensive.\n <b>• Dual Kawase:</b> High quality smooth blur, optimized for low-end GPUs.\n <b>• Monte Carlo:</b> Grainy, frosted-glass style noisy blur.\n <b>• Simple:</b> Basic subtle blur for ancient computers.\n\n<b>Static vs Dynamic:</b>\n <b>• Dynamic:</b> Blurs background elements behind the blurred element in real-time.\n <b>• Static:</b> Only blurs the wallpaper, like x-ray vision to the desktop wallpaper."
     },
 
     "radius": {
@@ -502,7 +512,7 @@
         "max": 64,
         "default": 5,
         "step": 1,
-        "tooltip": "Increasing number of iterations will make the blur appear smoother at the cost of some CPU power."
+        "tooltip": "Increasing number of iterations will make the blur appear smoother at the cost of some GPU power."
     },
 
     "monte-carlo-use-base-pixel": {
@@ -523,7 +533,7 @@
         "type" : "custom",
         "file" : "CustomWidgets.py",
         "widget" : "LabelWithTooltip",
-        "description" : "<b>Note:</b> These Monte Carlo settings are used globally for all components",
+        "description" : "💡 The above Monte Carlo settings are used globally for all components",
         "tooltip": "The above Monte Carlo settings are used globally for all components that are configured to use the Monte Carlo blur algorithm, these settings can not be configured separately for each component"
     },
 
@@ -549,12 +559,13 @@
 
     "overview-blurType": {
         "type": "combobox",
-        "default": 2,
+        "default": 7,
         "options": {
             "None": 0,
             "Simple": 1,
             "Gaussian": 2,
-            "Monte Carlo": 5
+            "Monte Carlo": 5,
+            "Dual Kawase": 7
         },
         "description": "Type of blur effect",
         "dependency" : "enable-overview-effects & component-selector=6 & enable-overview-override",
@@ -610,12 +621,13 @@
 
     "expo-blurType": {
         "type": "combobox",
-        "default": 2,
+        "default": 7,
         "options": {
             "None": 0,
             "Simple": 1,
             "Gaussian": 2,
-            "Monte Carlo": 5
+            "Monte Carlo": 5,
+            "Dual Kawase": 7
         },
         "description": "Type of blur effect",
         "dependency" : "enable-expo-effects & component-selector=3 & enable-expo-override",
@@ -671,7 +683,7 @@
 
     "panels-blurType": {
         "type": "combobox",
-        "default": 4,
+        "default": 8,
         "options": {
             "Transparent": 3,
             "Transparent to wallpaper": 0,
@@ -679,7 +691,9 @@
             "Gaussian static blur": 2,
             "Gaussian dynamic blur": 4,
             "Monte Carlo static blur": 5,
-            "Monte Carlo dynamic blur": 6
+            "Monte Carlo dynamic blur": 6,
+            "Dual Kawase static blur": 7,
+            "Dual Kawase dynamic blur": 8
         },
         "description": "Type of background effect",
         "tooltip": "What type of background effect should be applied",
@@ -769,7 +783,7 @@
 
     "popup-blurType": {
         "type": "combobox",
-        "default": 4,
+        "default": 8,
         "options": {
             "Transparent": 3,
             "Transparent to wallpaper": 0,
@@ -777,7 +791,9 @@
             "Gaussian static blur": 2,
             "Gaussian dynamic blur": 4,
             "Monte Carlo static blur": 5,
-            "Monte Carlo dynamic blur": 6
+            "Monte Carlo dynamic blur": 6,
+            "Dual Kawase static blur": 7,
+            "Dual Kawase dynamic blur": 8
         },
         "description": "Type of background effect",
         "tooltip": "What type of background effect should be applied",
@@ -849,12 +865,13 @@
 
     "desktop-blurType": {
         "type": "combobox",
-        "default": 2,
+        "default": 7,
         "options": {
             "None": 0,
             "Simple": 1,
             "Gaussian": 2,
-            "Monte Carlo": 5
+            "Monte Carlo": 5,
+            "Dual Kawase": 7
         },
         "description": "Type of blur effect",
         "tooltip": "What type of blur algorithm should be used to blur the background",
@@ -910,7 +927,7 @@
 
     "notification-blurType": {
         "type": "combobox",
-        "default": 4,
+        "default": 8,
         "options": {
             "Transparent": 3,
             "Transparent to wallpaper": 0,
@@ -918,7 +935,9 @@
             "Gaussian static blur": 2,
             "Gaussian dynamic blur": 4,
             "Monte Carlo static blur": 5,
-            "Monte Carlo dynamic blur": 6
+            "Monte Carlo dynamic blur": 6,
+            "Dual Kawase static blur": 7,
+            "Dual Kawase dynamic blur": 8
         },
         "description": "Type of background effect",
         "dependency" : "enable-notification-effects & component-selector=5 & enable-notification-override",
@@ -1005,14 +1024,16 @@
 
     "appswitcher-blurType": {
         "type": "combobox",
-        "default": 4,
+        "default": 8,
         "options": {
             "None": 0,
             "Simple static blur": 1,
             "Gaussian static blur": 2,
             "Gaussian dynamic blur": 4,
             "Monte Carlo static blur": 5,
-            "Monte Carlo dynamic blur": 6
+            "Monte Carlo dynamic blur": 6,
+            "Dual Kawase static blur": 7,
+            "Dual Kawase dynamic blur": 8
         },
         "description": "Type of blur effect",
         "dependency" : "enable-appswitcher-effects & component-selector=0 & enable-appswitcher-override",
@@ -1067,7 +1088,7 @@
 
     "tooltips-blurType": {
         "type": "combobox",
-        "default": 4,
+        "default": 8,
         "options": {
             "Transparent": 3,
             "Transparent to wallpaper": 0,
@@ -1075,7 +1096,9 @@
             "Gaussian static blur": 2,
             "Gaussian dynamic blur": 4,
             "Monte Carlo static blur": 5,
-            "Monte Carlo dynamic blur": 6
+            "Monte Carlo dynamic blur": 6,
+            "Dual Kawase static blur": 7,
+            "Dual Kawase dynamic blur": 8
         },
         "description": "Type of background effect",
         "dependency" : "enable-tooltips-effects & component-selector=8 & enable-tooltips-override",
@@ -1131,14 +1154,16 @@
 
     "desklets-blurType": {
         "type": "combobox",
-        "default": 2,
+        "default": 8,
         "options": {
             "None": 0,
             "Simple static blur": 1,
             "Gaussian static blur": 2,
             "Gaussian dynamic blur": 4,
             "Monte Carlo static blur": 5,
-            "Monte Carlo dynamic blur": 6
+            "Monte Carlo dynamic blur": 6,
+            "Dual Kawase static blur": 7,
+            "Dual Kawase dynamic blur": 8
         },
         "description": "Type of blur effect",
         "tooltip": "What type of blur algorithm should be used to blur the background",
@@ -1208,14 +1233,16 @@
 
     "osd-blurType": {
         "type": "combobox",
-        "default": 2,
+        "default": 8,
         "options": {
             "None": 0,
             "Simple static blur": 1,
             "Gaussian static blur": 2,
             "Gaussian dynamic blur": 4,
             "Monte Carlo static blur": 5,
-            "Monte Carlo dynamic blur": 6
+            "Monte Carlo dynamic blur": 6,
+            "Dual Kawase static blur": 7,
+            "Dual Kawase dynamic blur": 8
         },
         "description": "Type of blur effect",
         "tooltip": "What type of blur algorithm should be used to blur the background",
@@ -1251,7 +1278,7 @@
 
     "windows-inclusion-list" : {
         "type" : "list",
-        "height" : 300,
+        "height" : 220,
         "description" : "Application window inclusion list",
         "dependency" : "enable-window-effects & component-selector=9",
         "columns" : [
@@ -1261,7 +1288,7 @@
             {"id": "override",      "title": "Custom",       "type": "boolean", "default": true},
             {"id": "opacity",       "title": "Dim",          "type": "integer", "default": 0,  "min": 0, "max": 100},
             {"id": "color",         "title": "Color",        "type": "string",  "default": "rgb(0,0,0)"},
-            {"id": "blurtype",      "title": "Background",   "type": "integer", "default": 2, "options": {"Transparent to wallpaper": 0, "Simple static blur": 1, "Gaussian static blur": 2, "Gaussian dynamic blur": 4, "Monte Carlo static blur": 5, "Monte Carlo dynamic blur": 6 } },
+            {"id": "blurtype",      "title": "Background",   "type": "integer", "default": 8, "options": {"Transparent to wallpaper": 0, "Simple static blur": 1, "Gaussian static blur": 2, "Gaussian dynamic blur": 4, "Monte Carlo static blur": 5, "Monte Carlo dynamic blur": 6, "Dual Kawase static blur": 7, "Dual Kawase dynamic blur": 8 } },
             {"id": "radius",        "title": "Intensity",    "type": "integer", "default": 10,  "min": 0, "max": 100},
             {"id": "saturation",    "title": "Saturation",   "type": "integer", "default": 100, "min": 0, "max": 100},
             {"id": "corner_radius", "title": "Corner Radius","type": "integer", "default": 10, "min": 0, "max": 25},
@@ -1270,13 +1297,13 @@
         ],
         "tooltip": "This table controls which application windows will have effects applied and the effect settings. When \"Custom\" is enabled the setting defined by this table will apply, otherwise the \"Generic effect settings\" will apply. The \"Application\" field can be a WM_CLASS or a desktop file name.",
         "default" : [
-            { "enabled": false, "application": "Alacritty.desktop",          "override": false, "opacity": 0, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100, "corner_radius": 10, "corner_top": true, "corner_bottom": false },
-            { "enabled": false, "application": "com.gexperts.Tilix.desktop", "override": false, "opacity": 0, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100, "corner_radius": 10, "corner_top": true, "corner_bottom": false },
-            { "enabled": false, "application": "org.gnome.Terminal.desktop", "override": false, "opacity": 0, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100, "corner_radius": 10, "corner_top": true, "corner_bottom": false },
-            { "enabled": false, "application": "org.gnome.Ptyxis.desktop",   "override": false, "opacity": 0, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100, "corner_radius": 16, "corner_top": true, "corner_bottom": true  },
-            { "enabled": false, "application": "kitty.desktop",              "override": false, "opacity": 0, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100, "corner_radius": 10, "corner_top": true, "corner_bottom": false },
-            { "enabled": false, "application": "org.kde.konsole.desktop",    "override": false, "opacity": 0, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100, "corner_radius": 10, "corner_top": true, "corner_bottom": false },
-            { "enabled": false, "application": "conky",                      "override": false, "opacity": 0, "color": "rgb(0,0,0)", "blurtype": 2, "radius": 10, "saturation": 100, "corner_radius": 10, "corner_top": true, "corner_bottom": false }
+            { "enabled": false, "application": "Alacritty.desktop",          "override": false, "opacity": 0, "color": "rgb(0,0,0)", "blurtype": 8, "radius": 10, "saturation": 100, "corner_radius": 10, "corner_top": true, "corner_bottom": false },
+            { "enabled": false, "application": "com.gexperts.Tilix.desktop", "override": false, "opacity": 0, "color": "rgb(0,0,0)", "blurtype": 8, "radius": 10, "saturation": 100, "corner_radius": 10, "corner_top": true, "corner_bottom": false },
+            { "enabled": false, "application": "org.gnome.Terminal.desktop", "override": false, "opacity": 0, "color": "rgb(0,0,0)", "blurtype": 8, "radius": 10, "saturation": 100, "corner_radius": 10, "corner_top": true, "corner_bottom": false },
+            { "enabled": false, "application": "org.gnome.Ptyxis.desktop",   "override": false, "opacity": 0, "color": "rgb(0,0,0)", "blurtype": 8, "radius": 10, "saturation": 100, "corner_radius": 16, "corner_top": true, "corner_bottom": true  },
+            { "enabled": false, "application": "kitty.desktop",              "override": false, "opacity": 0, "color": "rgb(0,0,0)", "blurtype": 8, "radius": 10, "saturation": 100, "corner_radius": 10, "corner_top": true, "corner_bottom": false },
+            { "enabled": false, "application": "org.kde.konsole.desktop",    "override": false, "opacity": 0, "color": "rgb(0,0,0)", "blurtype": 8, "radius": 10, "saturation": 100, "corner_radius": 10, "corner_top": true, "corner_bottom": false },
+            { "enabled": false, "application": "conky",                      "override": false, "opacity": 0, "color": "rgb(0,0,0)", "blurtype": 8, "radius": 10, "saturation": 100, "corner_radius": 10, "corner_top": true, "corner_bottom": false }
         ]
     },
 
@@ -1304,6 +1331,14 @@
         "tooltip": "When enabled, steps will be taken to eliminate background graphical artifacts for windows that use dynamic blur effects. The mitigation steps will have some minor persistent CPU costs when a dynamic blurred window is on top of two or more other windows. This option is recommended unless you are using video wallpaper like Hidamari"
     },
 
+    "windows-titlebar-blur": {
+        "type": "switch",
+        "default": false,
+        "description": "Blur window title bars (please read tooltip)",
+        "dependency" : "enable-window-effects & component-selector=9",
+        "tooltip": "When enabled, the title bar area under most windows will be blurred excluding GTK4 windows and windows with custom title bars. This behaves like \"Default window settings\" entry above and even uses its settings, but with this option only title bar areas are blurred rather than the entire window. Note: The title bar blurring will only be visible when the title bars are configured to be semi-transparent which MUST be done using CSS. See the Blur Cinnamon website for instructions."
+    },
+
     "desklets-auto": {
         "type": "switch",
         "default": true,
@@ -1325,7 +1360,7 @@
             {"id": "override",   "title": "Custom",     "type": "boolean", "default": true},
             {"id": "opacity",    "title": "Dim",        "type": "integer", "default": 0,  "min": 0, "max": 100},
             {"id": "color",      "title": "Color",      "type": "string",  "default": "rgb(0,0,0)"},
-            {"id": "blurtype",   "title": "Blur",       "type": "integer", "default": 2, "options": { "None": 0, "Simple static blur": 1, "Gaussian static blur": 2, "Gaussian dynamic blur": 4, "Monte Carlo static blur": 5, "Monte Carlo dynamic blur": 6 } },
+            {"id": "blurtype",   "title": "Blur",       "type": "integer", "default": 8, "options": { "None": 0, "Simple static blur": 1, "Gaussian static blur": 2, "Gaussian dynamic blur": 4, "Monte Carlo static blur": 5, "Monte Carlo dynamic blur": 6, "Dual Kawase static blur": 7, "Dual Kawase dynamic blur": 8 } },
             {"id": "radius",     "title": "Intensity",  "type": "integer", "default": 10,  "min": 0, "max": 100},
             {"id": "saturation", "title": "Saturation", "type": "integer", "default": 100, "min": 0, "max": 100}
         ],

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/metadata.json
@@ -1,7 +1,7 @@
 {
     "uuid": "BlurCinnamon@klangman",
     "name": "Blur Cinnamon",
-    "version": "2.5.2",
+    "version": "2.6.0",
     "description": "Allows you to blur, colorize, desaturate and adjust the dimming of several Cinnamon Desktop components",
     "url": "https://github.com/klangman/BlurCinnamon",
     "cinnamon-version": [

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/BlurCinnamon@klangman.pot
@@ -5,10 +5,10 @@
 #, fuzzy
 msgid ""
 msgstr ""
-"Project-Id-Version: BlurCinnamon@klangman 2.5.2\n"
+"Project-Id-Version: BlurCinnamon@klangman 2.6.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-07-03 10:34-0400\n"
+"POT-Creation-Date: 2026-08-07 15:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,26 +17,26 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.0/extension.js:2819 6.0/extension.js:2822 6.0/extension.js:2932
+#. 6.0/extension.js:2862 6.0/extension.js:2865 6.0/extension.js:2974
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:3080
+#. 6.0/extension.js:3140
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:3081
+#. 6.0/extension.js:3141
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3963
+#. 6.0/extension.js:4023
 msgid "Welcome to Blur Cinnamon"
 msgstr ""
 
-#. 6.0/extension.js:3964
+#. 6.0/extension.js:4024
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
@@ -47,15 +47,15 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:3968
+#. 6.0/extension.js:4028
 msgid "Open Blur Cinnamon Settings"
 msgstr ""
 
-#. 6.0/extension.js:4058
+#. 6.0/extension.js:4118
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:4059
+#. 6.0/extension.js:4119
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -96,7 +96,7 @@ msgid "Cinnamon desktop components where effects will be applied"
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-settings->title
-msgid "Monte Carlo specific settings"
+msgid "Additional Monte Carlo specific settings"
 msgstr ""
 
 #. 6.0->settings-schema.json->component-selector-section->title
@@ -113,74 +113,68 @@ msgstr ""
 
 #. 6.0->settings-schema.json->appswitcher-warning->description
 msgid ""
-"Note: The Alt-Tab effects are currently disabled under the \"General setup\" "
+"💡 The Alt-Tab effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-warning->description
 msgid ""
-"Note: The Desklet effects are currently disabled under the \"General setup\" "
+"💡 The Desklet effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 
 #. 6.0->settings-schema.json->desktop-warning->description
 msgid ""
-"Note: The Desktop effects are currently disabled under the \"General setup\" "
+"💡 The Desktop effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 
 #. 6.0->settings-schema.json->expo-warning->description
 msgid ""
-"Note: The Expo effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Expo effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 
 #. 6.0->settings-schema.json->popup-warning->description
 msgid ""
-"Note: The Menu effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Menu effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 
 #. 6.0->settings-schema.json->notification-warning->description
 msgid ""
-"Note: The Notification effects are currently disabled under the \"General "
+"💡 The Notification effects are currently disabled under the \"General "
 "setup\" tab."
 msgstr ""
 
 #. 6.0->settings-schema.json->osd-warning->description
 msgid ""
-"Note: The On-Screen-Display effects are currently disabled under the "
-"\"General setup\" tab."
+"💡 The On-Screen-Display effects are currently disabled under the \"General "
+"setup\" tab."
 msgstr ""
 
 #. 6.0->settings-schema.json->overview-warning->description
 msgid ""
-"Note: The Overview effects are currently disabled under the \"General "
-"setup\" tab."
+"💡 The Overview effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr ""
 
 #. 6.0->settings-schema.json->panel-warning->description
 msgid ""
-"Note: The Panel effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Panel effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 
 #. 6.0->settings-schema.json->tooltips-warning->description
 msgid ""
-"Note: The Tooltip effects are currently disabled under the \"General setup\" "
+"💡 The Tooltip effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-warning->description
 msgid ""
-"Note: The Window effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Window effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-label->description
-msgid ""
-"<b>Note:</b> You must configure your Desklets to be transparent! (see "
-"tooltip)"
+msgid "💡 You must configure your Desklets to be transparent! (see tooltip)"
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-label->tooltip
@@ -193,9 +187,7 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-label->description
-msgid ""
-"<b>Note:</b> Read tooltip for information about the \"Default window "
-"settings\""
+msgid "💡 Read tooltip for information about the \"Default window settings\""
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-label->tooltip
@@ -266,10 +258,13 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners, Gaussian and Monte Carlo effects\n"
-"are based on code by aunetx (Blur-my-shell)\n"
-"<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
-"href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
+"The rounded corners, Gaussian and Monte Carlo effects are\n"
+"based on code by aunetx (Blur-my-shell <a href=\"https://github.com/aunetx/"
+"blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</"
+"a>)\n"
+"\n"
+"The Dual Kawase effect was written by <a href=\"https://github.com/Lucas-X-"
+"A\">Lucas-X-A</a>\n"
 "\n"
 "The Overview effect is partially based on the BlurOverview extension by "
 "nailfarmer"
@@ -739,6 +734,21 @@ msgstr ""
 msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr ""
 
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+msgid "Dual Kawase static blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->blurType->options
+msgid "Dual Kawase dynamic blur (if applicable)"
+msgstr ""
+
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
@@ -756,6 +766,26 @@ msgstr ""
 #. 6.0->settings-schema.json->desklets-blurType->tooltip
 #. 6.0->settings-schema.json->osd-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
+msgstr ""
+
+#. 6.0->settings-schema.json->show-blur-info->description
+msgid "💡 Blur Algorithm Guide (see tooltip)"
+msgstr ""
+
+#. 6.0->settings-schema.json->show-blur-info->tooltip
+msgid ""
+"<b>Blur Algorithm Guide:</b>\n"
+" <b>• Gaussian:</b> Good quality smooth blur, can be GPU intensive.\n"
+" <b>• Dual Kawase:</b> High quality smooth blur, optimized for low-end "
+"GPUs.\n"
+" <b>• Monte Carlo:</b> Grainy, frosted-glass style noisy blur.\n"
+" <b>• Simple:</b> Basic subtle blur for ancient computers.\n"
+"\n"
+"<b>Static vs Dynamic:</b>\n"
+" <b>• Dynamic:</b> Blurs background elements behind the blurred element in "
+"real-time.\n"
+" <b>• Static:</b> Only blurs the wallpaper, like x-ray vision to the desktop "
+"wallpaper."
 msgstr ""
 
 #. 6.0->settings-schema.json->radius->description
@@ -824,7 +854,7 @@ msgstr ""
 #. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
 msgid ""
 "Increasing number of iterations will make the blur appear smoother at the "
-"cost of some CPU power."
+"cost of some GPU power."
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
@@ -848,8 +878,7 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->description
-msgid ""
-"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgid "💡 The above Monte Carlo settings are used globally for all components"
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->tooltip
@@ -886,6 +915,12 @@ msgstr ""
 msgid "Monte Carlo"
 msgstr ""
 
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Dual Kawase"
+msgstr ""
+
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
@@ -918,6 +953,16 @@ msgstr ""
 #. 6.0->settings-schema.json->desklets-blurType->options
 #. 6.0->settings-schema.json->osd-blurType->options
 msgid "Monte Carlo dynamic blur"
+msgstr ""
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+msgid "Dual Kawase dynamic blur"
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -1110,6 +1155,21 @@ msgid ""
 "will have some minor persistent CPU costs when a dynamic blurred window is "
 "on top of two or more other windows. This option is recommended unless you "
 "are using video wallpaper like Hidamari"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->description
+msgid "Blur window title bars (please read tooltip)"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->tooltip
+msgid ""
+"When enabled, the title bar area under most windows will be blurred "
+"excluding GTK4 windows and windows with custom title bars. This behaves like "
+"\"Default window settings\" entry above and even uses its settings, but with "
+"this option only title bar areas are blurred rather than the entire window. "
+"Note: The title bar blurring will only be visible when the title bars are "
+"configured to be semi-transparent which MUST be done using CSS. See the Blur "
+"Cinnamon website for instructions."
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ca.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-07-03 10:34-0400\n"
+"POT-Creation-Date: 2026-08-07 15:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Odyssey <odysseyhyd@gmail.com>\n"
 "Language-Team: \n"
@@ -18,27 +18,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.6\n"
 
-#. 6.0/extension.js:2819 6.0/extension.js:2822 6.0/extension.js:2932
+#. 6.0/extension.js:2862 6.0/extension.js:2865 6.0/extension.js:2974
 #, fuzzy
 msgid "Default window settings"
 msgstr "Obrir la configuració d'Alt-Tab de Cinnamon"
 
-#. 6.0/extension.js:3080
+#. 6.0/extension.js:3140
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:3081
+#. 6.0/extension.js:3141
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3963
+#. 6.0/extension.js:4023
 msgid "Welcome to Blur Cinnamon"
 msgstr "Benvingut al Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:3964
+#. 6.0/extension.js:4024
 #, fuzzy
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
@@ -58,15 +58,15 @@ msgstr ""
 "per defecte. També podeu realitzar canvis a les propietats dels efectes, com "
 "ara la intensitat del desenfoc, la saturació del color i l'enfoscament."
 
-#. 6.0/extension.js:3968
+#. 6.0/extension.js:4028
 msgid "Open Blur Cinnamon Settings"
 msgstr "Obre la configuració del Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:4058
+#. 6.0/extension.js:4118
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Provant els efectes del Desenfoc de Cinnamon"
 
-#. 6.0/extension.js:4059
+#. 6.0/extension.js:4119
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -118,7 +118,7 @@ msgstr "Components de Cinnamon als quals s'aplicaran els efectes"
 
 #. 6.0->settings-schema.json->monte-carlo-settings->title
 #, fuzzy
-msgid "Monte Carlo specific settings"
+msgid "Additional Monte Carlo specific settings"
 msgstr "Configuració exclusiva del Tauler"
 
 #. 6.0->settings-schema.json->component-selector-section->title
@@ -138,21 +138,21 @@ msgstr "Desenfoc de Cinnamon"
 #. 6.0->settings-schema.json->appswitcher-warning->description
 #, fuzzy
 msgid ""
-"Note: The Alt-Tab effects are currently disabled under the \"General setup\" "
+"💡 The Alt-Tab effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr "Avís: els efectes d'Alt-Tab estan desactivats a la pestanya General."
 
 #. 6.0->settings-schema.json->desklets-warning->description
 #, fuzzy
 msgid ""
-"Note: The Desklet effects are currently disabled under the \"General setup\" "
+"💡 The Desklet effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr "Avís: els efectes de Tauler estan desactivats a la pestanya General."
 
 #. 6.0->settings-schema.json->desktop-warning->description
 #, fuzzy
 msgid ""
-"Note: The Desktop effects are currently disabled under the \"General setup\" "
+"💡 The Desktop effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Avís: els efectes de fons d'escriptori estan desactivats a la pestanya "
@@ -161,16 +161,14 @@ msgstr ""
 #. 6.0->settings-schema.json->expo-warning->description
 #, fuzzy
 msgid ""
-"Note: The Expo effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Expo effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Avís: els efectes de l'Exposició estan desactivats a la pestanya General."
 
 #. 6.0->settings-schema.json->popup-warning->description
 #, fuzzy
 msgid ""
-"Note: The Menu effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Menu effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Avís: els efectes dels menús emergents estan desactivats a la pestanya "
 "General."
@@ -178,7 +176,7 @@ msgstr ""
 #. 6.0->settings-schema.json->notification-warning->description
 #, fuzzy
 msgid ""
-"Note: The Notification effects are currently disabled under the \"General "
+"💡 The Notification effects are currently disabled under the \"General "
 "setup\" tab."
 msgstr ""
 "Avís: els efectes de notificacions emergents estan desactivats a la pestanya "
@@ -187,29 +185,28 @@ msgstr ""
 #. 6.0->settings-schema.json->osd-warning->description
 #, fuzzy
 msgid ""
-"Note: The On-Screen-Display effects are currently disabled under the "
-"\"General setup\" tab."
+"💡 The On-Screen-Display effects are currently disabled under the \"General "
+"setup\" tab."
 msgstr "Avís: els efectes de Tauler estan desactivats a la pestanya General."
 
 #. 6.0->settings-schema.json->overview-warning->description
 #, fuzzy
 msgid ""
-"Note: The Overview effects are currently disabled under the \"General "
-"setup\" tab."
+"💡 The Overview effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr ""
 "Avís: els efectes de Vista General estan desactivats a la pestanya General."
 
 #. 6.0->settings-schema.json->panel-warning->description
 #, fuzzy
 msgid ""
-"Note: The Panel effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Panel effects are currently disabled under the \"General setup\" tab."
 msgstr "Avís: els efectes de Tauler estan desactivats a la pestanya General."
 
 #. 6.0->settings-schema.json->tooltips-warning->description
 #, fuzzy
 msgid ""
-"Note: The Tooltip effects are currently disabled under the \"General setup\" "
+"💡 The Tooltip effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Avís: els efectes d'informació emergent estan desactivats a la pestanya "
@@ -218,15 +215,12 @@ msgstr ""
 #. 6.0->settings-schema.json->windows-warning->description
 #, fuzzy
 msgid ""
-"Note: The Window effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Window effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Avís: els efectes de l'Exposició estan desactivats a la pestanya General."
 
 #. 6.0->settings-schema.json->desklets-label->description
-msgid ""
-"<b>Note:</b> You must configure your Desklets to be transparent! (see "
-"tooltip)"
+msgid "💡 You must configure your Desklets to be transparent! (see tooltip)"
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-label->tooltip
@@ -239,9 +233,7 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-label->description
-msgid ""
-"<b>Note:</b> Read tooltip for information about the \"Default window "
-"settings\""
+msgid "💡 Read tooltip for information about the \"Default window settings\""
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-label->tooltip
@@ -313,10 +305,13 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners, Gaussian and Monte Carlo effects\n"
-"are based on code by aunetx (Blur-my-shell)\n"
-"<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
-"href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
+"The rounded corners, Gaussian and Monte Carlo effects are\n"
+"based on code by aunetx (Blur-my-shell <a href=\"https://github.com/aunetx/"
+"blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</"
+"a>)\n"
+"\n"
+"The Dual Kawase effect was written by <a href=\"https://github.com/Lucas-X-"
+"A\">Lucas-X-A</a>\n"
 "\n"
 "The Overview effect is partially based on the BlurOverview extension by "
 "nailfarmer"
@@ -907,6 +902,22 @@ msgstr "Intensitat del difuminat Gaussià"
 msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr ""
 
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase static blur"
+msgstr "Intensitat del difuminat Gaussià"
+
+#. 6.0->settings-schema.json->blurType->options
+msgid "Dual Kawase dynamic blur (if applicable)"
+msgstr ""
+
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
@@ -925,6 +936,26 @@ msgstr "Tipus d'efecte de difuminat"
 #. 6.0->settings-schema.json->osd-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Tipus d'algorisme de difuminat que s'utilitzarà pel fons"
+
+#. 6.0->settings-schema.json->show-blur-info->description
+msgid "💡 Blur Algorithm Guide (see tooltip)"
+msgstr ""
+
+#. 6.0->settings-schema.json->show-blur-info->tooltip
+msgid ""
+"<b>Blur Algorithm Guide:</b>\n"
+" <b>• Gaussian:</b> Good quality smooth blur, can be GPU intensive.\n"
+" <b>• Dual Kawase:</b> High quality smooth blur, optimized for low-end "
+"GPUs.\n"
+" <b>• Monte Carlo:</b> Grainy, frosted-glass style noisy blur.\n"
+" <b>• Simple:</b> Basic subtle blur for ancient computers.\n"
+"\n"
+"<b>Static vs Dynamic:</b>\n"
+" <b>• Dynamic:</b> Blurs background elements behind the blurred element in "
+"real-time.\n"
+" <b>• Static:</b> Only blurs the wallpaper, like x-ray vision to the desktop "
+"wallpaper."
+msgstr ""
 
 #. 6.0->settings-schema.json->radius->description
 #. 6.0->settings-schema.json->overview-radius->description
@@ -997,7 +1028,7 @@ msgstr "Saturació"
 #. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
 msgid ""
 "Increasing number of iterations will make the blur appear smoother at the "
-"cost of some CPU power."
+"cost of some GPU power."
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
@@ -1021,8 +1052,7 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->description
-msgid ""
-"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgid "💡 The above Monte Carlo settings are used globally for all components"
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->tooltip
@@ -1057,6 +1087,12 @@ msgstr "Gaussià"
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
 msgid "Monte Carlo"
+msgstr ""
+
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Dual Kawase"
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->options
@@ -1094,6 +1130,17 @@ msgstr "Intensitat del difuminat Gaussià"
 #. 6.0->settings-schema.json->osd-blurType->options
 #, fuzzy
 msgid "Monte Carlo dynamic blur"
+msgstr "Intensitat del difuminat Gaussià"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur"
 msgstr "Intensitat del difuminat Gaussià"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -1308,6 +1355,22 @@ msgid ""
 "will have some minor persistent CPU costs when a dynamic blurred window is "
 "on top of two or more other windows. This option is recommended unless you "
 "are using video wallpaper like Hidamari"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->description
+#, fuzzy
+msgid "Blur window title bars (please read tooltip)"
+msgstr "Notificacions emergents (Si us plau, llegiu el consell informatiu)"
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->tooltip
+msgid ""
+"When enabled, the title bar area under most windows will be blurred "
+"excluding GTK4 windows and windows with custom title bars. This behaves like "
+"\"Default window settings\" entry above and even uses its settings, but with "
+"this option only title bar areas are blurred rather than the entire window. "
+"Note: The title bar blurring will only be visible when the title bars are "
+"configured to be semi-transparent which MUST be done using CSS. See the Blur "
+"Cinnamon website for instructions."
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/da.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/da.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.5.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-07-03 10:34-0400\n"
+"POT-Creation-Date: 2026-08-07 15:04-0400\n"
 "PO-Revision-Date: 2026-07-27 10:34-0400\n"
 "Last-Translator: Alan Mortensen <over.tackiness223@passinbox.com>\n"
 "Language-Team: \n"
@@ -18,15 +18,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2819 6.0/extension.js:2822 6.0/extension.js:2932
+#. 6.0/extension.js:2862 6.0/extension.js:2865 6.0/extension.js:2974
 msgid "Default window settings"
 msgstr "Standardvinduesindstillinger"
 
-#. 6.0/extension.js:3080
+#. 6.0/extension.js:3140
 msgid "Error"
 msgstr "Fejl"
 
-#. 6.0/extension.js:3081
+#. 6.0/extension.js:3141
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
@@ -36,11 +36,11 @@ msgstr ""
 "vindue, der tidligere var i fokus, tilhører, og derfor kan Blur Cinnamon-"
 "effekterne ikke anvendes på dette vindue"
 
-#. 6.0/extension.js:3963
+#. 6.0/extension.js:4023
 msgid "Welcome to Blur Cinnamon"
 msgstr "Velkommen til Sløret Cinnamon"
 
-#. 6.0/extension.js:3964
+#. 6.0/extension.js:4024
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
@@ -59,15 +59,15 @@ msgstr ""
 "kan også foretage ændringer i effektens egenskaber, såsom sløringens "
 "intensitet, farvemætning og dæmpning."
 
-#. 6.0/extension.js:3968
+#. 6.0/extension.js:4028
 msgid "Open Blur Cinnamon Settings"
 msgstr "Åbn Sløret Cinnamon-indstillinger"
 
-#. 6.0/extension.js:4058
+#. 6.0/extension.js:4118
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Tester Sløret Cinnamons underretningseffekter"
 
-#. 6.0/extension.js:4059
+#. 6.0/extension.js:4119
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -112,7 +112,8 @@ msgid "Cinnamon desktop components where effects will be applied"
 msgstr "Cinnamon-skrivebordskomponenter som vil blive påvirket af effekter"
 
 #. 6.0->settings-schema.json->monte-carlo-settings->title
-msgid "Monte Carlo specific settings"
+#, fuzzy
+msgid "Additional Monte Carlo specific settings"
 msgstr "Monte Carlo-specifikke indstillinger"
 
 #. 6.0->settings-schema.json->component-selector-section->title
@@ -128,97 +129,103 @@ msgid "About Blur Cinnamon"
 msgstr "Om Sløret Cinnamon"
 
 #. 6.0->settings-schema.json->appswitcher-warning->description
+#, fuzzy
 msgid ""
-"Note: The Alt-Tab effects are currently disabled under the \"General setup\" "
+"💡 The Alt-Tab effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Bemærk: Alt-Tab-effekter er i øjeblikket deaktiveret under fanebladet "
 "“Generel opsætning”."
 
 #. 6.0->settings-schema.json->desklets-warning->description
+#, fuzzy
 msgid ""
-"Note: The Desklet effects are currently disabled under the \"General setup\" "
+"💡 The Desklet effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Bemærk: Skrivebordsprogrameffekter er i øjeblikket deaktiveret under "
 "fanebladet “Generel opsætning”."
 
 #. 6.0->settings-schema.json->desktop-warning->description
+#, fuzzy
 msgid ""
-"Note: The Desktop effects are currently disabled under the \"General setup\" "
+"💡 The Desktop effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Bemærk: Skrivebordseffekter er i øjeblikket deaktiveret under fanebladet "
 "“Generel opsætning”."
 
 #. 6.0->settings-schema.json->expo-warning->description
+#, fuzzy
 msgid ""
-"Note: The Expo effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Expo effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Bemærk: Vis arbejdsområde-effekter er i øjeblikket deaktiveret under "
 "fanebladet “Generel opsætning”."
 
 #. 6.0->settings-schema.json->popup-warning->description
+#, fuzzy
 msgid ""
-"Note: The Menu effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Menu effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Bemærk: Menueffekter er i øjeblikket deaktiveret under fanebladet “Generel "
 "opsætning”."
 
 #. 6.0->settings-schema.json->notification-warning->description
+#, fuzzy
 msgid ""
-"Note: The Notification effects are currently disabled under the \"General "
+"💡 The Notification effects are currently disabled under the \"General "
 "setup\" tab."
 msgstr ""
 "Bemærk: Underretningseffekter er i øjeblikket deaktiveret under fanebladet "
 "“Generel opsætning”."
 
 #. 6.0->settings-schema.json->osd-warning->description
+#, fuzzy
 msgid ""
-"Note: The On-Screen-Display effects are currently disabled under the "
-"\"General setup\" tab."
+"💡 The On-Screen-Display effects are currently disabled under the \"General "
+"setup\" tab."
 msgstr ""
 "Bemærk: Effekter for skærmbaseret visning er i øjeblikket deaktiveret under "
 "fanebladet “Generel opsætning”."
 
 #. 6.0->settings-schema.json->overview-warning->description
+#, fuzzy
 msgid ""
-"Note: The Overview effects are currently disabled under the \"General "
-"setup\" tab."
+"💡 The Overview effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr ""
 "Bemærk: Oversigtseffekter er i øjeblikket deaktiveret under fanebladet "
 "“Generel opsætning”."
 
 #. 6.0->settings-schema.json->panel-warning->description
+#, fuzzy
 msgid ""
-"Note: The Panel effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Panel effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Bemærk: Paneleffekter er i øjeblikket deaktiveret under fanebladet “Generel "
 "opsætning”."
 
 #. 6.0->settings-schema.json->tooltips-warning->description
+#, fuzzy
 msgid ""
-"Note: The Tooltip effects are currently disabled under the \"General setup\" "
+"💡 The Tooltip effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Bemærk: Værktøjstipeffekter er i øjeblikket deaktiveret under fanebladet "
 "“Generel opsætning”."
 
 #. 6.0->settings-schema.json->windows-warning->description
+#, fuzzy
 msgid ""
-"Note: The Window effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Window effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Bemærk: Vindueseffekter er i øjeblikket deaktiveret under fanebladet "
 "“Generel opsætning”."
 
 #. 6.0->settings-schema.json->desklets-label->description
-msgid ""
-"<b>Note:</b> You must configure your Desklets to be transparent! (see "
-"tooltip)"
+#, fuzzy
+msgid "💡 You must configure your Desklets to be transparent! (see tooltip)"
 msgstr ""
 "<b>Bemærk:</b> Du skal indstille dine skrivebordsprogrammer til at være "
 "gennemsigtige! (se værktøjstip)"
@@ -239,9 +246,8 @@ msgstr ""
 "skrivebordsprogrammets konfigurationsvindue."
 
 #. 6.0->settings-schema.json->windows-label->description
-msgid ""
-"<b>Note:</b> Read tooltip for information about the \"Default window "
-"settings\""
+#, fuzzy
+msgid "💡 Read tooltip for information about the \"Default window settings\""
 msgstr ""
 "<b>Bemærk:</b> Læs værktøjstippet for oplysninger om "
 "“Standardvinduesindstillinger”"
@@ -309,6 +315,7 @@ msgid "Show settings for component:"
 msgstr "Vis indstillinger for komponent:"
 
 #. 6.0->settings-schema.json->about-text->description
+#, fuzzy
 msgid ""
 "\n"
 "<b>Bringing your style into focus</b>\n"
@@ -317,13 +324,16 @@ msgid ""
 "Developed by: Kevin Langman\n"
 "<a href=\"https://github.com/klangman/BlurCinnamon\">Github</a> / <a "
 "href=\"https://github.com/klangman/BlurCinnamon/issues/new\">Report an "
-"issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/"
-"view/104\">Website</a>\n"
+"issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
+"104\">Website</a>\n"
 "\n"
-"The rounded corners, Gaussian and Monte Carlo effects\n"
-"are based on code by aunetx (Blur-my-shell)\n"
-"<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
-"href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
+"The rounded corners, Gaussian and Monte Carlo effects are\n"
+"based on code by aunetx (Blur-my-shell <a href=\"https://github.com/aunetx/"
+"blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</"
+"a>)\n"
+"\n"
+"The Dual Kawase effect was written by <a href=\"https://github.com/Lucas-X-"
+"A\">Lucas-X-A</a>\n"
 "\n"
 "The Overview effect is partially based on the BlurOverview extension by "
 "nailfarmer"
@@ -924,6 +934,23 @@ msgstr "Monte Carlo statisk sløring"
 msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr "Monte Carlo dynamisk sløring (hvis tilgængelig)"
 
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase static blur"
+msgstr "Enkel statisk sløring"
+
+#. 6.0->settings-schema.json->blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur (if applicable)"
+msgstr "Gaussisk dynamisk sløring (hvis tilgængelig)"
+
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
@@ -942,6 +969,26 @@ msgstr "Type af sløringseffekt"
 #. 6.0->settings-schema.json->osd-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Hvilken type sløringsalgoritme skal bruges til at sløre baggrunden."
+
+#. 6.0->settings-schema.json->show-blur-info->description
+msgid "💡 Blur Algorithm Guide (see tooltip)"
+msgstr ""
+
+#. 6.0->settings-schema.json->show-blur-info->tooltip
+msgid ""
+"<b>Blur Algorithm Guide:</b>\n"
+" <b>• Gaussian:</b> Good quality smooth blur, can be GPU intensive.\n"
+" <b>• Dual Kawase:</b> High quality smooth blur, optimized for low-end "
+"GPUs.\n"
+" <b>• Monte Carlo:</b> Grainy, frosted-glass style noisy blur.\n"
+" <b>• Simple:</b> Basic subtle blur for ancient computers.\n"
+"\n"
+"<b>Static vs Dynamic:</b>\n"
+" <b>• Dynamic:</b> Blurs background elements behind the blurred element in "
+"real-time.\n"
+" <b>• Static:</b> Only blurs the wallpaper, like x-ray vision to the desktop "
+"wallpaper."
+msgstr ""
 
 #. 6.0->settings-schema.json->radius->description
 #. 6.0->settings-schema.json->overview-radius->description
@@ -1009,9 +1056,10 @@ msgid "Iterations"
 msgstr "Gentagelser"
 
 #. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
+#, fuzzy
 msgid ""
 "Increasing number of iterations will make the blur appear smoother at the "
-"cost of some CPU power."
+"cost of some GPU power."
 msgstr ""
 "Øges antallet af iterationer, vil sløringen fremstå mere jævn, men det vil "
 "kræve lidt mere CPU-kraft."
@@ -1041,8 +1089,8 @@ msgstr ""
 "vægt eller ej."
 
 #. 6.0->settings-schema.json->monte-carlo-label->description
-msgid ""
-"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+#, fuzzy
+msgid "💡 The above Monte Carlo settings are used globally for all components"
 msgstr ""
 "<b>Bemærk:</b> Disse Monte Carlo-indstillinger anvendes globalt til alle "
 "komponenter"
@@ -1084,6 +1132,12 @@ msgstr "Gaussisk"
 msgid "Monte Carlo"
 msgstr "Monte Carlo"
 
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Dual Kawase"
+msgstr ""
+
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
@@ -1118,6 +1172,17 @@ msgstr "Gaussisk dynamisk sløring"
 msgid "Monte Carlo dynamic blur"
 msgstr "Monte Carlo dynamisk sløring"
 
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur"
+msgstr "Gaussisk dynamisk sløring"
+
 #. 6.0->settings-schema.json->panels-blurType->description
 #. 6.0->settings-schema.json->popup-blurType->description
 #. 6.0->settings-schema.json->notification-blurType->description
@@ -1150,9 +1215,9 @@ msgstr "Yderligere dæmpning af fremhævede pop op-menuelementer (%)"
 
 #. 6.0->settings-schema.json->popup-accent-opacity->tooltip
 msgid ""
-"Defines the additional dimming applied to the popup menu accent elements (i."
-"e. the main menu favorites box and entry boxes) which allow these elements "
-"to stand out from the other popup menu areas"
+"Defines the additional dimming applied to the popup menu accent elements "
+"(i.e. the main menu favorites box and entry boxes) which allow these "
+"elements to stand out from the other popup menu areas"
 msgstr ""
 "Definerer den ekstra dæmpning, der anvendes på pop op-menuenes fremhævede "
 "elementer (dvs. hovedmenuenes favoritfelt og indtastningsfelter), som gør "
@@ -1352,6 +1417,22 @@ msgstr ""
 "vedvarende belastning af CPU’en, når et vindue med dynamisk sløring ligger "
 "oven på to eller flere andre vinduer. Denne indstilling anbefales, medmindre "
 "du bruger videobaggrund som f.eks. Hidamari."
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->description
+#, fuzzy
+msgid "Blur window title bars (please read tooltip)"
+msgstr "Programvinduer (læs værktøjstip)"
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->tooltip
+msgid ""
+"When enabled, the title bar area under most windows will be blurred "
+"excluding GTK4 windows and windows with custom title bars. This behaves like "
+"\"Default window settings\" entry above and even uses its settings, but with "
+"this option only title bar areas are blurred rather than the entire window. "
+"Note: The title bar blurring will only be visible when the title bars are "
+"configured to be semi-transparent which MUST be done using CSS. See the Blur "
+"Cinnamon website for instructions."
+msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description
 msgid "Automatically enable effects for newly added Desklets"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/es.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.0.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-07-03 10:34-0400\n"
+"POT-Creation-Date: 2026-08-07 15:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -17,15 +17,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.9\n"
 
-#. 6.0/extension.js:2819 6.0/extension.js:2822 6.0/extension.js:2932
+#. 6.0/extension.js:2862 6.0/extension.js:2865 6.0/extension.js:2974
 msgid "Default window settings"
 msgstr "Configuración predeterminada de la ventana"
 
-#. 6.0/extension.js:3080
+#. 6.0/extension.js:3140
 msgid "Error"
 msgstr "Error"
 
-#. 6.0/extension.js:3081
+#. 6.0/extension.js:3141
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
@@ -35,11 +35,11 @@ msgstr ""
 "tenía el foco anteriormente, por lo que no se pueden aplicar los efectos de "
 "Desenfoque Cinnamon a esa ventana"
 
-#. 6.0/extension.js:3963
+#. 6.0/extension.js:4023
 msgid "Welcome to Blur Cinnamon"
 msgstr "Bienvenido a Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:3964
+#. 6.0/extension.js:4024
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
@@ -58,15 +58,15 @@ msgstr ""
 "También puedes modificar las propiedades de los efectos, como la intensidad "
 "del desenfoque, la saturación del color y el atenuado."
 
-#. 6.0/extension.js:3968
+#. 6.0/extension.js:4028
 msgid "Open Blur Cinnamon Settings"
 msgstr "Abrir configuración de Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:4058
+#. 6.0/extension.js:4118
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Probando los efectos de notificación de Desenfoque de Cinnamon"
 
-#. 6.0/extension.js:4059
+#. 6.0/extension.js:4119
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -117,7 +117,8 @@ msgid "Cinnamon desktop components where effects will be applied"
 msgstr "Componentes del escritorio Cinnamon a los que se aplicarán los efectos"
 
 #. 6.0->settings-schema.json->monte-carlo-settings->title
-msgid "Monte Carlo specific settings"
+#, fuzzy
+msgid "Additional Monte Carlo specific settings"
 msgstr "Configuración específica de Monte Carlo"
 
 #. 6.0->settings-schema.json->component-selector-section->title
@@ -133,97 +134,103 @@ msgid "About Blur Cinnamon"
 msgstr "Acerca de Desenfoque de Cinnamon"
 
 #. 6.0->settings-schema.json->appswitcher-warning->description
+#, fuzzy
 msgid ""
-"Note: The Alt-Tab effects are currently disabled under the \"General setup\" "
+"💡 The Alt-Tab effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Nota: Los efectos Alt-Tab están desactivados actualmente en la pestaña "
 "\"Configuración general\"."
 
 #. 6.0->settings-schema.json->desklets-warning->description
+#, fuzzy
 msgid ""
-"Note: The Desklet effects are currently disabled under the \"General setup\" "
+"💡 The Desklet effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Nota: Los efectos Desklet están actualmente desactivados en la pestaña "
 "\"Configuración general\"."
 
 #. 6.0->settings-schema.json->desktop-warning->description
+#, fuzzy
 msgid ""
-"Note: The Desktop effects are currently disabled under the \"General setup\" "
+"💡 The Desktop effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Nota: Los efectos de escritorio están actualmente desactivados en la pestaña "
 "\"Configuración general\"."
 
 #. 6.0->settings-schema.json->expo-warning->description
+#, fuzzy
 msgid ""
-"Note: The Expo effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Expo effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Nota: Los efectos de Expo están actualmente desactivados en la pestaña "
 "\"Configuración general\"."
 
 #. 6.0->settings-schema.json->popup-warning->description
+#, fuzzy
 msgid ""
-"Note: The Menu effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Menu effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Nota: Los efectos del menú están actualmente desactivados en la pestaña "
 "\"Configuración general\"."
 
 #. 6.0->settings-schema.json->notification-warning->description
+#, fuzzy
 msgid ""
-"Note: The Notification effects are currently disabled under the \"General "
+"💡 The Notification effects are currently disabled under the \"General "
 "setup\" tab."
 msgstr ""
 "Nota: Los efectos de notificación están desactivados actualmente en la "
 "pestaña \"Configuración general\"."
 
 #. 6.0->settings-schema.json->osd-warning->description
+#, fuzzy
 msgid ""
-"Note: The On-Screen-Display effects are currently disabled under the "
-"\"General setup\" tab."
+"💡 The On-Screen-Display effects are currently disabled under the \"General "
+"setup\" tab."
 msgstr ""
 "Nota: Los efectos de visualización en pantalla están desactivados "
 "actualmente en la pestaña \"Configuración general\"."
 
 #. 6.0->settings-schema.json->overview-warning->description
+#, fuzzy
 msgid ""
-"Note: The Overview effects are currently disabled under the \"General "
-"setup\" tab."
+"💡 The Overview effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr ""
 "Nota: Los efectos de la vista general están actualmente desactivados en la "
 "pestaña \"Configuración general\"."
 
 #. 6.0->settings-schema.json->panel-warning->description
+#, fuzzy
 msgid ""
-"Note: The Panel effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Panel effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Nota: Los efectos del panel están actualmente desactivados en la pestaña "
 "\"Configuración general\"."
 
 #. 6.0->settings-schema.json->tooltips-warning->description
+#, fuzzy
 msgid ""
-"Note: The Tooltip effects are currently disabled under the \"General setup\" "
+"💡 The Tooltip effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Nota: Los efectos de información sobre herramientas están desactivados "
 "actualmente en la pestaña \"Configuración general\"."
 
 #. 6.0->settings-schema.json->windows-warning->description
+#, fuzzy
 msgid ""
-"Note: The Window effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Window effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Nota: Los efectos de ventana están actualmente desactivados en la pestaña "
 "\"Configuración general\"."
 
 #. 6.0->settings-schema.json->desklets-label->description
-msgid ""
-"<b>Note:</b> You must configure your Desklets to be transparent! (see "
-"tooltip)"
+#, fuzzy
+msgid "💡 You must configure your Desklets to be transparent! (see tooltip)"
 msgstr ""
 "<b>Nota:</b> ¡Debes configurar tus Desklets para que sean transparentes! "
 "(ver información sobre herramientas)"
@@ -245,9 +252,8 @@ msgstr ""
 "del Desklet."
 
 #. 6.0->settings-schema.json->windows-label->description
-msgid ""
-"<b>Note:</b> Read tooltip for information about the \"Default window "
-"settings\""
+#, fuzzy
+msgid "💡 Read tooltip for information about the \"Default window settings\""
 msgstr ""
 "<b>Nota:</b> Lea la información sobre herramientas para obtener información "
 "sobre la \"Configuración predeterminada de la ventana\""
@@ -315,6 +321,7 @@ msgid "Show settings for component:"
 msgstr "Mostrar configuración del componente:"
 
 #. 6.0->settings-schema.json->about-text->description
+#, fuzzy
 msgid ""
 "\n"
 "<b>Bringing your style into focus</b>\n"
@@ -326,10 +333,13 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners, Gaussian and Monte Carlo effects\n"
-"are based on code by aunetx (Blur-my-shell)\n"
-"<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
-"href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
+"The rounded corners, Gaussian and Monte Carlo effects are\n"
+"based on code by aunetx (Blur-my-shell <a href=\"https://github.com/aunetx/"
+"blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</"
+"a>)\n"
+"\n"
+"The Dual Kawase effect was written by <a href=\"https://github.com/Lucas-X-"
+"A\">Lucas-X-A</a>\n"
 "\n"
 "The Overview effect is partially based on the BlurOverview extension by "
 "nailfarmer"
@@ -938,6 +948,23 @@ msgstr "Desenfoque Monte Carlo estático"
 msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr "Desenfoque dinámico Monte Carlo (si procede)"
 
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase static blur"
+msgstr "Desenfoque estático simple"
+
+#. 6.0->settings-schema.json->blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur (if applicable)"
+msgstr "Desenfoque dinámico gaussiano (si procede)"
+
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
@@ -957,6 +984,26 @@ msgstr "Tipo de efecto de desenfoque"
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr ""
 "Que tipo de algoritmo de desenfoque debe utilizarse para desenfocar el fondo."
+
+#. 6.0->settings-schema.json->show-blur-info->description
+msgid "💡 Blur Algorithm Guide (see tooltip)"
+msgstr ""
+
+#. 6.0->settings-schema.json->show-blur-info->tooltip
+msgid ""
+"<b>Blur Algorithm Guide:</b>\n"
+" <b>• Gaussian:</b> Good quality smooth blur, can be GPU intensive.\n"
+" <b>• Dual Kawase:</b> High quality smooth blur, optimized for low-end "
+"GPUs.\n"
+" <b>• Monte Carlo:</b> Grainy, frosted-glass style noisy blur.\n"
+" <b>• Simple:</b> Basic subtle blur for ancient computers.\n"
+"\n"
+"<b>Static vs Dynamic:</b>\n"
+" <b>• Dynamic:</b> Blurs background elements behind the blurred element in "
+"real-time.\n"
+" <b>• Static:</b> Only blurs the wallpaper, like x-ray vision to the desktop "
+"wallpaper."
+msgstr ""
 
 #. 6.0->settings-schema.json->radius->description
 #. 6.0->settings-schema.json->overview-radius->description
@@ -1026,9 +1073,10 @@ msgid "Iterations"
 msgstr "Iteraciones"
 
 #. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
+#, fuzzy
 msgid ""
 "Increasing number of iterations will make the blur appear smoother at the "
-"cost of some CPU power."
+"cost of some GPU power."
 msgstr ""
 "Aumentar el número de iteraciones hará que el desenfoque resulte más suave, "
 "aunque a costa de un mayor consumo de recursos de la CPU."
@@ -1056,8 +1104,8 @@ msgid ""
 msgstr "Si los píxeles más cercanos al píxel original tendrán mayor peso o no."
 
 #. 6.0->settings-schema.json->monte-carlo-label->description
-msgid ""
-"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+#, fuzzy
+msgid "💡 The above Monte Carlo settings are used globally for all components"
 msgstr ""
 "<b>Nota:</b> Estos ajustes de Monte Carlo se aplican de forma global a todos "
 "los componentes"
@@ -1100,6 +1148,12 @@ msgstr "Gaussiano"
 msgid "Monte Carlo"
 msgstr "Monte Carlo"
 
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Dual Kawase"
+msgstr ""
+
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
@@ -1133,6 +1187,17 @@ msgstr "Desenfoque dinámico gaussiano"
 #. 6.0->settings-schema.json->osd-blurType->options
 msgid "Monte Carlo dynamic blur"
 msgstr "Desenfoque dinámico Monte Carlo"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur"
+msgstr "Desenfoque dinámico gaussiano"
 
 #. 6.0->settings-schema.json->panels-blurType->description
 #. 6.0->settings-schema.json->popup-blurType->description
@@ -1376,6 +1441,22 @@ msgstr ""
 "y persistente de la CPU cuando una ventana con desenfoque dinámico se "
 "encuentre sobre otras dos o más ventanas. Se recomienda esta opción a menos "
 "que utilices un fondo de pantalla en vídeo como Hidamari"
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->description
+#, fuzzy
+msgid "Blur window title bars (please read tooltip)"
+msgstr "Ventanas de aplicación (lea la información sobre herramientas)"
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->tooltip
+msgid ""
+"When enabled, the title bar area under most windows will be blurred "
+"excluding GTK4 windows and windows with custom title bars. This behaves like "
+"\"Default window settings\" entry above and even uses its settings, but with "
+"this option only title bar areas are blurred rather than the entire window. "
+"Note: The title bar blurring will only be visible when the title bars are "
+"configured to be semi-transparent which MUST be done using CSS. See the Blur "
+"Cinnamon website for instructions."
+msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description
 msgid "Automatically enable effects for newly added Desklets"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fi.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-07-03 10:34-0400\n"
+"POT-Creation-Date: 2026-08-07 15:04-0400\n"
 "PO-Revision-Date: 2025-03-30 10:53+0300\n"
 "Last-Translator: Kimmo Kujansuu <mrkujansuu@gmail.com>\n"
 "Language-Team: \n"
@@ -18,27 +18,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2819 6.0/extension.js:2822 6.0/extension.js:2932
+#. 6.0/extension.js:2862 6.0/extension.js:2865 6.0/extension.js:2974
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:3080
+#. 6.0/extension.js:3140
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:3081
+#. 6.0/extension.js:3141
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3963
+#. 6.0/extension.js:4023
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Blur Cinnamon"
 
-#. 6.0/extension.js:3964
+#. 6.0/extension.js:4024
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
@@ -49,16 +49,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:3968
+#. 6.0/extension.js:4028
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Blur Cinnamon"
 
-#. 6.0/extension.js:4058
+#. 6.0/extension.js:4118
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:4059
+#. 6.0/extension.js:4119
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -107,7 +107,7 @@ msgstr "Cinnamon komponentit. Valitse mihin tehoste lisätään"
 
 #. 6.0->settings-schema.json->monte-carlo-settings->title
 #, fuzzy
-msgid "Monte Carlo specific settings"
+msgid "Additional Monte Carlo specific settings"
 msgstr "Paneelikohtaiset asetukset"
 
 #. 6.0->settings-schema.json->component-selector-section->title
@@ -127,21 +127,21 @@ msgstr "Blur Cinnamon"
 #. 6.0->settings-schema.json->appswitcher-warning->description
 #, fuzzy
 msgid ""
-"Note: The Alt-Tab effects are currently disabled under the \"General setup\" "
+"💡 The Alt-Tab effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr "Varoitus: Paneelin tehosteet ovat pois käytöstä Yleinen-välilehdellä."
 
 #. 6.0->settings-schema.json->desklets-warning->description
 #, fuzzy
 msgid ""
-"Note: The Desklet effects are currently disabled under the \"General setup\" "
+"💡 The Desklet effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr "Varoitus: Paneelin tehosteet ovat pois käytöstä Yleinen-välilehdellä."
 
 #. 6.0->settings-schema.json->desktop-warning->description
 #, fuzzy
 msgid ""
-"Note: The Desktop effects are currently disabled under the \"General setup\" "
+"💡 The Desktop effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Varoitus: Tauskakuvien tehosteet ovat pois käytöstä Yleinen-välilehdellä."
@@ -149,16 +149,14 @@ msgstr ""
 #. 6.0->settings-schema.json->expo-warning->description
 #, fuzzy
 msgid ""
-"Note: The Expo effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Expo effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Varoitus: Työtilojen tehosteet ovat pois käytöstä Yleinen-välilehdellä."
 
 #. 6.0->settings-schema.json->popup-warning->description
 #, fuzzy
 msgid ""
-"Note: The Menu effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Menu effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Varoitus: Ponnahdusvalikoiden tehosteet ovat pois käytöstä Yleinen-"
 "välilehdellä."
@@ -166,7 +164,7 @@ msgstr ""
 #. 6.0->settings-schema.json->notification-warning->description
 #, fuzzy
 msgid ""
-"Note: The Notification effects are currently disabled under the \"General "
+"💡 The Notification effects are currently disabled under the \"General "
 "setup\" tab."
 msgstr ""
 "Varoitus: Työtilojen tehosteet ovat pois käytöstä Yleinen-välilehdellä."
@@ -174,44 +172,40 @@ msgstr ""
 #. 6.0->settings-schema.json->osd-warning->description
 #, fuzzy
 msgid ""
-"Note: The On-Screen-Display effects are currently disabled under the "
-"\"General setup\" tab."
+"💡 The On-Screen-Display effects are currently disabled under the \"General "
+"setup\" tab."
 msgstr "Varoitus: Paneelin tehosteet ovat pois käytöstä Yleinen-välilehdellä."
 
 #. 6.0->settings-schema.json->overview-warning->description
 #, fuzzy
 msgid ""
-"Note: The Overview effects are currently disabled under the \"General "
-"setup\" tab."
+"💡 The Overview effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr ""
 "Varoitus: Ohjelmat näkymän tehosteet ovat pois käytöstä Yleinen-välilehdellä."
 
 #. 6.0->settings-schema.json->panel-warning->description
 #, fuzzy
 msgid ""
-"Note: The Panel effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Panel effects are currently disabled under the \"General setup\" tab."
 msgstr "Varoitus: Paneelin tehosteet ovat pois käytöstä Yleinen-välilehdellä."
 
 #. 6.0->settings-schema.json->tooltips-warning->description
 #, fuzzy
 msgid ""
-"Note: The Tooltip effects are currently disabled under the \"General setup\" "
+"💡 The Tooltip effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr "Varoitus: Paneelin tehosteet ovat pois käytöstä Yleinen-välilehdellä."
 
 #. 6.0->settings-schema.json->windows-warning->description
 #, fuzzy
 msgid ""
-"Note: The Window effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Window effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Varoitus: Työtilojen tehosteet ovat pois käytöstä Yleinen-välilehdellä."
 
 #. 6.0->settings-schema.json->desklets-label->description
-msgid ""
-"<b>Note:</b> You must configure your Desklets to be transparent! (see "
-"tooltip)"
+msgid "💡 You must configure your Desklets to be transparent! (see tooltip)"
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-label->tooltip
@@ -224,9 +218,7 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-label->description
-msgid ""
-"<b>Note:</b> Read tooltip for information about the \"Default window "
-"settings\""
+msgid "💡 Read tooltip for information about the \"Default window settings\""
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-label->tooltip
@@ -298,10 +290,13 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners, Gaussian and Monte Carlo effects\n"
-"are based on code by aunetx (Blur-my-shell)\n"
-"<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
-"href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
+"The rounded corners, Gaussian and Monte Carlo effects are\n"
+"based on code by aunetx (Blur-my-shell <a href=\"https://github.com/aunetx/"
+"blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</"
+"a>)\n"
+"\n"
+"The Dual Kawase effect was written by <a href=\"https://github.com/Lucas-X-"
+"A\">Lucas-X-A</a>\n"
 "\n"
 "The Overview effect is partially based on the BlurOverview extension by "
 "nailfarmer"
@@ -882,6 +877,22 @@ msgstr "Sumennuksen voimakkuus"
 msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr ""
 
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase static blur"
+msgstr "Sumennuksen voimakkuus"
+
+#. 6.0->settings-schema.json->blurType->options
+msgid "Dual Kawase dynamic blur (if applicable)"
+msgstr ""
+
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
@@ -900,6 +911,26 @@ msgstr "Sumeustehoste"
 #. 6.0->settings-schema.json->osd-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Mitä sumennusalgoritmia tulisi käyttää taustan sumentamiseen"
+
+#. 6.0->settings-schema.json->show-blur-info->description
+msgid "💡 Blur Algorithm Guide (see tooltip)"
+msgstr ""
+
+#. 6.0->settings-schema.json->show-blur-info->tooltip
+msgid ""
+"<b>Blur Algorithm Guide:</b>\n"
+" <b>• Gaussian:</b> Good quality smooth blur, can be GPU intensive.\n"
+" <b>• Dual Kawase:</b> High quality smooth blur, optimized for low-end "
+"GPUs.\n"
+" <b>• Monte Carlo:</b> Grainy, frosted-glass style noisy blur.\n"
+" <b>• Simple:</b> Basic subtle blur for ancient computers.\n"
+"\n"
+"<b>Static vs Dynamic:</b>\n"
+" <b>• Dynamic:</b> Blurs background elements behind the blurred element in "
+"real-time.\n"
+" <b>• Static:</b> Only blurs the wallpaper, like x-ray vision to the desktop "
+"wallpaper."
+msgstr ""
 
 #. 6.0->settings-schema.json->radius->description
 #. 6.0->settings-schema.json->overview-radius->description
@@ -970,7 +1001,7 @@ msgstr "Kylläisyys"
 #. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
 msgid ""
 "Increasing number of iterations will make the blur appear smoother at the "
-"cost of some CPU power."
+"cost of some GPU power."
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
@@ -994,8 +1025,7 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->description
-msgid ""
-"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgid "💡 The above Monte Carlo settings are used globally for all components"
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->tooltip
@@ -1030,6 +1060,12 @@ msgstr "Gaussian"
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
 msgid "Monte Carlo"
+msgstr ""
+
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Dual Kawase"
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->options
@@ -1067,6 +1103,17 @@ msgstr "Sumennuksen voimakkuus"
 #. 6.0->settings-schema.json->osd-blurType->options
 #, fuzzy
 msgid "Monte Carlo dynamic blur"
+msgstr "Sumennuksen voimakkuus"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur"
 msgstr "Sumennuksen voimakkuus"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -1273,6 +1320,22 @@ msgid ""
 "will have some minor persistent CPU costs when a dynamic blurred window is "
 "on top of two or more other windows. This option is recommended unless you "
 "are using video wallpaper like Hidamari"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->description
+#, fuzzy
+msgid "Blur window title bars (please read tooltip)"
+msgstr "Ponnahdusvalikot (lue työkaluvihje)"
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->tooltip
+msgid ""
+"When enabled, the title bar area under most windows will be blurred "
+"excluding GTK4 windows and windows with custom title bars. This behaves like "
+"\"Default window settings\" entry above and even uses its settings, but with "
+"this option only title bar areas are blurred rather than the entire window. "
+"Note: The title bar blurring will only be visible when the title bars are "
+"configured to be semi-transparent which MUST be done using CSS. See the Blur "
+"Cinnamon website for instructions."
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/fr.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.2.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-07-03 10:34-0400\n"
+"POT-Creation-Date: 2026-08-07 15:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: claudiux\n"
 "Language-Team: \n"
@@ -18,27 +18,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2819 6.0/extension.js:2822 6.0/extension.js:2932
+#. 6.0/extension.js:2862 6.0/extension.js:2865 6.0/extension.js:2974
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:3080
+#. 6.0/extension.js:3140
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:3081
+#. 6.0/extension.js:3141
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3963
+#. 6.0/extension.js:4023
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Flou pour Cinnamon"
 
-#. 6.0/extension.js:3964
+#. 6.0/extension.js:4024
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
@@ -49,16 +49,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:3968
+#. 6.0/extension.js:4028
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Flou pour Cinnamon"
 
-#. 6.0/extension.js:4058
+#. 6.0/extension.js:4118
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:4059
+#. 6.0/extension.js:4119
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -106,7 +106,7 @@ msgstr "Composants de Cinnamon où les effets seront appliqués"
 
 #. 6.0->settings-schema.json->monte-carlo-settings->title
 #, fuzzy
-msgid "Monte Carlo specific settings"
+msgid "Additional Monte Carlo specific settings"
 msgstr "Paramètres spécifiques au Panneau"
 
 #. 6.0->settings-schema.json->component-selector-section->title
@@ -126,7 +126,7 @@ msgstr "Flou pour Cinnamon"
 #. 6.0->settings-schema.json->appswitcher-warning->description
 #, fuzzy
 msgid ""
-"Note: The Alt-Tab effects are currently disabled under the \"General setup\" "
+"💡 The Alt-Tab effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Avertissement : Les effets des Panneaux sont actuellement désactivés dans "
@@ -135,7 +135,7 @@ msgstr ""
 #. 6.0->settings-schema.json->desklets-warning->description
 #, fuzzy
 msgid ""
-"Note: The Desklet effects are currently disabled under the \"General setup\" "
+"💡 The Desklet effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Avertissement : Les effets des Panneaux sont actuellement désactivés dans "
@@ -144,7 +144,7 @@ msgstr ""
 #. 6.0->settings-schema.json->desktop-warning->description
 #, fuzzy
 msgid ""
-"Note: The Desktop effects are currently disabled under the \"General setup\" "
+"💡 The Desktop effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Avertissement : Les effets Expo sont actuellement désactivés dans l'onglet "
@@ -153,8 +153,7 @@ msgstr ""
 #. 6.0->settings-schema.json->expo-warning->description
 #, fuzzy
 msgid ""
-"Note: The Expo effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Expo effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Avertissement : Les effets Expo sont actuellement désactivés dans l'onglet "
 "Général."
@@ -162,8 +161,7 @@ msgstr ""
 #. 6.0->settings-schema.json->popup-warning->description
 #, fuzzy
 msgid ""
-"Note: The Menu effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Menu effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Avertissement : Les effets du Menu principal sont actuellement désactivés "
 "dans l'onglet Général."
@@ -171,7 +169,7 @@ msgstr ""
 #. 6.0->settings-schema.json->notification-warning->description
 #, fuzzy
 msgid ""
-"Note: The Notification effects are currently disabled under the \"General "
+"💡 The Notification effects are currently disabled under the \"General "
 "setup\" tab."
 msgstr ""
 "Avertissement : Les effets Expo sont actuellement désactivés dans l'onglet "
@@ -180,8 +178,8 @@ msgstr ""
 #. 6.0->settings-schema.json->osd-warning->description
 #, fuzzy
 msgid ""
-"Note: The On-Screen-Display effects are currently disabled under the "
-"\"General setup\" tab."
+"💡 The On-Screen-Display effects are currently disabled under the \"General "
+"setup\" tab."
 msgstr ""
 "Avertissement : Les effets des Panneaux sont actuellement désactivés dans "
 "l'onglet Général."
@@ -189,8 +187,8 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-warning->description
 #, fuzzy
 msgid ""
-"Note: The Overview effects are currently disabled under the \"General "
-"setup\" tab."
+"💡 The Overview effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr ""
 "Avertissement : Les effets de la Vue d'ensemble sont actuellement désactivés "
 "dans l'onglet Général."
@@ -198,8 +196,7 @@ msgstr ""
 #. 6.0->settings-schema.json->panel-warning->description
 #, fuzzy
 msgid ""
-"Note: The Panel effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Panel effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Avertissement : Les effets des Panneaux sont actuellement désactivés dans "
 "l'onglet Général."
@@ -207,7 +204,7 @@ msgstr ""
 #. 6.0->settings-schema.json->tooltips-warning->description
 #, fuzzy
 msgid ""
-"Note: The Tooltip effects are currently disabled under the \"General setup\" "
+"💡 The Tooltip effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Avertissement : Les effets des Panneaux sont actuellement désactivés dans "
@@ -216,16 +213,13 @@ msgstr ""
 #. 6.0->settings-schema.json->windows-warning->description
 #, fuzzy
 msgid ""
-"Note: The Window effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Window effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Avertissement : Les effets Expo sont actuellement désactivés dans l'onglet "
 "Général."
 
 #. 6.0->settings-schema.json->desklets-label->description
-msgid ""
-"<b>Note:</b> You must configure your Desklets to be transparent! (see "
-"tooltip)"
+msgid "💡 You must configure your Desklets to be transparent! (see tooltip)"
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-label->tooltip
@@ -238,9 +232,7 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-label->description
-msgid ""
-"<b>Note:</b> Read tooltip for information about the \"Default window "
-"settings\""
+msgid "💡 Read tooltip for information about the \"Default window settings\""
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-label->tooltip
@@ -311,10 +303,13 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners, Gaussian and Monte Carlo effects\n"
-"are based on code by aunetx (Blur-my-shell)\n"
-"<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
-"href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
+"The rounded corners, Gaussian and Monte Carlo effects are\n"
+"based on code by aunetx (Blur-my-shell <a href=\"https://github.com/aunetx/"
+"blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</"
+"a>)\n"
+"\n"
+"The Dual Kawase effect was written by <a href=\"https://github.com/Lucas-X-"
+"A\">Lucas-X-A</a>\n"
 "\n"
 "The Overview effect is partially based on the BlurOverview extension by "
 "nailfarmer"
@@ -910,6 +905,22 @@ msgstr "Intensité du flou gaussien"
 msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr ""
 
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase static blur"
+msgstr "Intensité du flou gaussien"
+
+#. 6.0->settings-schema.json->blurType->options
+msgid "Dual Kawase dynamic blur (if applicable)"
+msgstr ""
+
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
@@ -928,6 +939,26 @@ msgstr "Type d'effet de flou"
 #. 6.0->settings-schema.json->osd-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Type d'algorithme à utiliser pour rendre l'arrière-plan flou"
+
+#. 6.0->settings-schema.json->show-blur-info->description
+msgid "💡 Blur Algorithm Guide (see tooltip)"
+msgstr ""
+
+#. 6.0->settings-schema.json->show-blur-info->tooltip
+msgid ""
+"<b>Blur Algorithm Guide:</b>\n"
+" <b>• Gaussian:</b> Good quality smooth blur, can be GPU intensive.\n"
+" <b>• Dual Kawase:</b> High quality smooth blur, optimized for low-end "
+"GPUs.\n"
+" <b>• Monte Carlo:</b> Grainy, frosted-glass style noisy blur.\n"
+" <b>• Simple:</b> Basic subtle blur for ancient computers.\n"
+"\n"
+"<b>Static vs Dynamic:</b>\n"
+" <b>• Dynamic:</b> Blurs background elements behind the blurred element in "
+"real-time.\n"
+" <b>• Static:</b> Only blurs the wallpaper, like x-ray vision to the desktop "
+"wallpaper."
+msgstr ""
 
 #. 6.0->settings-schema.json->radius->description
 #. 6.0->settings-schema.json->overview-radius->description
@@ -998,7 +1029,7 @@ msgstr ""
 #. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
 msgid ""
 "Increasing number of iterations will make the blur appear smoother at the "
-"cost of some CPU power."
+"cost of some GPU power."
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
@@ -1022,8 +1053,7 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->description
-msgid ""
-"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgid "💡 The above Monte Carlo settings are used globally for all components"
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->tooltip
@@ -1060,6 +1090,12 @@ msgstr "Gaussien"
 msgid "Monte Carlo"
 msgstr ""
 
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Dual Kawase"
+msgstr ""
+
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
@@ -1094,6 +1130,17 @@ msgstr "Intensité du flou gaussien"
 #. 6.0->settings-schema.json->osd-blurType->options
 #, fuzzy
 msgid "Monte Carlo dynamic blur"
+msgstr "Intensité du flou gaussien"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur"
 msgstr "Intensité du flou gaussien"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -1298,6 +1345,22 @@ msgid ""
 "will have some minor persistent CPU costs when a dynamic blurred window is "
 "on top of two or more other windows. This option is recommended unless you "
 "are using video wallpaper like Hidamari"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->description
+#, fuzzy
+msgid "Blur window title bars (please read tooltip)"
+msgstr "Menu principal (Veuillez lire l'infobulle)"
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->tooltip
+msgid ""
+"When enabled, the title bar area under most windows will be blurred "
+"excluding GTK4 windows and windows with custom title bars. This behaves like "
+"\"Default window settings\" entry above and even uses its settings, but with "
+"this option only title bar areas are blurred rather than the entire window. "
+"Note: The title bar blurring will only be visible when the title bars are "
+"configured to be semi-transparent which MUST be done using CSS. See the Blur "
+"Cinnamon website for instructions."
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/hu.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/hu.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-07-03 10:34-0400\n"
+"POT-Creation-Date: 2026-08-07 15:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: \n"
 "Language-Team: \n"
@@ -18,15 +18,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2819 6.0/extension.js:2822 6.0/extension.js:2932
+#. 6.0/extension.js:2862 6.0/extension.js:2865 6.0/extension.js:2974
 msgid "Default window settings"
 msgstr "Alapértelmezett ablakbeállítások"
 
-#. 6.0/extension.js:3080
+#. 6.0/extension.js:3140
 msgid "Error"
 msgstr "Hiba"
 
-#. 6.0/extension.js:3081
+#. 6.0/extension.js:3141
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
@@ -36,11 +36,11 @@ msgstr ""
 "WM_CLASS osztályát, ezért a Cinnamon Elhomályosítása effektek nem "
 "alkalmazhatók erre az ablakra"
 
-#. 6.0/extension.js:3963
+#. 6.0/extension.js:4023
 msgid "Welcome to Blur Cinnamon"
 msgstr "Üdvözöljük a Cinnamon Elhomályosításában"
 
-#. 6.0/extension.js:3964
+#. 6.0/extension.js:4024
 #, fuzzy
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
@@ -60,15 +60,15 @@ msgstr ""
 "Módosíthatod az effektek tulajdonságait is, például az elmosás intenzitását, "
 "a színtelítettséget és a fényerőt."
 
-#. 6.0/extension.js:3968
+#. 6.0/extension.js:4028
 msgid "Open Blur Cinnamon Settings"
 msgstr "Nyissa meg a Cinnamon Elhomályosítása beállításait"
 
-#. 6.0/extension.js:4058
+#. 6.0/extension.js:4118
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Cinnamon Elhomályosítása értesítési effektek tesztelése"
 
-#. 6.0/extension.js:4059
+#. 6.0/extension.js:4119
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -117,7 +117,7 @@ msgstr "Cinnamon asztali komponensek, ahol az effektek alkalmazásra kerülnek"
 
 #. 6.0->settings-schema.json->monte-carlo-settings->title
 #, fuzzy
-msgid "Monte Carlo specific settings"
+msgid "Additional Monte Carlo specific settings"
 msgstr "Panelspecifikus beállítások"
 
 #. 6.0->settings-schema.json->component-selector-section->title
@@ -133,48 +133,52 @@ msgid "About Blur Cinnamon"
 msgstr "Cinnamon Elhomályosítása Névjegye"
 
 #. 6.0->settings-schema.json->appswitcher-warning->description
+#, fuzzy
 msgid ""
-"Note: The Alt-Tab effects are currently disabled under the \"General setup\" "
+"💡 The Alt-Tab effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Megjegyzés: Az Alt-Tab effektek jelenleg le vannak tiltva az „Általános "
 "beállítások” lapon."
 
 #. 6.0->settings-schema.json->desklets-warning->description
+#, fuzzy
 msgid ""
-"Note: The Desklet effects are currently disabled under the \"General setup\" "
+"💡 The Desklet effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Megjegyzés: az asztalkalmazás-effektek jelenleg le vannak tiltva az "
 "„Általános beállítások” lapon."
 
 #. 6.0->settings-schema.json->desktop-warning->description
+#, fuzzy
 msgid ""
-"Note: The Desktop effects are currently disabled under the \"General setup\" "
+"💡 The Desktop effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Megjegyzés: Az asztali effektek jelenleg le vannak tiltva az „Általános "
 "beállítások” lapon."
 
 #. 6.0->settings-schema.json->expo-warning->description
+#, fuzzy
 msgid ""
-"Note: The Expo effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Expo effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Megjegyzés: Az Expo effektek jelenleg le vannak tiltva az „Általános "
 "beállítások” lapon."
 
 #. 6.0->settings-schema.json->popup-warning->description
+#, fuzzy
 msgid ""
-"Note: The Menu effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Menu effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Megjegyzés: A Menüeffektusok jelenleg le vannak tiltva az „Általános "
 "beállítások” lapon."
 
 #. 6.0->settings-schema.json->notification-warning->description
+#, fuzzy
 msgid ""
-"Note: The Notification effects are currently disabled under the \"General "
+"💡 The Notification effects are currently disabled under the \"General "
 "setup\" tab."
 msgstr ""
 "Megjegyzés: Az értesítési effektusok jelenleg le vannak tiltva az „Általános "
@@ -183,48 +187,49 @@ msgstr ""
 #. 6.0->settings-schema.json->osd-warning->description
 #, fuzzy
 msgid ""
-"Note: The On-Screen-Display effects are currently disabled under the "
-"\"General setup\" tab."
+"💡 The On-Screen-Display effects are currently disabled under the \"General "
+"setup\" tab."
 msgstr ""
 "Megjegyzés: A Paneleffektusok jelenleg le vannak tiltva az „Általános "
 "beállítások” lapon."
 
 #. 6.0->settings-schema.json->overview-warning->description
+#, fuzzy
 msgid ""
-"Note: The Overview effects are currently disabled under the \"General "
-"setup\" tab."
+"💡 The Overview effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr ""
 "Megjegyzés: Az Áttekintés effektek jelenleg le vannak tiltva az „Általános "
 "beállítások” lapon."
 
 #. 6.0->settings-schema.json->panel-warning->description
+#, fuzzy
 msgid ""
-"Note: The Panel effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Panel effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Megjegyzés: A Paneleffektusok jelenleg le vannak tiltva az „Általános "
 "beállítások” lapon."
 
 #. 6.0->settings-schema.json->tooltips-warning->description
+#, fuzzy
 msgid ""
-"Note: The Tooltip effects are currently disabled under the \"General setup\" "
+"💡 The Tooltip effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Megjegyzés: Az eszköztipp-effektusok jelenleg le vannak tiltva az „Általános "
 "beállítások” lapon."
 
 #. 6.0->settings-schema.json->windows-warning->description
+#, fuzzy
 msgid ""
-"Note: The Window effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Window effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Megjegyzés: Az Ablakeffektusok jelenleg le vannak tiltva az „Általános "
 "beállítások” lapon."
 
 #. 6.0->settings-schema.json->desklets-label->description
-msgid ""
-"<b>Note:</b> You must configure your Desklets to be transparent! (see "
-"tooltip)"
+#, fuzzy
+msgid "💡 You must configure your Desklets to be transparent! (see tooltip)"
 msgstr ""
 "<b>Megjegyzés:</b> Átlátszóra kell állítania az asztalkalmazást! (lásd az "
 "elemleírást)"
@@ -245,9 +250,8 @@ msgstr ""
 "\" menüpontot az asztalkalmazás konfigurációs ablakának megnyitásához."
 
 #. 6.0->settings-schema.json->windows-label->description
-msgid ""
-"<b>Note:</b> Read tooltip for information about the \"Default window "
-"settings\""
+#, fuzzy
+msgid "💡 Read tooltip for information about the \"Default window settings\""
 msgstr ""
 "<b>Megjegyzés:</b> Az „Alapértelmezett ablakbeállítások” elemleírásában "
 "további információkat talál."
@@ -327,10 +331,13 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners, Gaussian and Monte Carlo effects\n"
-"are based on code by aunetx (Blur-my-shell)\n"
-"<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
-"href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
+"The rounded corners, Gaussian and Monte Carlo effects are\n"
+"based on code by aunetx (Blur-my-shell <a href=\"https://github.com/aunetx/"
+"blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</"
+"a>)\n"
+"\n"
+"The Dual Kawase effect was written by <a href=\"https://github.com/Lucas-X-"
+"A\">Lucas-X-A</a>\n"
 "\n"
 "The Overview effect is partially based on the BlurOverview extension by "
 "nailfarmer"
@@ -941,6 +948,23 @@ msgstr "Egyszerű statikus elmosódás"
 msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr "Gauss-féle dinamikus elmosás (ha alkalmazható)"
 
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase static blur"
+msgstr "Egyszerű statikus elmosódás"
+
+#. 6.0->settings-schema.json->blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur (if applicable)"
+msgstr "Gauss-féle dinamikus elmosás (ha alkalmazható)"
+
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
@@ -960,6 +984,26 @@ msgstr "Az elmosódási hatás típusa"
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr ""
 "Milyen típusú elmosódási algoritmust kell használni a háttér elmosásához"
+
+#. 6.0->settings-schema.json->show-blur-info->description
+msgid "💡 Blur Algorithm Guide (see tooltip)"
+msgstr ""
+
+#. 6.0->settings-schema.json->show-blur-info->tooltip
+msgid ""
+"<b>Blur Algorithm Guide:</b>\n"
+" <b>• Gaussian:</b> Good quality smooth blur, can be GPU intensive.\n"
+" <b>• Dual Kawase:</b> High quality smooth blur, optimized for low-end "
+"GPUs.\n"
+" <b>• Monte Carlo:</b> Grainy, frosted-glass style noisy blur.\n"
+" <b>• Simple:</b> Basic subtle blur for ancient computers.\n"
+"\n"
+"<b>Static vs Dynamic:</b>\n"
+" <b>• Dynamic:</b> Blurs background elements behind the blurred element in "
+"real-time.\n"
+" <b>• Static:</b> Only blurs the wallpaper, like x-ray vision to the desktop "
+"wallpaper."
+msgstr ""
 
 #. 6.0->settings-schema.json->radius->description
 #. 6.0->settings-schema.json->overview-radius->description
@@ -1032,7 +1076,7 @@ msgstr "Telítettség"
 #. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
 msgid ""
 "Increasing number of iterations will make the blur appear smoother at the "
-"cost of some CPU power."
+"cost of some GPU power."
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
@@ -1056,8 +1100,7 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->description
-msgid ""
-"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgid "💡 The above Monte Carlo settings are used globally for all components"
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->tooltip
@@ -1094,6 +1137,12 @@ msgstr "Gauss-féle"
 msgid "Monte Carlo"
 msgstr ""
 
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Dual Kawase"
+msgstr ""
+
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
@@ -1127,6 +1176,17 @@ msgstr "Gauss-féle dinamikus elmosódás"
 #. 6.0->settings-schema.json->osd-blurType->options
 #, fuzzy
 msgid "Monte Carlo dynamic blur"
+msgstr "Gauss-féle dinamikus elmosódás"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur"
 msgstr "Gauss-féle dinamikus elmosódás"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -1348,6 +1408,22 @@ msgid ""
 "will have some minor persistent CPU costs when a dynamic blurred window is "
 "on top of two or more other windows. This option is recommended unless you "
 "are using video wallpaper like Hidamari"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->description
+#, fuzzy
+msgid "Blur window title bars (please read tooltip)"
+msgstr "Alkalmazásablakok (Kérjük, olvassa el az elemleírást)"
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->tooltip
+msgid ""
+"When enabled, the title bar area under most windows will be blurred "
+"excluding GTK4 windows and windows with custom title bars. This behaves like "
+"\"Default window settings\" entry above and even uses its settings, but with "
+"this option only title bar areas are blurred rather than the entire window. "
+"Note: The title bar blurring will only be visible when the title bars are "
+"configured to be semi-transparent which MUST be done using CSS. See the Blur "
+"Cinnamon website for instructions."
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/it.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/it.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.4.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-07-03 10:34-0400\n"
+"POT-Creation-Date: 2026-08-07 15:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: Dragone2 <dragone2@risposteinformatiche.it>\n"
 "Language-Team: \n"
@@ -18,27 +18,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2819 6.0/extension.js:2822 6.0/extension.js:2932
+#. 6.0/extension.js:2862 6.0/extension.js:2865 6.0/extension.js:2974
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:3080
+#. 6.0/extension.js:3140
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:3081
+#. 6.0/extension.js:3141
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3963
+#. 6.0/extension.js:4023
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Sfoca Cinnamom"
 
-#. 6.0/extension.js:3964
+#. 6.0/extension.js:4024
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
@@ -49,16 +49,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:3968
+#. 6.0/extension.js:4028
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Sfoca Cinnamom"
 
-#. 6.0/extension.js:4058
+#. 6.0/extension.js:4118
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:4059
+#. 6.0/extension.js:4119
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -107,7 +107,7 @@ msgstr "Componenti di Cinnamon dove verranno applicati gli effetti"
 
 #. 6.0->settings-schema.json->monte-carlo-settings->title
 #, fuzzy
-msgid "Monte Carlo specific settings"
+msgid "Additional Monte Carlo specific settings"
 msgstr "Impostazioni specifiche pannello"
 
 #. 6.0->settings-schema.json->component-selector-section->title
@@ -127,7 +127,7 @@ msgstr "Sfoca Cinnamom"
 #. 6.0->settings-schema.json->appswitcher-warning->description
 #, fuzzy
 msgid ""
-"Note: The Alt-Tab effects are currently disabled under the \"General setup\" "
+"💡 The Alt-Tab effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Attenzione: gli effetti del pannello sono attualmente disabilitati nella "
@@ -136,7 +136,7 @@ msgstr ""
 #. 6.0->settings-schema.json->desklets-warning->description
 #, fuzzy
 msgid ""
-"Note: The Desklet effects are currently disabled under the \"General setup\" "
+"💡 The Desklet effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Attenzione: gli effetti del pannello sono attualmente disabilitati nella "
@@ -145,7 +145,7 @@ msgstr ""
 #. 6.0->settings-schema.json->desktop-warning->description
 #, fuzzy
 msgid ""
-"Note: The Desktop effects are currently disabled under the \"General setup\" "
+"💡 The Desktop effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Attenzione: gli effetti di sfondo del desktop sono attualmente disabilitati "
@@ -154,8 +154,7 @@ msgstr ""
 #. 6.0->settings-schema.json->expo-warning->description
 #, fuzzy
 msgid ""
-"Note: The Expo effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Expo effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Attenzione: gli effetti Expo sono attualmente disabilitati nella scheda "
 "Generale."
@@ -163,8 +162,7 @@ msgstr ""
 #. 6.0->settings-schema.json->popup-warning->description
 #, fuzzy
 msgid ""
-"Note: The Menu effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Menu effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Attenzione: gli effetti del menu popup sono attualmente disabilitati nella "
 "scheda Generale."
@@ -172,7 +170,7 @@ msgstr ""
 #. 6.0->settings-schema.json->notification-warning->description
 #, fuzzy
 msgid ""
-"Note: The Notification effects are currently disabled under the \"General "
+"💡 The Notification effects are currently disabled under the \"General "
 "setup\" tab."
 msgstr ""
 "Attenzione: gli effetti Expo sono attualmente disabilitati nella scheda "
@@ -181,8 +179,8 @@ msgstr ""
 #. 6.0->settings-schema.json->osd-warning->description
 #, fuzzy
 msgid ""
-"Note: The On-Screen-Display effects are currently disabled under the "
-"\"General setup\" tab."
+"💡 The On-Screen-Display effects are currently disabled under the \"General "
+"setup\" tab."
 msgstr ""
 "Attenzione: gli effetti del pannello sono attualmente disabilitati nella "
 "scheda Generale."
@@ -190,8 +188,8 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-warning->description
 #, fuzzy
 msgid ""
-"Note: The Overview effects are currently disabled under the \"General "
-"setup\" tab."
+"💡 The Overview effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr ""
 "Attenzione: gli effetti Panoramica sono attualmente disabilitati nella "
 "scheda Generale."
@@ -199,8 +197,7 @@ msgstr ""
 #. 6.0->settings-schema.json->panel-warning->description
 #, fuzzy
 msgid ""
-"Note: The Panel effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Panel effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Attenzione: gli effetti del pannello sono attualmente disabilitati nella "
 "scheda Generale."
@@ -208,7 +205,7 @@ msgstr ""
 #. 6.0->settings-schema.json->tooltips-warning->description
 #, fuzzy
 msgid ""
-"Note: The Tooltip effects are currently disabled under the \"General setup\" "
+"💡 The Tooltip effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Attenzione: gli effetti del pannello sono attualmente disabilitati nella "
@@ -217,16 +214,13 @@ msgstr ""
 #. 6.0->settings-schema.json->windows-warning->description
 #, fuzzy
 msgid ""
-"Note: The Window effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Window effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Attenzione: gli effetti Expo sono attualmente disabilitati nella scheda "
 "Generale."
 
 #. 6.0->settings-schema.json->desklets-label->description
-msgid ""
-"<b>Note:</b> You must configure your Desklets to be transparent! (see "
-"tooltip)"
+msgid "💡 You must configure your Desklets to be transparent! (see tooltip)"
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-label->tooltip
@@ -239,9 +233,7 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-label->description
-msgid ""
-"<b>Note:</b> Read tooltip for information about the \"Default window "
-"settings\""
+msgid "💡 Read tooltip for information about the \"Default window settings\""
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-label->tooltip
@@ -313,10 +305,13 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners, Gaussian and Monte Carlo effects\n"
-"are based on code by aunetx (Blur-my-shell)\n"
-"<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
-"href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
+"The rounded corners, Gaussian and Monte Carlo effects are\n"
+"based on code by aunetx (Blur-my-shell <a href=\"https://github.com/aunetx/"
+"blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</"
+"a>)\n"
+"\n"
+"The Dual Kawase effect was written by <a href=\"https://github.com/Lucas-X-"
+"A\">Lucas-X-A</a>\n"
 "\n"
 "The Overview effect is partially based on the BlurOverview extension by "
 "nailfarmer"
@@ -912,6 +907,22 @@ msgstr "Intensità della sfocatura gaussiana"
 msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr ""
 
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase static blur"
+msgstr "Intensità della sfocatura gaussiana"
+
+#. 6.0->settings-schema.json->blurType->options
+msgid "Dual Kawase dynamic blur (if applicable)"
+msgstr ""
+
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
@@ -932,6 +943,26 @@ msgid "What type of blur algorithm should be used to blur the background"
 msgstr ""
 "Quale tipo di algoritmo di sfocatura deve essere utilizzato per sfocare lo "
 "sfondo"
+
+#. 6.0->settings-schema.json->show-blur-info->description
+msgid "💡 Blur Algorithm Guide (see tooltip)"
+msgstr ""
+
+#. 6.0->settings-schema.json->show-blur-info->tooltip
+msgid ""
+"<b>Blur Algorithm Guide:</b>\n"
+" <b>• Gaussian:</b> Good quality smooth blur, can be GPU intensive.\n"
+" <b>• Dual Kawase:</b> High quality smooth blur, optimized for low-end "
+"GPUs.\n"
+" <b>• Monte Carlo:</b> Grainy, frosted-glass style noisy blur.\n"
+" <b>• Simple:</b> Basic subtle blur for ancient computers.\n"
+"\n"
+"<b>Static vs Dynamic:</b>\n"
+" <b>• Dynamic:</b> Blurs background elements behind the blurred element in "
+"real-time.\n"
+" <b>• Static:</b> Only blurs the wallpaper, like x-ray vision to the desktop "
+"wallpaper."
+msgstr ""
 
 #. 6.0->settings-schema.json->radius->description
 #. 6.0->settings-schema.json->overview-radius->description
@@ -1004,7 +1035,7 @@ msgstr "Saturazione"
 #. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
 msgid ""
 "Increasing number of iterations will make the blur appear smoother at the "
-"cost of some CPU power."
+"cost of some GPU power."
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
@@ -1028,8 +1059,7 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->description
-msgid ""
-"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgid "💡 The above Monte Carlo settings are used globally for all components"
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->tooltip
@@ -1064,6 +1094,12 @@ msgstr "Gaussiana"
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
 msgid "Monte Carlo"
+msgstr ""
+
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Dual Kawase"
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->options
@@ -1101,6 +1137,17 @@ msgstr "Intensità della sfocatura gaussiana"
 #. 6.0->settings-schema.json->osd-blurType->options
 #, fuzzy
 msgid "Monte Carlo dynamic blur"
+msgstr "Intensità della sfocatura gaussiana"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur"
 msgstr "Intensità della sfocatura gaussiana"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -1313,6 +1360,22 @@ msgid ""
 "will have some minor persistent CPU costs when a dynamic blurred window is "
 "on top of two or more other windows. This option is recommended unless you "
 "are using video wallpaper like Hidamari"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->description
+#, fuzzy
+msgid "Blur window title bars (please read tooltip)"
+msgstr "Menù a comparsa  (Leggi il tooltip)"
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->tooltip
+msgid ""
+"When enabled, the title bar area under most windows will be blurred "
+"excluding GTK4 windows and windows with custom title bars. This behaves like "
+"\"Default window settings\" entry above and even uses its settings, but with "
+"this option only title bar areas are blurred rather than the entire window. "
+"Note: The title bar blurring will only be visible when the title bars are "
+"configured to be semi-transparent which MUST be done using CSS. See the Blur "
+"Cinnamon website for instructions."
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/nl.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/nl.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.3.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-07-03 10:34-0400\n"
+"POT-Creation-Date: 2026-08-07 15:04-0400\n"
 "PO-Revision-Date: 2025-06-13 17:14+0200\n"
 "Last-Translator: qadzek\n"
 "Language-Team: \n"
@@ -16,27 +16,27 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.0/extension.js:2819 6.0/extension.js:2822 6.0/extension.js:2932
+#. 6.0/extension.js:2862 6.0/extension.js:2865 6.0/extension.js:2974
 msgid "Default window settings"
 msgstr ""
 
-#. 6.0/extension.js:3080
+#. 6.0/extension.js:3140
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:3081
+#. 6.0/extension.js:3141
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3963
+#. 6.0/extension.js:4023
 #, fuzzy
 msgid "Welcome to Blur Cinnamon"
 msgstr "Vervaag Cinnamon"
 
-#. 6.0/extension.js:3964
+#. 6.0/extension.js:4024
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
@@ -47,16 +47,16 @@ msgid ""
 "dimming."
 msgstr ""
 
-#. 6.0/extension.js:3968
+#. 6.0/extension.js:4028
 #, fuzzy
 msgid "Open Blur Cinnamon Settings"
 msgstr "Vervaag Cinnamon"
 
-#. 6.0/extension.js:4058
+#. 6.0/extension.js:4118
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr ""
 
-#. 6.0/extension.js:4059
+#. 6.0/extension.js:4119
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -105,7 +105,7 @@ msgstr "Cinnamon-componenten waarop effecten worden toegepast"
 
 #. 6.0->settings-schema.json->monte-carlo-settings->title
 #, fuzzy
-msgid "Monte Carlo specific settings"
+msgid "Additional Monte Carlo specific settings"
 msgstr "Paneelspecifieke instellingen"
 
 #. 6.0->settings-schema.json->component-selector-section->title
@@ -125,7 +125,7 @@ msgstr "Vervaag Cinnamon"
 #. 6.0->settings-schema.json->appswitcher-warning->description
 #, fuzzy
 msgid ""
-"Note: The Alt-Tab effects are currently disabled under the \"General setup\" "
+"💡 The Alt-Tab effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Waarschuwing: effecten voor Panelen zijn momenteel uitgeschakeld op het "
@@ -134,7 +134,7 @@ msgstr ""
 #. 6.0->settings-schema.json->desklets-warning->description
 #, fuzzy
 msgid ""
-"Note: The Desklet effects are currently disabled under the \"General setup\" "
+"💡 The Desklet effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Waarschuwing: effecten voor Panelen zijn momenteel uitgeschakeld op het "
@@ -143,7 +143,7 @@ msgstr ""
 #. 6.0->settings-schema.json->desktop-warning->description
 #, fuzzy
 msgid ""
-"Note: The Desktop effects are currently disabled under the \"General setup\" "
+"💡 The Desktop effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Waarschuwing: Effecten voor de bureaubladachtergrond zijn momenteel "
@@ -152,8 +152,7 @@ msgstr ""
 #. 6.0->settings-schema.json->expo-warning->description
 #, fuzzy
 msgid ""
-"Note: The Expo effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Expo effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Waarschuwing: effecten voor Expo zijn momenteel uitgeschakeld op het tabblad "
 "Algemeen."
@@ -161,8 +160,7 @@ msgstr ""
 #. 6.0->settings-schema.json->popup-warning->description
 #, fuzzy
 msgid ""
-"Note: The Menu effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Menu effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Waarschuwing: effecten voor Pop-upmenu's zijn momenteel uitgeschakeld op het "
 "tabblad Algemeen."
@@ -170,7 +168,7 @@ msgstr ""
 #. 6.0->settings-schema.json->notification-warning->description
 #, fuzzy
 msgid ""
-"Note: The Notification effects are currently disabled under the \"General "
+"💡 The Notification effects are currently disabled under the \"General "
 "setup\" tab."
 msgstr ""
 "Waarschuwing: effecten voor Expo zijn momenteel uitgeschakeld op het tabblad "
@@ -179,8 +177,8 @@ msgstr ""
 #. 6.0->settings-schema.json->osd-warning->description
 #, fuzzy
 msgid ""
-"Note: The On-Screen-Display effects are currently disabled under the "
-"\"General setup\" tab."
+"💡 The On-Screen-Display effects are currently disabled under the \"General "
+"setup\" tab."
 msgstr ""
 "Waarschuwing: effecten voor Panelen zijn momenteel uitgeschakeld op het "
 "tabblad Algemeen."
@@ -188,8 +186,8 @@ msgstr ""
 #. 6.0->settings-schema.json->overview-warning->description
 #, fuzzy
 msgid ""
-"Note: The Overview effects are currently disabled under the \"General "
-"setup\" tab."
+"💡 The Overview effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr ""
 "Waarschuwing: effecten voor Overzicht zijn momenteel uitgeschakeld op het "
 "tabblad Algemeen."
@@ -197,8 +195,7 @@ msgstr ""
 #. 6.0->settings-schema.json->panel-warning->description
 #, fuzzy
 msgid ""
-"Note: The Panel effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Panel effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Waarschuwing: effecten voor Panelen zijn momenteel uitgeschakeld op het "
 "tabblad Algemeen."
@@ -206,7 +203,7 @@ msgstr ""
 #. 6.0->settings-schema.json->tooltips-warning->description
 #, fuzzy
 msgid ""
-"Note: The Tooltip effects are currently disabled under the \"General setup\" "
+"💡 The Tooltip effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Waarschuwing: effecten voor Panelen zijn momenteel uitgeschakeld op het "
@@ -215,16 +212,13 @@ msgstr ""
 #. 6.0->settings-schema.json->windows-warning->description
 #, fuzzy
 msgid ""
-"Note: The Window effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Window effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Waarschuwing: effecten voor Expo zijn momenteel uitgeschakeld op het tabblad "
 "Algemeen."
 
 #. 6.0->settings-schema.json->desklets-label->description
-msgid ""
-"<b>Note:</b> You must configure your Desklets to be transparent! (see "
-"tooltip)"
+msgid "💡 You must configure your Desklets to be transparent! (see tooltip)"
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-label->tooltip
@@ -237,9 +231,7 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-label->description
-msgid ""
-"<b>Note:</b> Read tooltip for information about the \"Default window "
-"settings\""
+msgid "💡 Read tooltip for information about the \"Default window settings\""
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-label->tooltip
@@ -311,10 +303,13 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners, Gaussian and Monte Carlo effects\n"
-"are based on code by aunetx (Blur-my-shell)\n"
-"<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
-"href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
+"The rounded corners, Gaussian and Monte Carlo effects are\n"
+"based on code by aunetx (Blur-my-shell <a href=\"https://github.com/aunetx/"
+"blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</"
+"a>)\n"
+"\n"
+"The Dual Kawase effect was written by <a href=\"https://github.com/Lucas-X-"
+"A\">Lucas-X-A</a>\n"
 "\n"
 "The Overview effect is partially based on the BlurOverview extension by "
 "nailfarmer"
@@ -911,6 +906,22 @@ msgstr "Gaussiaanse vervagingsintensiteit"
 msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr ""
 
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase static blur"
+msgstr "Gaussiaanse vervagingsintensiteit"
+
+#. 6.0->settings-schema.json->blurType->options
+msgid "Dual Kawase dynamic blur (if applicable)"
+msgstr ""
+
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
@@ -929,6 +940,26 @@ msgstr "Type van het vervagingseffect"
 #. 6.0->settings-schema.json->osd-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Welk type algoritme wordt gebruikt om de achtergrond te vervagen."
+
+#. 6.0->settings-schema.json->show-blur-info->description
+msgid "💡 Blur Algorithm Guide (see tooltip)"
+msgstr ""
+
+#. 6.0->settings-schema.json->show-blur-info->tooltip
+msgid ""
+"<b>Blur Algorithm Guide:</b>\n"
+" <b>• Gaussian:</b> Good quality smooth blur, can be GPU intensive.\n"
+" <b>• Dual Kawase:</b> High quality smooth blur, optimized for low-end "
+"GPUs.\n"
+" <b>• Monte Carlo:</b> Grainy, frosted-glass style noisy blur.\n"
+" <b>• Simple:</b> Basic subtle blur for ancient computers.\n"
+"\n"
+"<b>Static vs Dynamic:</b>\n"
+" <b>• Dynamic:</b> Blurs background elements behind the blurred element in "
+"real-time.\n"
+" <b>• Static:</b> Only blurs the wallpaper, like x-ray vision to the desktop "
+"wallpaper."
+msgstr ""
 
 #. 6.0->settings-schema.json->radius->description
 #. 6.0->settings-schema.json->overview-radius->description
@@ -1001,7 +1032,7 @@ msgstr "Verzadiging"
 #. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
 msgid ""
 "Increasing number of iterations will make the blur appear smoother at the "
-"cost of some CPU power."
+"cost of some GPU power."
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
@@ -1025,8 +1056,7 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->description
-msgid ""
-"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgid "💡 The above Monte Carlo settings are used globally for all components"
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->tooltip
@@ -1061,6 +1091,12 @@ msgstr "Gaussiaans"
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
 msgid "Monte Carlo"
+msgstr ""
+
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Dual Kawase"
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->options
@@ -1098,6 +1134,17 @@ msgstr "Gaussiaanse vervagingsintensiteit"
 #. 6.0->settings-schema.json->osd-blurType->options
 #, fuzzy
 msgid "Monte Carlo dynamic blur"
+msgstr "Gaussiaanse vervagingsintensiteit"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur"
 msgstr "Gaussiaanse vervagingsintensiteit"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -1307,6 +1354,22 @@ msgid ""
 "will have some minor persistent CPU costs when a dynamic blurred window is "
 "on top of two or more other windows. This option is recommended unless you "
 "are using video wallpaper like Hidamari"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->description
+#, fuzzy
+msgid "Blur window title bars (please read tooltip)"
+msgstr "Pop-upmenu’s (lees de tooltip)"
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->tooltip
+msgid ""
+"When enabled, the title bar area under most windows will be blurred "
+"excluding GTK4 windows and windows with custom title bars. This behaves like "
+"\"Default window settings\" entry above and even uses its settings, but with "
+"this option only title bar areas are blurred rather than the entire window. "
+"Note: The title bar blurring will only be visible when the title bars are "
+"configured to be semi-transparent which MUST be done using CSS. See the Blur "
+"Cinnamon website for instructions."
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/pt_PT.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/pt_PT.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 2.5.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-07-03 10:34-0400\n"
+"POT-Creation-Date: 2026-08-07 15:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: André Silva\n"
 "Language-Team: \n"
@@ -18,15 +18,15 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2819 6.0/extension.js:2822 6.0/extension.js:2932
+#. 6.0/extension.js:2862 6.0/extension.js:2865 6.0/extension.js:2974
 msgid "Default window settings"
 msgstr "Opções padrão para janelas"
 
-#. 6.0/extension.js:3080
+#. 6.0/extension.js:3140
 msgid "Error"
 msgstr "Erro"
 
-#. 6.0/extension.js:3081
+#. 6.0/extension.js:3141
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
@@ -36,11 +36,11 @@ msgstr ""
 "recente e, por esse motivo, os efeitos do Blur Cinnamon não podem ser "
 "aplicados a essa janela"
 
-#. 6.0/extension.js:3963
+#. 6.0/extension.js:4023
 msgid "Welcome to Blur Cinnamon"
 msgstr "Bem-vindo ao Blur Cinnamon"
 
-#. 6.0/extension.js:3964
+#. 6.0/extension.js:4024
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
@@ -58,15 +58,15 @@ msgstr ""
 "omissão. Também pode fazer alterações às propriedades dos efeitos como a "
 "intensidade de desfoque, saturação da cor ou escurecimento."
 
-#. 6.0/extension.js:3968
+#. 6.0/extension.js:4028
 msgid "Open Blur Cinnamon Settings"
 msgstr "Abrir definições do Blur Cinnamon"
 
-#. 6.0/extension.js:4058
+#. 6.0/extension.js:4118
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Teste dos Efeitos de Notificação do Blur Cinnamon"
 
-#. 6.0/extension.js:4059
+#. 6.0/extension.js:4119
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -114,7 +114,8 @@ msgid "Cinnamon desktop components where effects will be applied"
 msgstr "Componentes do Cinammon onde serão aplicados os efeitos"
 
 #. 6.0->settings-schema.json->monte-carlo-settings->title
-msgid "Monte Carlo specific settings"
+#, fuzzy
+msgid "Additional Monte Carlo specific settings"
 msgstr "Definições específicas Monte Carlo"
 
 #. 6.0->settings-schema.json->component-selector-section->title
@@ -130,96 +131,102 @@ msgid "About Blur Cinnamon"
 msgstr "Sobre o Blur Cinnamon"
 
 #. 6.0->settings-schema.json->appswitcher-warning->description
+#, fuzzy
 msgid ""
-"Note: The Alt-Tab effects are currently disabled under the \"General setup\" "
+"💡 The Alt-Tab effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Nota: Os efeitos do alternador Alt-Tab estão atualmente desativados no "
 "separador \"Geral\"."
 
 #. 6.0->settings-schema.json->desklets-warning->description
+#, fuzzy
 msgid ""
-"Note: The Desklet effects are currently disabled under the \"General setup\" "
+"💡 The Desklet effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Nota: Os efeitos das Mini-Aplicações estão atualmente desativados no "
 "separador \"Geral\"."
 
 #. 6.0->settings-schema.json->desktop-warning->description
+#, fuzzy
 msgid ""
-"Note: The Desktop effects are currently disabled under the \"General setup\" "
+"💡 The Desktop effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Nota: Os efeitos do Fundo do ambiente de trabalho estão atualmente "
 "desativados no separador \"Geral\"."
 
 #. 6.0->settings-schema.json->expo-warning->description
+#, fuzzy
 msgid ""
-"Note: The Expo effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Expo effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Nota: Os efeitos do Expo estão atualmente desativados no separador \"Geral\"."
 
 #. 6.0->settings-schema.json->popup-warning->description
+#, fuzzy
 msgid ""
-"Note: The Menu effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Menu effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Nota: Os efeitos dos Menus estão atualmente desativados no separador "
 "\"Geral\"."
 
 #. 6.0->settings-schema.json->notification-warning->description
+#, fuzzy
 msgid ""
-"Note: The Notification effects are currently disabled under the \"General "
+"💡 The Notification effects are currently disabled under the \"General "
 "setup\" tab."
 msgstr ""
 "Nota: Os efeitos das Notificações estão atualmente desativados no separador "
 "\"Geral\"."
 
 #. 6.0->settings-schema.json->osd-warning->description
+#, fuzzy
 msgid ""
-"Note: The On-Screen-Display effects are currently disabled under the "
-"\"General setup\" tab."
+"💡 The On-Screen-Display effects are currently disabled under the \"General "
+"setup\" tab."
 msgstr ""
 "Nota: Os efeitos das Janelas de ecrã (OSD) estão atualmente desativados no "
 "separador \"Geral\"."
 
 #. 6.0->settings-schema.json->overview-warning->description
+#, fuzzy
 msgid ""
-"Note: The Overview effects are currently disabled under the \"General "
-"setup\" tab."
+"💡 The Overview effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr ""
 "Nota: Os efeitos da Vista Global estão atualmente desativados no separador "
 "\"Geral\"."
 
 #. 6.0->settings-schema.json->panel-warning->description
+#, fuzzy
 msgid ""
-"Note: The Panel effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Panel effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Nota: Os efeitos dos Painéis estão atualmente desativados no separador "
 "\"Geral\"."
 
 #. 6.0->settings-schema.json->tooltips-warning->description
+#, fuzzy
 msgid ""
-"Note: The Tooltip effects are currently disabled under the \"General setup\" "
+"💡 The Tooltip effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Nota: Os efeitos da Dicas de painel estão atualmente desativados no "
 "separador \"Geral\"."
 
 #. 6.0->settings-schema.json->windows-warning->description
+#, fuzzy
 msgid ""
-"Note: The Window effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Window effects are currently disabled under the \"General setup\" tab."
 msgstr ""
 "Nota: Os efeitos das Janelas de aplicações estão atualmente desativados no "
 "separador \"Geral\"."
 
 #. 6.0->settings-schema.json->desklets-label->description
-msgid ""
-"<b>Note:</b> You must configure your Desklets to be transparent! (see "
-"tooltip)"
+#, fuzzy
+msgid "💡 You must configure your Desklets to be transparent! (see tooltip)"
 msgstr ""
 "<b>Nota:</b> É necessário configurar as Mini-Aplicações para serem "
 "transparentes! (leia a dica)"
@@ -240,9 +247,8 @@ msgstr ""
 "a opção \"Configurar...\" para abrir as respetivas definições."
 
 #. 6.0->settings-schema.json->windows-label->description
-msgid ""
-"<b>Note:</b> Read tooltip for information about the \"Default window "
-"settings\""
+#, fuzzy
+msgid "💡 Read tooltip for information about the \"Default window settings\""
 msgstr ""
 "<b>Nota:</b> Leia a dica para obter informação sobre as \"Opções padrão para "
 "janelas\""
@@ -310,6 +316,7 @@ msgid "Show settings for component:"
 msgstr "Mostrar definições para o componente:"
 
 #. 6.0->settings-schema.json->about-text->description
+#, fuzzy
 msgid ""
 "\n"
 "<b>Bringing your style into focus</b>\n"
@@ -318,13 +325,16 @@ msgid ""
 "Developed by: Kevin Langman\n"
 "<a href=\"https://github.com/klangman/BlurCinnamon\">Github</a> / <a "
 "href=\"https://github.com/klangman/BlurCinnamon/issues/new\">Report an "
-"issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/"
-"view/104\">Website</a>\n"
+"issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
+"104\">Website</a>\n"
 "\n"
-"The rounded corners, Gaussian and Monte Carlo effects\n"
-"are based on code by aunetx (Blur-my-shell)\n"
-"<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
-"href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
+"The rounded corners, Gaussian and Monte Carlo effects are\n"
+"based on code by aunetx (Blur-my-shell <a href=\"https://github.com/aunetx/"
+"blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</"
+"a>)\n"
+"\n"
+"The Dual Kawase effect was written by <a href=\"https://github.com/Lucas-X-"
+"A\">Lucas-X-A</a>\n"
 "\n"
 "The Overview effect is partially based on the BlurOverview extension by "
 "nailfarmer"
@@ -926,6 +936,23 @@ msgstr "Desfoque Monte Carlo estático"
 msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr "Desfoque Monte Carlo dinâmico (quando disponível)"
 
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase static blur"
+msgstr "Desfoque estático simples"
+
+#. 6.0->settings-schema.json->blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur (if applicable)"
+msgstr "Desfoque Guassiano dinâmico (se disponível)"
+
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
@@ -944,6 +971,26 @@ msgstr "Tipo de efeito de desfoque"
 #. 6.0->settings-schema.json->osd-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Qual o tipo de algoritmo a utilizar para desfocar o fundo"
+
+#. 6.0->settings-schema.json->show-blur-info->description
+msgid "💡 Blur Algorithm Guide (see tooltip)"
+msgstr ""
+
+#. 6.0->settings-schema.json->show-blur-info->tooltip
+msgid ""
+"<b>Blur Algorithm Guide:</b>\n"
+" <b>• Gaussian:</b> Good quality smooth blur, can be GPU intensive.\n"
+" <b>• Dual Kawase:</b> High quality smooth blur, optimized for low-end "
+"GPUs.\n"
+" <b>• Monte Carlo:</b> Grainy, frosted-glass style noisy blur.\n"
+" <b>• Simple:</b> Basic subtle blur for ancient computers.\n"
+"\n"
+"<b>Static vs Dynamic:</b>\n"
+" <b>• Dynamic:</b> Blurs background elements behind the blurred element in "
+"real-time.\n"
+" <b>• Static:</b> Only blurs the wallpaper, like x-ray vision to the desktop "
+"wallpaper."
+msgstr ""
 
 #. 6.0->settings-schema.json->radius->description
 #. 6.0->settings-schema.json->overview-radius->description
@@ -1013,9 +1060,10 @@ msgid "Iterations"
 msgstr "Iterações"
 
 #. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
+#, fuzzy
 msgid ""
 "Increasing number of iterations will make the blur appear smoother at the "
-"cost of some CPU power."
+"cost of some GPU power."
 msgstr ""
 "Aumentar o número de iterações irá tornar o efeito de desfoque mais suave à "
 "custa de maior utilização da CPU."
@@ -1044,8 +1092,8 @@ msgstr ""
 "Define se os pixeis que estão mais perto irão ou não ter maior ponderação."
 
 #. 6.0->settings-schema.json->monte-carlo-label->description
-msgid ""
-"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+#, fuzzy
+msgid "💡 The above Monte Carlo settings are used globally for all components"
 msgstr ""
 "<b>Nota:</b> Estas definições Monte Carlo são usadas de forma geral para "
 "todos os componentes"
@@ -1088,6 +1136,12 @@ msgstr "Guassiano"
 msgid "Monte Carlo"
 msgstr "Monte Carlo"
 
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Dual Kawase"
+msgstr ""
+
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
@@ -1121,6 +1175,17 @@ msgstr "Desfoque Guassiano dinâmico"
 #. 6.0->settings-schema.json->osd-blurType->options
 msgid "Monte Carlo dynamic blur"
 msgstr "Desfoque Monte Carlo dinâmico"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur"
+msgstr "Desfoque Guassiano dinâmico"
 
 #. 6.0->settings-schema.json->panels-blurType->description
 #. 6.0->settings-schema.json->popup-blurType->description
@@ -1157,9 +1222,9 @@ msgstr ""
 
 #. 6.0->settings-schema.json->popup-accent-opacity->tooltip
 msgid ""
-"Defines the additional dimming applied to the popup menu accent elements (i."
-"e. the main menu favorites box and entry boxes) which allow these elements "
-"to stand out from the other popup menu areas"
+"Defines the additional dimming applied to the popup menu accent elements "
+"(i.e. the main menu favorites box and entry boxes) which allow these "
+"elements to stand out from the other popup menu areas"
 msgstr ""
 "Define o efeito de escurecimento adicional aplicado às cores de destaque do "
 "menu (ex: caixa de favoritos do menu principal e caixas de entrada) "
@@ -1363,6 +1428,22 @@ msgstr ""
 "CPU quando uma janela com efeitos de desfoque dinâmico está sobre duas ou "
 "mais janelas. Esta opção é recomendada a não ser que esteja em uso um fundo "
 "de ambiente de trabalho em forma de vídeo como o Hidamari"
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->description
+#, fuzzy
+msgid "Blur window title bars (please read tooltip)"
+msgstr "Janelas de aplicações (Por favor leia a dica)"
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->tooltip
+msgid ""
+"When enabled, the title bar area under most windows will be blurred "
+"excluding GTK4 windows and windows with custom title bars. This behaves like "
+"\"Default window settings\" entry above and even uses its settings, but with "
+"this option only title bar areas are blurred rather than the entire window. "
+"Note: The title bar blurring will only be visible when the title bars are "
+"configured to be semi-transparent which MUST be done using CSS. See the Blur "
+"Cinnamon website for instructions."
+msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description
 msgid "Automatically enable effects for newly added Desklets"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ru.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/ru.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 2.5.0\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-07-03 10:34-0400\n"
+"POT-Creation-Date: 2026-08-07 15:04-0400\n"
 "PO-Revision-Date: 2026-06-06 21:14-0400\n"
 "Last-Translator: Grom-TS\n"
 "Language-Team: \n"
@@ -17,15 +17,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.0/extension.js:2819 6.0/extension.js:2822 6.0/extension.js:2932
+#. 6.0/extension.js:2862 6.0/extension.js:2865 6.0/extension.js:2974
 msgid "Default window settings"
 msgstr "Настройки окон по умолчанию"
 
-#. 6.0/extension.js:3080
+#. 6.0/extension.js:3140
 msgid "Error"
 msgstr "Ошибка"
 
-#. 6.0/extension.js:3081
+#. 6.0/extension.js:3141
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
@@ -34,11 +34,11 @@ msgstr ""
 "Не удалось определить приложение или WM_CLASS ранее активного окна, поэтому "
 "эффекты Blur Cinnamon не могут быть применены к этому окну"
 
-#. 6.0/extension.js:3963
+#. 6.0/extension.js:4023
 msgid "Welcome to Blur Cinnamon"
 msgstr "Добро пожаловать в Blur Cinnamon"
 
-#. 6.0/extension.js:3964
+#. 6.0/extension.js:4024
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
 "\n"
@@ -56,15 +56,15 @@ msgstr ""
 "также можете настроить параметры эффектов, такие как интенсивность размытия, "
 "насыщенность цвета и затемнение."
 
-#. 6.0/extension.js:3968
+#. 6.0/extension.js:4028
 msgid "Open Blur Cinnamon Settings"
 msgstr "Открыть настройки Blur Cinnamon"
 
-#. 6.0/extension.js:4058
+#. 6.0/extension.js:4118
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Тестирование эффектов уведомлений Blur Cinnamon"
 
-#. 6.0/extension.js:4059
+#. 6.0/extension.js:4119
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -113,7 +113,8 @@ msgstr ""
 "Компоненты рабочего стола Cinnamon, к которым будут применяться эффекты"
 
 #. 6.0->settings-schema.json->monte-carlo-settings->title
-msgid "Monte Carlo specific settings"
+#, fuzzy
+msgid "Additional Monte Carlo specific settings"
 msgstr "Настройки Monte Carlo"
 
 #. 6.0->settings-schema.json->component-selector-section->title
@@ -129,41 +130,45 @@ msgid "About Blur Cinnamon"
 msgstr "О Blur Cinnamon"
 
 #. 6.0->settings-schema.json->appswitcher-warning->description
+#, fuzzy
 msgid ""
-"Note: The Alt-Tab effects are currently disabled under the \"General setup\" "
+"💡 The Alt-Tab effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Примечание: эффекты Alt-Tab в настоящее время отключены на вкладке «Общие "
 "настройки»."
 
 #. 6.0->settings-schema.json->desklets-warning->description
+#, fuzzy
 msgid ""
-"Note: The Desklet effects are currently disabled under the \"General setup\" "
+"💡 The Desklet effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr "Примечание: эффекты десклетов отключены на вкладке «Общие настройки»."
 
 #. 6.0->settings-schema.json->desktop-warning->description
+#, fuzzy
 msgid ""
-"Note: The Desktop effects are currently disabled under the \"General setup\" "
+"💡 The Desktop effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Примечание: эффекты рабочего стола отключены на вкладке «Общие настройки»."
 
 #. 6.0->settings-schema.json->expo-warning->description
+#, fuzzy
 msgid ""
-"Note: The Expo effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Expo effects are currently disabled under the \"General setup\" tab."
 msgstr "Примечание: эффекты Expo отключены на вкладке «Общие настройки»."
 
 #. 6.0->settings-schema.json->popup-warning->description
+#, fuzzy
 msgid ""
-"Note: The Menu effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Menu effects are currently disabled under the \"General setup\" tab."
 msgstr "Примечание: эффекты меню отключены на вкладке «Общие настройки»."
 
 #. 6.0->settings-schema.json->notification-warning->description
+#, fuzzy
 msgid ""
-"Note: The Notification effects are currently disabled under the \"General "
+"💡 The Notification effects are currently disabled under the \"General "
 "setup\" tab."
 msgstr ""
 "Примечание: эффекты уведомлений отключены на вкладке «Общие настройки»."
@@ -171,40 +176,41 @@ msgstr ""
 #. 6.0->settings-schema.json->osd-warning->description
 #, fuzzy
 msgid ""
-"Note: The On-Screen-Display effects are currently disabled under the "
-"\"General setup\" tab."
+"💡 The On-Screen-Display effects are currently disabled under the \"General "
+"setup\" tab."
 msgstr "Примечание: эффекты панели отключены на вкладке «Общие настройки»."
 
 #. 6.0->settings-schema.json->overview-warning->description
+#, fuzzy
 msgid ""
-"Note: The Overview effects are currently disabled under the \"General "
-"setup\" tab."
+"💡 The Overview effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr "Примечание: эффекты обзора отключены на вкладке «Общие настройки»."
 
 #. 6.0->settings-schema.json->panel-warning->description
+#, fuzzy
 msgid ""
-"Note: The Panel effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Panel effects are currently disabled under the \"General setup\" tab."
 msgstr "Примечание: эффекты панели отключены на вкладке «Общие настройки»."
 
 #. 6.0->settings-schema.json->tooltips-warning->description
+#, fuzzy
 msgid ""
-"Note: The Tooltip effects are currently disabled under the \"General setup\" "
+"💡 The Tooltip effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr ""
 "Примечание: эффекты всплывающих подсказок отключены на вкладке «Общие "
 "настройки»."
 
 #. 6.0->settings-schema.json->windows-warning->description
+#, fuzzy
 msgid ""
-"Note: The Window effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Window effects are currently disabled under the \"General setup\" tab."
 msgstr "Примечание: эффекты окон отключены на вкладке «Общие настройки»."
 
 #. 6.0->settings-schema.json->desklets-label->description
-msgid ""
-"<b>Note:</b> You must configure your Desklets to be transparent! (see "
-"tooltip)"
+#, fuzzy
+msgid "💡 You must configure your Desklets to be transparent! (see tooltip)"
 msgstr ""
 "Примечание: необходимо настроить десклеты на прозрачность (см. подсказку)"
 
@@ -223,9 +229,8 @@ msgstr ""
 "«Настроить…», чтобы открыть окно конфигурации десклета."
 
 #. 6.0->settings-schema.json->windows-label->description
-msgid ""
-"<b>Note:</b> Read tooltip for information about the \"Default window "
-"settings\""
+#, fuzzy
+msgid "💡 Read tooltip for information about the \"Default window settings\""
 msgstr ""
 "Примечание: см. подсказку для информации о «настройках окон по умолчанию»"
 
@@ -291,6 +296,7 @@ msgid "Show settings for component:"
 msgstr "Показывать настройки для компонента:"
 
 #. 6.0->settings-schema.json->about-text->description
+#, fuzzy
 msgid ""
 "\n"
 "<b>Bringing your style into focus</b>\n"
@@ -302,10 +308,13 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners, Gaussian and Monte Carlo effects\n"
-"are based on code by aunetx (Blur-my-shell)\n"
-"<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
-"href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
+"The rounded corners, Gaussian and Monte Carlo effects are\n"
+"based on code by aunetx (Blur-my-shell <a href=\"https://github.com/aunetx/"
+"blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</"
+"a>)\n"
+"\n"
+"The Dual Kawase effect was written by <a href=\"https://github.com/Lucas-X-"
+"A\">Lucas-X-A</a>\n"
 "\n"
 "The Overview effect is partially based on the BlurOverview extension by "
 "nailfarmer"
@@ -896,6 +905,23 @@ msgstr "Статическое размытие Монте-Карло"
 msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr "Динамическое размытие Монте-Карло (если применимо)"
 
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase static blur"
+msgstr "Простое статическое размытие"
+
+#. 6.0->settings-schema.json->blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur (if applicable)"
+msgstr "Гауссово динамическое размытие (если применимо)"
+
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
@@ -914,6 +940,26 @@ msgstr "Тип эффекта размытия"
 #. 6.0->settings-schema.json->osd-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Какой алгоритм размытия следует использовать для размытия фона"
+
+#. 6.0->settings-schema.json->show-blur-info->description
+msgid "💡 Blur Algorithm Guide (see tooltip)"
+msgstr ""
+
+#. 6.0->settings-schema.json->show-blur-info->tooltip
+msgid ""
+"<b>Blur Algorithm Guide:</b>\n"
+" <b>• Gaussian:</b> Good quality smooth blur, can be GPU intensive.\n"
+" <b>• Dual Kawase:</b> High quality smooth blur, optimized for low-end "
+"GPUs.\n"
+" <b>• Monte Carlo:</b> Grainy, frosted-glass style noisy blur.\n"
+" <b>• Simple:</b> Basic subtle blur for ancient computers.\n"
+"\n"
+"<b>Static vs Dynamic:</b>\n"
+" <b>• Dynamic:</b> Blurs background elements behind the blurred element in "
+"real-time.\n"
+" <b>• Static:</b> Only blurs the wallpaper, like x-ray vision to the desktop "
+"wallpaper."
+msgstr ""
 
 #. 6.0->settings-schema.json->radius->description
 #. 6.0->settings-schema.json->overview-radius->description
@@ -983,9 +1029,10 @@ msgid "Iterations"
 msgstr "Итерации"
 
 #. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
+#, fuzzy
 msgid ""
 "Increasing number of iterations will make the blur appear smoother at the "
-"cost of some CPU power."
+"cost of some GPU power."
 msgstr ""
 "Увеличение числа итераций делает размытие более плавным, но увеличивает "
 "нагрузку на процессор."
@@ -1015,8 +1062,8 @@ msgstr ""
 "больший вес."
 
 #. 6.0->settings-schema.json->monte-carlo-label->description
-msgid ""
-"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+#, fuzzy
+msgid "💡 The above Monte Carlo settings are used globally for all components"
 msgstr ""
 "<b>Примечание:</b> Эти настройки Монте-Карло используются глобально для всех "
 "компонентов"
@@ -1058,6 +1105,12 @@ msgstr "Гауссово"
 msgid "Monte Carlo"
 msgstr "Монте-Карло"
 
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Dual Kawase"
+msgstr ""
+
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
@@ -1091,6 +1144,17 @@ msgstr "Гауссово динамическое размытие"
 #. 6.0->settings-schema.json->osd-blurType->options
 msgid "Monte Carlo dynamic blur"
 msgstr "Динамическое размытие Монте-Карло"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur"
+msgstr "Гауссово динамическое размытие"
 
 #. 6.0->settings-schema.json->panels-blurType->description
 #. 6.0->settings-schema.json->popup-blurType->description
@@ -1326,6 +1390,22 @@ msgstr ""
 "постоянному использованию процессора, если окно с динамическим размытием "
 "находится поверх двух или более других окон. Рекомендуется включить эту "
 "опцию, если вы не используете видеообои, например Hidamari"
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->description
+#, fuzzy
+msgid "Blur window title bars (please read tooltip)"
+msgstr "Окна приложений (см. подсказку)"
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->tooltip
+msgid ""
+"When enabled, the title bar area under most windows will be blurred "
+"excluding GTK4 windows and windows with custom title bars. This behaves like "
+"\"Default window settings\" entry above and even uses its settings, but with "
+"this option only title bar areas are blurred rather than the entire window. "
+"Note: The title bar blurring will only be visible when the title bars are "
+"configured to be semi-transparent which MUST be done using CSS. See the Blur "
+"Cinnamon website for instructions."
+msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description
 msgid "Automatically enable effects for newly added Desklets"

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/vi.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/vi.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 1.5.2\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-07-03 10:34-0400\n"
+"POT-Creation-Date: 2026-08-07 15:04-0400\n"
 "PO-Revision-Date: \n"
 "Last-Translator: loccun <huynhloc.contact@gmail.com>\n"
 "Language-Team: \n"
@@ -18,27 +18,27 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "X-Generator: Poedit 3.4.2\n"
 
-#. 6.0/extension.js:2819 6.0/extension.js:2822 6.0/extension.js:2932
+#. 6.0/extension.js:2862 6.0/extension.js:2865 6.0/extension.js:2974
 #, fuzzy
 msgid "Default window settings"
 msgstr "Mở cài đặt Alt-Tab Cinnamon"
 
-#. 6.0/extension.js:3080
+#. 6.0/extension.js:3140
 msgid "Error"
 msgstr ""
 
-#. 6.0/extension.js:3081
+#. 6.0/extension.js:3141
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
 "window"
 msgstr ""
 
-#. 6.0/extension.js:3963
+#. 6.0/extension.js:4023
 msgid "Welcome to Blur Cinnamon"
 msgstr "Chào mừng đến với Blur Cinnamon"
 
-#. 6.0/extension.js:3964
+#. 6.0/extension.js:4024
 #, fuzzy
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
@@ -57,15 +57,15 @@ msgstr ""
 "phần được bật theo mặc định. Bạn cũng có thể thay đổi các thuộc tính hiệu "
 "ứng như cường độ làm mờ, độ bão hòa màu và làm tối."
 
-#. 6.0/extension.js:3968
+#. 6.0/extension.js:4028
 msgid "Open Blur Cinnamon Settings"
 msgstr "Mở Cài đặt Blur Cinnamon"
 
-#. 6.0/extension.js:4058
+#. 6.0/extension.js:4118
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "Đang thử nghiệm Hiệu ứng Thông báo Blur Cinnamon"
 
-#. 6.0/extension.js:4059
+#. 6.0/extension.js:4119
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -117,7 +117,7 @@ msgstr "Các thành phần Cinnamon sẽ áp dụng hiệu ứng"
 
 #. 6.0->settings-schema.json->monte-carlo-settings->title
 #, fuzzy
-msgid "Monte Carlo specific settings"
+msgid "Additional Monte Carlo specific settings"
 msgstr "Cài đặt cụ thể cho panel"
 
 #. 6.0->settings-schema.json->component-selector-section->title
@@ -137,84 +137,78 @@ msgstr "Blur Cinnamon"
 #. 6.0->settings-schema.json->appswitcher-warning->description
 #, fuzzy
 msgid ""
-"Note: The Alt-Tab effects are currently disabled under the \"General setup\" "
+"💡 The Alt-Tab effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr "Cảnh báo: Hiệu ứng Alt-Tab hiện bị tắt dưới thẻ Chung."
 
 #. 6.0->settings-schema.json->desklets-warning->description
 #, fuzzy
 msgid ""
-"Note: The Desklet effects are currently disabled under the \"General setup\" "
+"💡 The Desklet effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr "Cảnh báo: Hiệu ứng Panel hiện bị tắt dưới thẻ Chung."
 
 #. 6.0->settings-schema.json->desktop-warning->description
 #, fuzzy
 msgid ""
-"Note: The Desktop effects are currently disabled under the \"General setup\" "
+"💡 The Desktop effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr "Cảnh báo: Hiệu ứng nền màn hình hiện bị tắt dưới thẻ Chung."
 
 #. 6.0->settings-schema.json->expo-warning->description
 #, fuzzy
 msgid ""
-"Note: The Expo effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Expo effects are currently disabled under the \"General setup\" tab."
 msgstr "Cảnh báo: Hiệu ứng Expo hiện bị tắt dưới thẻ Chung."
 
 #. 6.0->settings-schema.json->popup-warning->description
 #, fuzzy
 msgid ""
-"Note: The Menu effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Menu effects are currently disabled under the \"General setup\" tab."
 msgstr "Cảnh báo: Hiệu ứng Trình đơn Bật lên hiện bị tắt dưới thẻ Chung."
 
 #. 6.0->settings-schema.json->notification-warning->description
 #, fuzzy
 msgid ""
-"Note: The Notification effects are currently disabled under the \"General "
+"💡 The Notification effects are currently disabled under the \"General "
 "setup\" tab."
 msgstr "Cảnh báo: Hiệu ứng thông báo bật lên hiện bị tắt dưới thẻ Chung."
 
 #. 6.0->settings-schema.json->osd-warning->description
 #, fuzzy
 msgid ""
-"Note: The On-Screen-Display effects are currently disabled under the "
-"\"General setup\" tab."
+"💡 The On-Screen-Display effects are currently disabled under the \"General "
+"setup\" tab."
 msgstr "Cảnh báo: Hiệu ứng Panel hiện bị tắt dưới thẻ Chung."
 
 #. 6.0->settings-schema.json->overview-warning->description
 #, fuzzy
 msgid ""
-"Note: The Overview effects are currently disabled under the \"General "
-"setup\" tab."
+"💡 The Overview effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr "Cảnh báo: Hiệu ứng Tổng quan hiện bị tắt dưới thẻ Chung."
 
 #. 6.0->settings-schema.json->panel-warning->description
 #, fuzzy
 msgid ""
-"Note: The Panel effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Panel effects are currently disabled under the \"General setup\" tab."
 msgstr "Cảnh báo: Hiệu ứng Panel hiện bị tắt dưới thẻ Chung."
 
 #. 6.0->settings-schema.json->tooltips-warning->description
 #, fuzzy
 msgid ""
-"Note: The Tooltip effects are currently disabled under the \"General setup\" "
+"💡 The Tooltip effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr "Cảnh báo: Hiệu ứng chú giải công cụ panel hiện bị tắt dưới thẻ Chung."
 
 #. 6.0->settings-schema.json->windows-warning->description
 #, fuzzy
 msgid ""
-"Note: The Window effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Window effects are currently disabled under the \"General setup\" tab."
 msgstr "Cảnh báo: Hiệu ứng Expo hiện bị tắt dưới thẻ Chung."
 
 #. 6.0->settings-schema.json->desklets-label->description
-msgid ""
-"<b>Note:</b> You must configure your Desklets to be transparent! (see "
-"tooltip)"
+msgid "💡 You must configure your Desklets to be transparent! (see tooltip)"
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-label->tooltip
@@ -227,9 +221,7 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-label->description
-msgid ""
-"<b>Note:</b> Read tooltip for information about the \"Default window "
-"settings\""
+msgid "💡 Read tooltip for information about the \"Default window settings\""
 msgstr ""
 
 #. 6.0->settings-schema.json->windows-label->tooltip
@@ -301,10 +293,13 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners, Gaussian and Monte Carlo effects\n"
-"are based on code by aunetx (Blur-my-shell)\n"
-"<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
-"href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
+"The rounded corners, Gaussian and Monte Carlo effects are\n"
+"based on code by aunetx (Blur-my-shell <a href=\"https://github.com/aunetx/"
+"blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</"
+"a>)\n"
+"\n"
+"The Dual Kawase effect was written by <a href=\"https://github.com/Lucas-X-"
+"A\">Lucas-X-A</a>\n"
 "\n"
 "The Overview effect is partially based on the BlurOverview extension by "
 "nailfarmer"
@@ -882,6 +877,22 @@ msgstr "Cường độ làm mờ Gaussian"
 msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr ""
 
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase static blur"
+msgstr "Cường độ làm mờ Gaussian"
+
+#. 6.0->settings-schema.json->blurType->options
+msgid "Dual Kawase dynamic blur (if applicable)"
+msgstr ""
+
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
@@ -900,6 +911,26 @@ msgstr "Loại hiệu ứng làm mờ"
 #. 6.0->settings-schema.json->osd-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "Loại thuật toán làm mờ nào nên được sử dụng để làm mờ nền"
+
+#. 6.0->settings-schema.json->show-blur-info->description
+msgid "💡 Blur Algorithm Guide (see tooltip)"
+msgstr ""
+
+#. 6.0->settings-schema.json->show-blur-info->tooltip
+msgid ""
+"<b>Blur Algorithm Guide:</b>\n"
+" <b>• Gaussian:</b> Good quality smooth blur, can be GPU intensive.\n"
+" <b>• Dual Kawase:</b> High quality smooth blur, optimized for low-end "
+"GPUs.\n"
+" <b>• Monte Carlo:</b> Grainy, frosted-glass style noisy blur.\n"
+" <b>• Simple:</b> Basic subtle blur for ancient computers.\n"
+"\n"
+"<b>Static vs Dynamic:</b>\n"
+" <b>• Dynamic:</b> Blurs background elements behind the blurred element in "
+"real-time.\n"
+" <b>• Static:</b> Only blurs the wallpaper, like x-ray vision to the desktop "
+"wallpaper."
+msgstr ""
 
 #. 6.0->settings-schema.json->radius->description
 #. 6.0->settings-schema.json->overview-radius->description
@@ -972,7 +1003,7 @@ msgstr "Độ bão hòa"
 #. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
 msgid ""
 "Increasing number of iterations will make the blur appear smoother at the "
-"cost of some CPU power."
+"cost of some GPU power."
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
@@ -996,8 +1027,7 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->description
-msgid ""
-"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgid "💡 The above Monte Carlo settings are used globally for all components"
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->tooltip
@@ -1032,6 +1062,12 @@ msgstr "Gaussian"
 #. 6.0->settings-schema.json->expo-blurType->options
 #. 6.0->settings-schema.json->desktop-blurType->options
 msgid "Monte Carlo"
+msgstr ""
+
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Dual Kawase"
 msgstr ""
 
 #. 6.0->settings-schema.json->panels-blurType->options
@@ -1069,6 +1105,17 @@ msgstr "Cường độ làm mờ Gaussian"
 #. 6.0->settings-schema.json->osd-blurType->options
 #, fuzzy
 msgid "Monte Carlo dynamic blur"
+msgstr "Cường độ làm mờ Gaussian"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur"
 msgstr "Cường độ làm mờ Gaussian"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -1277,6 +1324,22 @@ msgid ""
 "will have some minor persistent CPU costs when a dynamic blurred window is "
 "on top of two or more other windows. This option is recommended unless you "
 "are using video wallpaper like Hidamari"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->description
+#, fuzzy
+msgid "Blur window title bars (please read tooltip)"
+msgstr "Thông báo bật lên (Vui lòng đọc chú giải công cụ)"
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->tooltip
+msgid ""
+"When enabled, the title bar area under most windows will be blurred "
+"excluding GTK4 windows and windows with custom title bars. This behaves like "
+"\"Default window settings\" entry above and even uses its settings, but with "
+"this option only title bar areas are blurred rather than the entire window. "
+"Note: The title bar blurring will only be visible when the title bars are "
+"configured to be semi-transparent which MUST be done using CSS. See the Blur "
+"Cinnamon website for instructions."
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description

--- a/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/zh_TW.po
+++ b/BlurCinnamon@klangman/files/BlurCinnamon@klangman/po/zh_TW.po
@@ -7,7 +7,7 @@ msgstr ""
 "Project-Id-Version: BlurCinnamon@klangman 2.0.1\n"
 "Report-Msgid-Bugs-To: https://github.com/linuxmint/cinnamon-spices-"
 "extensions/issues\n"
-"POT-Creation-Date: 2026-07-03 10:34-0400\n"
+"POT-Creation-Date: 2026-08-07 15:04-0400\n"
 "PO-Revision-Date: 2026-06-01 18:00+0800\n"
 "Last-Translator: Alang Hsu <alang.hsu@gmail.com>\n"
 "Language-Team: \n"
@@ -16,15 +16,15 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#. 6.0/extension.js:2819 6.0/extension.js:2822 6.0/extension.js:2932
+#. 6.0/extension.js:2862 6.0/extension.js:2865 6.0/extension.js:2974
 msgid "Default window settings"
 msgstr "預設視窗設定"
 
-#. 6.0/extension.js:3080
+#. 6.0/extension.js:3140
 msgid "Error"
 msgstr "錯誤"
 
-#. 6.0/extension.js:3081
+#. 6.0/extension.js:3141
 msgid ""
 "Unable to determine the application or the WM_CLASS of the previously "
 "focused window, therefore Blur Cinnamon effects can not be applied to that "
@@ -32,11 +32,11 @@ msgid ""
 msgstr ""
 "無法判斷先前聚焦的視窗或其 WM_CLASS，因此無法對該視窗套用 Blur Cinnamon 效果"
 
-#. 6.0/extension.js:3963
+#. 6.0/extension.js:4023
 msgid "Welcome to Blur Cinnamon"
 msgstr "歡迎使用 Blur Cinnamon"
 
-#. 6.0/extension.js:3964
+#. 6.0/extension.js:4024
 #, fuzzy
 msgid ""
 "Hope you are enjoying your new Panel, Expo, Overview and Alt-Tab effects.\n"
@@ -52,15 +52,15 @@ msgstr ""
 "開啟 Blur Cinnamon 設定以啟用其他桌面元素（如選單、通知和視窗）的效果，或停用"
 "預設啟用的元件效果。您也可以調整效果屬性，如模糊強度、色彩飽和度和調暗程度。"
 
-#. 6.0/extension.js:3968
+#. 6.0/extension.js:4028
 msgid "Open Blur Cinnamon Settings"
 msgstr "開啟 Blur Cinnamon 設定"
 
-#. 6.0/extension.js:4058
+#. 6.0/extension.js:4118
 msgid "Testing Blur Cinnamon Notification Effects"
 msgstr "測試 Blur Cinnamon 通知效果"
 
-#. 6.0/extension.js:4059
+#. 6.0/extension.js:4119
 msgid ""
 "This is how notifications will appear when using the current Blur Cinnamon "
 "Notification Popup effects.\n"
@@ -105,7 +105,7 @@ msgstr "將套用效果的 Cinnamon 桌面元件"
 
 #. 6.0->settings-schema.json->monte-carlo-settings->title
 #, fuzzy
-msgid "Monte Carlo specific settings"
+msgid "Additional Monte Carlo specific settings"
 msgstr "面板專屬設定"
 
 #. 6.0->settings-schema.json->component-selector-section->title
@@ -121,76 +121,81 @@ msgid "About Blur Cinnamon"
 msgstr "關於 Blur Cinnamon"
 
 #. 6.0->settings-schema.json->appswitcher-warning->description
+#, fuzzy
 msgid ""
-"Note: The Alt-Tab effects are currently disabled under the \"General setup\" "
+"💡 The Alt-Tab effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr "注意：Alt-Tab 效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->desklets-warning->description
+#, fuzzy
 msgid ""
-"Note: The Desklet effects are currently disabled under the \"General setup\" "
+"💡 The Desklet effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr "注意：Desklet 效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->desktop-warning->description
+#, fuzzy
 msgid ""
-"Note: The Desktop effects are currently disabled under the \"General setup\" "
+"💡 The Desktop effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr "注意：桌面效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->expo-warning->description
+#, fuzzy
 msgid ""
-"Note: The Expo effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Expo effects are currently disabled under the \"General setup\" tab."
 msgstr "注意：Expo 效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->popup-warning->description
+#, fuzzy
 msgid ""
-"Note: The Menu effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Menu effects are currently disabled under the \"General setup\" tab."
 msgstr "注意：選單效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->notification-warning->description
+#, fuzzy
 msgid ""
-"Note: The Notification effects are currently disabled under the \"General "
+"💡 The Notification effects are currently disabled under the \"General "
 "setup\" tab."
 msgstr "注意：通知效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->osd-warning->description
 #, fuzzy
 msgid ""
-"Note: The On-Screen-Display effects are currently disabled under the "
-"\"General setup\" tab."
+"💡 The On-Screen-Display effects are currently disabled under the \"General "
+"setup\" tab."
 msgstr "注意：面板效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->overview-warning->description
+#, fuzzy
 msgid ""
-"Note: The Overview effects are currently disabled under the \"General "
-"setup\" tab."
+"💡 The Overview effects are currently disabled under the \"General setup\" "
+"tab."
 msgstr "注意：Overview 效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->panel-warning->description
+#, fuzzy
 msgid ""
-"Note: The Panel effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Panel effects are currently disabled under the \"General setup\" tab."
 msgstr "注意：面板效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->tooltips-warning->description
+#, fuzzy
 msgid ""
-"Note: The Tooltip effects are currently disabled under the \"General setup\" "
+"💡 The Tooltip effects are currently disabled under the \"General setup\" "
 "tab."
 msgstr "注意：工具提示效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->windows-warning->description
+#, fuzzy
 msgid ""
-"Note: The Window effects are currently disabled under the \"General setup\" "
-"tab."
+"💡 The Window effects are currently disabled under the \"General setup\" tab."
 msgstr "注意：視窗效果目前在「一般設定」標籤下已停用。"
 
 #. 6.0->settings-schema.json->desklets-label->description
-msgid ""
-"<b>Note:</b> You must configure your Desklets to be transparent! (see "
-"tooltip)"
+#, fuzzy
+msgid "💡 You must configure your Desklets to be transparent! (see tooltip)"
 msgstr "<b>注意：</b>您必須將 Desklet 設為透明！（請參閱工具提示）"
 
 #. 6.0->settings-schema.json->desklets-label->tooltip
@@ -206,9 +211,8 @@ msgstr ""
 "Desklet 上按右鍵，選擇「設定...」選單項目即可開啟 Desklet 的設定視窗。"
 
 #. 6.0->settings-schema.json->windows-label->description
-msgid ""
-"<b>Note:</b> Read tooltip for information about the \"Default window "
-"settings\""
+#, fuzzy
+msgid "💡 Read tooltip for information about the \"Default window settings\""
 msgstr "<b>注意：</b>請參閱工具提示以瞭解「預設視窗設定」的相關資訊"
 
 #. 6.0->settings-schema.json->windows-label->tooltip
@@ -283,10 +287,13 @@ msgid ""
 "issue</a> / <a href=\"https://cinnamon-spices.linuxmint.com/extensions/view/"
 "104\">Website</a>\n"
 "\n"
-"The rounded corners, Gaussian and Monte Carlo effects\n"
-"are based on code by aunetx (Blur-my-shell)\n"
-"<a href=\"https://github.com/aunetx/blur-my-shell\">Github</a> / <a "
-"href=\"https://ko-fi.com/aunetx\">Ko-fi</a>\n"
+"The rounded corners, Gaussian and Monte Carlo effects are\n"
+"based on code by aunetx (Blur-my-shell <a href=\"https://github.com/aunetx/"
+"blur-my-shell\">Github</a> / <a href=\"https://ko-fi.com/aunetx\">Ko-fi</"
+"a>)\n"
+"\n"
+"The Dual Kawase effect was written by <a href=\"https://github.com/Lucas-X-"
+"A\">Lucas-X-A</a>\n"
 "\n"
 "The Overview effect is partially based on the BlurOverview extension by "
 "nailfarmer"
@@ -848,6 +855,23 @@ msgstr "簡單靜態模糊"
 msgid "Monte Carlo dynamic blur (if applicable)"
 msgstr "高斯動態模糊（如適用）"
 
+#. 6.0->settings-schema.json->blurType->options
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase static blur"
+msgstr "簡單靜態模糊"
+
+#. 6.0->settings-schema.json->blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur (if applicable)"
+msgstr "高斯動態模糊（如適用）"
+
 #. 6.0->settings-schema.json->blurType->description
 #. 6.0->settings-schema.json->overview-blurType->description
 #. 6.0->settings-schema.json->expo-blurType->description
@@ -866,6 +890,26 @@ msgstr "模糊效果類型"
 #. 6.0->settings-schema.json->osd-blurType->tooltip
 msgid "What type of blur algorithm should be used to blur the background"
 msgstr "要用哪種模糊演算法來模糊背景"
+
+#. 6.0->settings-schema.json->show-blur-info->description
+msgid "💡 Blur Algorithm Guide (see tooltip)"
+msgstr ""
+
+#. 6.0->settings-schema.json->show-blur-info->tooltip
+msgid ""
+"<b>Blur Algorithm Guide:</b>\n"
+" <b>• Gaussian:</b> Good quality smooth blur, can be GPU intensive.\n"
+" <b>• Dual Kawase:</b> High quality smooth blur, optimized for low-end "
+"GPUs.\n"
+" <b>• Monte Carlo:</b> Grainy, frosted-glass style noisy blur.\n"
+" <b>• Simple:</b> Basic subtle blur for ancient computers.\n"
+"\n"
+"<b>Static vs Dynamic:</b>\n"
+" <b>• Dynamic:</b> Blurs background elements behind the blurred element in "
+"real-time.\n"
+" <b>• Static:</b> Only blurs the wallpaper, like x-ray vision to the desktop "
+"wallpaper."
+msgstr ""
 
 #. 6.0->settings-schema.json->radius->description
 #. 6.0->settings-schema.json->overview-radius->description
@@ -935,7 +979,7 @@ msgstr "飽和度"
 #. 6.0->settings-schema.json->monte-carlo-iterations->tooltip
 msgid ""
 "Increasing number of iterations will make the blur appear smoother at the "
-"cost of some CPU power."
+"cost of some GPU power."
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-use-base-pixel->description
@@ -959,8 +1003,7 @@ msgid ""
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->description
-msgid ""
-"<b>Note:</b> These Monte Carlo settings are used globally for all components"
+msgid "💡 The above Monte Carlo settings are used globally for all components"
 msgstr ""
 
 #. 6.0->settings-schema.json->monte-carlo-label->tooltip
@@ -997,6 +1040,12 @@ msgstr "高斯"
 msgid "Monte Carlo"
 msgstr ""
 
+#. 6.0->settings-schema.json->overview-blurType->options
+#. 6.0->settings-schema.json->expo-blurType->options
+#. 6.0->settings-schema.json->desktop-blurType->options
+msgid "Dual Kawase"
+msgstr ""
+
 #. 6.0->settings-schema.json->panels-blurType->options
 #. 6.0->settings-schema.json->popup-blurType->options
 #. 6.0->settings-schema.json->notification-blurType->options
@@ -1030,6 +1079,17 @@ msgstr "高斯動態模糊"
 #. 6.0->settings-schema.json->osd-blurType->options
 #, fuzzy
 msgid "Monte Carlo dynamic blur"
+msgstr "高斯動態模糊"
+
+#. 6.0->settings-schema.json->panels-blurType->options
+#. 6.0->settings-schema.json->popup-blurType->options
+#. 6.0->settings-schema.json->notification-blurType->options
+#. 6.0->settings-schema.json->appswitcher-blurType->options
+#. 6.0->settings-schema.json->tooltips-blurType->options
+#. 6.0->settings-schema.json->desklets-blurType->options
+#. 6.0->settings-schema.json->osd-blurType->options
+#, fuzzy
+msgid "Dual Kawase dynamic blur"
 msgstr "高斯動態模糊"
 
 #. 6.0->settings-schema.json->panels-blurType->description
@@ -1235,6 +1295,22 @@ msgid ""
 "will have some minor persistent CPU costs when a dynamic blurred window is "
 "on top of two or more other windows. This option is recommended unless you "
 "are using video wallpaper like Hidamari"
+msgstr ""
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->description
+#, fuzzy
+msgid "Blur window title bars (please read tooltip)"
+msgstr "應用程式視窗（請閱讀工具提示）"
+
+#. 6.0->settings-schema.json->windows-titlebar-blur->tooltip
+msgid ""
+"When enabled, the title bar area under most windows will be blurred "
+"excluding GTK4 windows and windows with custom title bars. This behaves like "
+"\"Default window settings\" entry above and even uses its settings, but with "
+"this option only title bar areas are blurred rather than the entire window. "
+"Note: The title bar blurring will only be visible when the title bars are "
+"configured to be semi-transparent which MUST be done using CSS. See the Blur "
+"Cinnamon website for instructions."
 msgstr ""
 
 #. 6.0->settings-schema.json->desklets-auto->description


### PR DESCRIPTION
- Added a new Dual Kawase Blur algorithm written by Lucas-X-A which gives a Gaussian like smooth blur that is faster (better for low end GPUs) and produces better results in many cases as compared to the Gaussian blur algorithm. This is the new default algorithm for new installs, but people upgrading to this version will need to manually switch to Dual Kawase if they want to take advantage of this new algorithm.
- Added an option to blur window title bars. This feature requires changes to your theme's CSS code, see the website for instruction (GTK3 and Mint-Y only)
- Fix an Cinnamon crash when closing a non-focused blurred application window when the focused window is also a blurred application window.
- Fix an issue where the desktop icons were not showing up the the Dynamic blur backgrounds
- Fix a small delay before Dynamic blur effects appear when using the show desklets (Super+S) Cinnamon feature.
- Fix some issues around UI scaling
- Fix a memory leak due to not removing some listeners
- Fix for window blurring not resizing properly when windows are "shaded"
- Add an blur algorithm information guide to the "Generic effect settings" tab