### PR TITLE
transparent-panels@germanfr: Refresh transparency state after moving a panel

### DIFF
--- a/transparent-panels@germanfr/files/transparent-panels@germanfr/extension.js
+++ b/transparent-panels@germanfr/files/transparent-panels@germanfr/extension.js
@@ -77,6 +77,7 @@ MyExtension.prototype = {
 		this.settings.bind("panel-left", "enable_position_left", this.on_settings_changed);
 
 		this._signals.connect(Main.layoutManager, 'monitors-changed', this.on_monitors_changed, this);
+		this._signals.connect(global.settings, 'changed::panels-enabled', this.on_monitors_changed, this);
 		this._classname = this.theme_defined ? this.transparency_type : this.transparency_type + INTERNAL_PREFIX;
 
 		Gettext.bindtextdomain(meta.uuid, GLib.get_home_dir() + "/.local/share/locale");


### PR DESCRIPTION
After moving a panel to another screen, the panel would drop all transparency effects until the extension is reloaded. Binding the panel move to `on_monitors_changed` refreshes the new positions of panels and transparency is working as expected.

Extension is not owned by me, unsure about the correct etiquette here. Would love the feedback 😄